### PR TITLE
Using Python 3.6

### DIFF
--- a/Build/step-build-libs.yml
+++ b/Build/step-build-libs.yml
@@ -20,7 +20,6 @@ steps:
 ##
 - task: DotNetCoreCLI@2
   displayName: 'Test Libraries'
-  enabled: false
   inputs:
     command: test
     projects: |

--- a/Build/step-build-libs.yml
+++ b/Build/step-build-libs.yml
@@ -20,6 +20,7 @@ steps:
 ##
 - task: DotNetCoreCLI@2
   displayName: 'Test Libraries'
+  enabled: false
   inputs:
     command: test
     projects: |

--- a/Build/step-build-python.yml
+++ b/Build/step-build-python.yml
@@ -11,7 +11,7 @@ steps:
   displayName: 'Create and update conda environment'
   inputs:
     environmentName: qsharp-build
-    packageSpecs: 'python=3 conda-build=3.15.1'
+    packageSpecs: 'python=3.6'
 
 
 - task: PowerShell@1


### PR DESCRIPTION
Builds have been failing with an error about conda unable to connect due to SSL certificate. Looks to be a Windows-specific problem for conda with Python 3.7. Trying using Pyton 3.6 as that has been reported to fix the problem.