### PR TITLE
Fields are case sensitive

### DIFF
--- a/Interoperability/python/src/qsharp/serialization.py
+++ b/Interoperability/python/src/qsharp/serialization.py
@@ -45,7 +45,7 @@ def unmap_tuples(obj):
     """
     if isinstance(obj, dict):
         # Does this dict represent a tuple?
-        if obj.get('@type', None) in ('tuple', '@tuple') or 'item1' in obj:
+        if obj.get('@type', None) in ('tuple', '@tuple') or 'Item1' in obj:
             values = []
             while True:
                 item = f"Item{len(values) + 1}"


### PR DESCRIPTION
The result of an operation returning UDT was showing in Python like this:
```
{'@type': 'Microsoft.Quantum.Chemistry.JordanWigner.JordanWignerEncodingData', 'Item1': 4, 'Item2': {'@type': 'Microsoft.Quantum.Chemistry.JordanWigner.JWOptimizedHTerms', 'Item1': [{'@type': 'Microsoft.Quantum.Chemistry.HTerm', 'Item1': [0], 'Item2': [0.17120128499999998]}, {'@type': 'Microsoft.Quantum.Chemistry.HTerm', 'Item1': [1], 'Item2': [-0.222796536]}, {'@type': 'Microsoft.Quantum.Chemistry.HTerm', 'Item1': [2], 'Item2': [0.17120128499999998]}, {'@type': 'Microsoft.Quantum.Chemistry.HTerm', 'Item1': [3], 'Item2': [-0.222796536]}], 'Item2': [{'@type': 'Microsoft.Quantum.Chemistry.HTerm', 'Item1': [0, 1], 'Item2': [0.12054614575]}, {'@type': 'Microsoft.Quantum.Chemistry.HTerm', 'Item1': [0, 2], 'Item2': [0.1686232915]}, {'@type': 'Microsoft.Quantum.Chemistry.HTerm', 'Item1': [0, 3], 'Item2': [0.16586802525]}, {'@type': 'Microsoft.Quantum.Chemistry.HTerm', 'Item1': [1, 2], 'Item2': [0.16586802525]}, {'@type': 'Microsoft.Quantum.Chemistry.HTerm', 'Item1': [1, 3], 'Item2': [0.1743495025]}, {'@type': 'Microsoft.Quantum.Chemistry.HTerm', 'Item1': [2, 3], 'Item2': [0.12054614575]}], 'Item3': [], 'Item4': [{'@type': 'Microsoft.Quantum.Chemistry.HTerm', 'Item1': [0, 1, 2, 3], 'Item2': [0.0453218795, 0.0453218795, 0.0, 0.0]}]}, 'Item3': [{'@type': 'Microsoft.Quantum.Chemistry.JordanWigner.JordanWignerInputState', 'Item1': (1.0, 0.0), 'Item2': [0, 2]}], 'Item4': -0.09883444599999994}
```
Instead of a plain tuple. After debugging, the problem was that `item1` and `Item1` are not the same thing.