### PR TITLE
Fix several formulas in the documentation

### DIFF
--- a/Canon/src/StatePreparation/StatePreparation.qs
+++ b/Canon/src/StatePreparation/StatePreparation.qs
@@ -19,9 +19,11 @@ namespace Microsoft.Quantum.Canon
     /// the $n$-qubit computational basis state $\ket{0...0}$.
     ///
     /// The action of U on a newly-allocated register is given by
+    /// $$
     /// \begin{align}
-    ///     U \ket{0\cdots 0} = \ket{\psi} = \frac{\sum^{2^n-1}_{j=0}\alpha_j \ket{j}}{\sqrt{\sum^{2^n-1}_{j=0}|\alpha_j|^2}}$.
+    ///     U \ket{0\cdots 0} = \ket{\psi} = \frac{\sum^{2^n-1}_{j=0}\alpha_j \ket{j}}{\sqrt{\sum^{2^n-1}_{j=0}|\alpha_j|^2}}.
     /// \end{align}
+    /// $$
     ///
     /// # Input
     /// ## coefficients
@@ -69,9 +71,11 @@ namespace Microsoft.Quantum.Canon
     /// the $n$-qubit computational basis state $\ket{0...0}$.
     ///
     /// The action of U on a newly-allocated register is given by
+    /// $$
     /// \begin{align}
-    /// U\ket{0...0}=\ket{\psi}=\frac{\sum^{2^n-1}_{j=0}r_j e^{i t_j}\ket{j}}{\sqrt{\sum^{2^n-1}_{j=0}|r_j|^2}}.
+    ///     U\ket{0...0}=\ket{\psi}=\frac{\sum^{2^n-1}_{j=0}r_j e^{i t_j}\ket{j}}{\sqrt{\sum^{2^n-1}_{j=0}|r_j|^2}}.
     /// \end{align}
+    /// $$
     ///
     /// # Input
     /// ## coefficients
@@ -96,9 +100,9 @@ namespace Microsoft.Quantum.Canon
     /// let phases = [0.1, 0.0, 0.0, 0.0];
     /// mutable complexNumbers = new ComplexPolar[4];
     /// for (idx in 0..3) {
-    ///     set complexNumbers[idx] = ComplexPolar(amplitudes, phases);
+    ///     set complexNumbers[idx] = ComplexPolar(amplitudes[idx], phases[idx]);
     /// }
-    /// let op = StatePreparationPositiveCoefficients(complexNumbers);
+    /// let op = StatePreparationComplexCoefficients(complexNumbers);
     /// using (qubits = Qubit[2]) {
     ///     let qubitsBE = BigEndian(qubits);
     ///     op(qubitsBE);

--- a/Canon/src/StatePreparation/UniformSuperposition.qs
+++ b/Canon/src/StatePreparation/UniformSuperposition.qs
@@ -14,7 +14,7 @@ namespace Microsoft.Quantum.Canon
     /// $0$ to $M-1$, given an input state $\ket{0\cdots 0}$. In other words, 
     /// $$
     /// \begin{align}
-    /// U\ket{0}=\frac{1}{\sqrt{M}}\sum_{j=1}^{M-1}\ket{j}.
+    /// U\ket{0}=\frac{1}{\sqrt{M}}\sum_{j=0}^{M-1}\ket{j}.
     /// \end{align}
     /// $$.
     ///
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.Canon
     /// initialized in the state $\ket{0\cdots 0}$.
     ///
     /// # Example
-    /// The following example prepares the state $\frac{1}{\sqrt{6}}\sum_{j=1}^{5}\ket{j}$
+    /// The following example prepares the state $\frac{1}{\sqrt{6}}\sum_{j=0}^{5}\ket{j}$
     /// on $3$ qubits.
     /// ``` Q#
     /// let nIndices = 6;


### PR DESCRIPTION
* Fix lower bound in the formula for PrepareUniformSuperposition
* Fix broken formulas in StatePreparation (#280)
* Fix Q# code example in StatePreparationComplexCoefficients (#280)