### PR TITLE
Missing $ for inline equation

### DIFF
--- a/Canon/src/PhaseEstimation/Types.qs
+++ b/Canon/src/PhaseEstimation/Types.qs
@@ -15,7 +15,7 @@ namespace Microsoft.Quantum.Canon
     /// Represents a continuous-time oracle.
 	///
 	/// This is an oracle that implements 
-    /// $U(\delta t) : \ket{\psi(t)} \mapsto \ket{\psi(t + \delta t)}
+    /// $U(\delta t) : \ket{\psi(t)} \mapsto \ket{\psi(t + \delta t)}$
     /// for all times $t$, where $U$ is a fixed operation, and where
     /// $\delta t$ is a non-negative real number.
     newtype ContinuousOracle = ((Double, Qubit[]) => Unit : Adjoint, Controlled);


### PR DESCRIPTION
The documentation for the ContinuousOracle type (https://docs.microsoft.com/en-us/qsharp/api/canon/microsoft.quantum.canon.continuousoracle?view=qsharp-preview) has a missing $ symbol to close the inline equation. This change is modified in the quantum-docs-pr as well as here