### PR TITLE
Fix "# Example" tag in documentation comments

### DIFF
--- a/Canon/src/Arrays/Arrays.qs
+++ b/Canon/src/Arrays/Arrays.qs
@@ -123,7 +123,8 @@ namespace Microsoft.Quantum.Canon
     /// each `idx`. If the two arrays are not of equal length, the output will
     /// be as long as the shorter of the inputs.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// ```qsharp
     /// let left = [1, 3, 71];
     /// let right = [false, true];
@@ -238,7 +239,8 @@ namespace Microsoft.Quantum.Canon
     /// such that `output[1]` is the second such element, and so
     /// forth.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// ```qsharp
     /// let array = [10, 11, 12, 13, 14, 15];
     /// // The following line returns [10, 12, 15].
@@ -300,7 +302,8 @@ namespace Microsoft.Quantum.Canon
     /// An array `output` that is the `inputArray` padded at the head
     /// with `defaultElement`s until `output` has length `nElementsTotal`
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// ```qsharp
     /// let array = [10, 11, 12];
     /// // The following line returns [10, 12, 15, 2, 2, 2].
@@ -338,7 +341,8 @@ namespace Microsoft.Quantum.Canon
     /// # Output
     /// A new array of integers corresponding to values iterated over by `range`.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// ```qsharp
     /// // The following returns [1,3,5,7];
     /// let array = IntArrayFromRange(1..2..8);
@@ -374,7 +378,8 @@ namespace Microsoft.Quantum.Canon
     /// and the second array are the next 'nElements[1]' of `arr` etc. The last array
     /// will contain all remaining elements.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// ```qsharp
     /// // The following returns [[1,5],[3],[7]];
     /// let (arr1, arr2) = SplitArray([2,1], [1,5,3,7]);

--- a/Canon/src/Asserts/QuantumAsserts.qs
+++ b/Canon/src/Asserts/QuantumAsserts.qs
@@ -31,7 +31,8 @@ namespace Microsoft.Quantum.Canon
     /// ## tolerance
     /// Absolute tolerance on the difference between actual and expected.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// Suppose that the `qubits` register encodes a 3-qubit quantum state
     /// $\ket{\psi}=\sqrt{1/8}\ket{0}+\sqrt{7/8}\ket{6}$ in little-endian format.
     /// This means that the number states $\ket{0}\equiv\ket{0}\ket{0}\ket{0}$
@@ -77,7 +78,8 @@ namespace Microsoft.Quantum.Canon
     /// ## tolerance
     /// Absolute tolerance on the difference between actual and expected.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// Suppose that the `qubits` register encodes a 3-qubit quantum state
     /// $\ket{\psi}=\sqrt{1/8}\ket{0}+\sqrt{7/8}\ket{6}$ in big-endian format.
     /// This means that the number states $\ket{0}\equiv\ket{0}\ket{0}\ket{0}$
@@ -109,7 +111,8 @@ namespace Microsoft.Quantum.Canon
     /// ## tolerance
     /// Absolute tolerance on the difference between actual and expected.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// The following assert succeeds:
     /// `qubit` is in state $\ket{\psi}=e^{i 0.5}\sqrt{1/2}\ket{0}+e^{i 0.5}\sqrt{1/2}\ket{1}$;
     /// - `AssertPhase(0.0,qubit,10e-10);`

--- a/Canon/src/Combinators/Bind.qs
+++ b/Canon/src/Combinators/Bind.qs
@@ -33,7 +33,8 @@ namespace Microsoft.Quantum.Canon
     /// ## 'T
     /// The target on which each of the operations in the array act.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// The following are equivalent:
     /// ```qsharp
     /// let bound = Bind([U, V]);
@@ -98,7 +99,8 @@ namespace Microsoft.Quantum.Canon
     /// ## 'T
     /// The target on which each of the operations in the array act.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// The following are equivalent:
     /// ```qsharp
     /// let bound = Bind([U, V]);
@@ -159,7 +161,8 @@ namespace Microsoft.Quantum.Canon
     /// ## 'T
     /// The target on which each of the operations in the array act.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// The following are equivalent:
     /// ```qsharp
     /// let bound = Bind([U, V]);
@@ -239,7 +242,8 @@ namespace Microsoft.Quantum.Canon
     /// ## 'T
     /// The target on which each of the operations in the array act.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// The following are equivalent:
     /// ```qsharp
     /// let bound = Bind([U, V]);

--- a/Canon/src/Data/GeneratorRepresentation.qs
+++ b/Canon/src/Data/GeneratorRepresentation.qs
@@ -10,7 +10,7 @@ namespace Microsoft.Quantum.Canon
     /// # Summary
     /// Represents a single primitive term in the set of all dynamical generators, e.g.
     /// Hermitian operators, for which there exists a map from that generator
-    /// to time-evolution by that that generator, through `EvolutionSet`. 
+    /// to time-evolution by that generator, through `EvolutionSet`. 
     ///
     /// The first element
     /// (Int[], Double[]) is indexes that single term -- For instance, the Pauli string
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.Canon
     /// > The interpretation of an `GeneratorIndex` is not defined except
     /// > with reference to a particular set of generators.
     ///
-    /// # Example
+    /// ## Example
     /// Using  <xref:microsoft.quantum.canon.paulievolutionset>, the operator
     /// $\pi X_2 X_5 Y_9$ is represented as:
     /// ```qsharp
@@ -211,7 +211,8 @@ namespace Microsoft.Quantum.Canon
     /// A `GeneratorIndex` representing a term with coefficient a factor
     /// `multiplier` larger.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// ```qsharp
     /// let gen = GeneratorIndex(([1,2,3],[coeff]),[1,2,3]);
     /// let ((idxPaulis, idxDoubles), idxQubits) = MultiplyGeneratorIndex(multipler, gen);

--- a/Canon/src/Enumeration/Fold.qs
+++ b/Canon/src/Enumeration/Fold.qs
@@ -27,7 +27,8 @@ namespace Microsoft.Quantum.Canon
     /// The final state returned by the folder after iterating over
     /// all elements of `array`.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// ```qsharp
     /// function Plus(a : Double, b : Double) { 
 	///     return a + b;

--- a/Canon/src/Enumeration/Map.qs
+++ b/Canon/src/Enumeration/Map.qs
@@ -67,7 +67,8 @@ namespace Microsoft.Quantum.Canon
     /// # Output
     /// An array `'U[]` of elements that are mapped by the `mapper` function.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// The following two lines are equivalent:
     /// ```qsharp
     /// let arr = MapIndex(f, [x0, x1, x2]);

--- a/Canon/src/Math/Functions.qs
+++ b/Canon/src/Math/Functions.qs
@@ -100,7 +100,7 @@ namespace Microsoft.Quantum.Canon
     /// The `minValue` input then effectively specifies where to cut the
     /// unit circle.
     ///
-    /// # Example
+    /// ## Example
     /// ```qsharp
     ///     // Returns 3 π / 2.
     ///     let y = RealMod(5.5 * PI(), 2.0 * PI(), 0.0);

--- a/Canon/src/PhaseEstimation/Types.qs
+++ b/Canon/src/PhaseEstimation/Types.qs
@@ -32,7 +32,8 @@ namespace Microsoft.Quantum.Canon
     /// # Output
     /// An operation partially applied over the "black-box" oracle representing the discrete-time oracle
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// `OracleToDiscrete(U)(3, target)` is equivalent to `U(target)` repeated three times.
     operation OracleToDiscrete (blackBoxOracle : (Qubit[] => Unit : Adjoint, Controlled)) : DiscreteOracle
     {

--- a/Canon/src/Qecc/Types.qs
+++ b/Canon/src/Qecc/Types.qs
@@ -46,7 +46,13 @@ namespace Microsoft.Quantum.Canon
     /// Represents an operation that is used to measure the syndrome
     /// of an error-correcting code block.
     ///
-    /// # Example
+    /// # Remarks
+    /// The signature `(LogicalRegister => Syndrome)` represents an operation
+    /// that acts jointly on the qubits in `LogicalRegister` and some ancilla
+    /// qubits followed by a measurements of the ancilla to extract a `Syndrome
+    /// type representing the `Result[]` of these measurements.
+    ///
+    /// ## Example
     /// Measure syndromes for the bit-flip code
     /// $S = \langle ZZI, IZZ \rangle$ using scratch qubits in a
     /// non–fault tolerant manner:
@@ -56,12 +62,6 @@ namespace Microsoft.Quantum.Canon
     ///             [PauliI, PauliZ, PauliZ]
     ///         ], _, MeasureWithScratch));
     /// ```
-    ///
-    /// # Remarks
-    /// The signature `(LogicalRegister => Syndrome)` represents an operation
-    /// that acts jointly on the qubits in `LogicalRegister` and some ancilla
-    /// qubits followed by a measurements of the ancilla to extract a `Syndrome
-    /// type representing the `Result[]` of these measurements.
     ///
     /// # See Also
     /// - Microsoft.Quantum.Canon.LogicalRegister

--- a/Canon/src/StatePreparation/QuantumROM.qs
+++ b/Canon/src/StatePreparation/QuantumROM.qs
@@ -39,7 +39,8 @@ namespace Microsoft.Quantum.Canon
     /// ## Third parameter
     /// The unitary $U$.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// The following code snippet prepares an purification of the $3$-qubit state 
     /// $\rho=\sum^{4}_{j=0}\frac{|alpha_j|}{\sum_k |\alpha_k|}\ket{j}\bra{j}$, where 
     /// $\vec\alpha=(1.0,2.0,3.0,4.0,5.0)$, and the error is `1e-3`;

--- a/Canon/src/StatePreparation/StatePreparation.qs
+++ b/Canon/src/StatePreparation/StatePreparation.qs
@@ -36,7 +36,7 @@ namespace Microsoft.Quantum.Canon
     /// positive with value $|\alpha_j|$. `coefficients` will be padded with
     /// elements $\alpha_j = 0.0$ if fewer than $2^n$ are specified.
     ///
-    /// # Example
+    /// ## Example
     /// The following snippet prepares the quantum state $\ket{\psi}=\sqrt{1/8}\ket{0}+\sqrt{7/8}\ket{2}$
     /// in the qubit register `qubitsBE`.
     /// ```qsharp
@@ -88,7 +88,7 @@ namespace Microsoft.Quantum.Canon
     /// elements $(r_j, t_j) = (0.0, 0.0)$ if fewer than $2^n$ are
     /// specified.
     ///
-    /// # Example
+    /// ## Example
     /// The following snippet prepares the quantum state $\ket{\psi}=e^{i 0.1}\sqrt{1/8}\ket{0}+\sqrt{7/8}\ket{2}$
     /// in the qubit register `qubitsBE`.
     /// ```qsharp

--- a/Canon/src/StatePreparation/UniformSuperposition.qs
+++ b/Canon/src/StatePreparation/UniformSuperposition.qs
@@ -26,7 +26,8 @@ namespace Microsoft.Quantum.Canon
     /// This register must be able to store the number $M-1$, and is assumed to be
     /// initialized in the state $\ket{0\cdots 0}$.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// The following example prepares the state $\frac{1}{\sqrt{6}}\sum_{j=1}^{5}\ket{j}$
     /// on $3$ qubits.
     /// ``` Q#

--- a/Canon/src/Utils/Paulis.qs
+++ b/Canon/src/Utils/Paulis.qs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon
@@ -87,7 +87,8 @@ namespace Microsoft.Quantum.Canon
     /// ## target
     /// Register to apply the given Pauli operation on.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// The following are equivalent:
     /// ```qsharp
     /// ApplyPauli([PauliY, PauliZ, PauliX], target);
@@ -245,7 +246,8 @@ namespace Microsoft.Quantum.Canon
     /// ## n
     /// Length of the array to be returned.
     ///
-    /// # Example
+    /// # Remarks
+    /// ## Example
     /// To obtain the array `[PauliI, PauliI, PauliX, PauliI]`:
     /// ```qsharp
     /// EmbedPauli(PauliX, 2, 3);


### PR DESCRIPTION
Standalone "# Example" tag is currently ignored by the parser; the currently supported syntax is "# Remarks / ## Example"