### PR TITLE
Making IntegralData as public and making it friendly to json encoding.

### DIFF
--- a/Chemistry/src/DataModel/FermionTerm.cs
+++ b/Chemistry/src/DataModel/FermionTerm.cs
@@ -423,7 +423,7 @@ namespace Microsoft.Quantum.Chemistry
 
         public override bool Equals(object x)
         {
-            return Equals((FermionTerm)x);
+            return (x is FermionTerm ft) ? Equals(ft) : false;
         }
 
         public bool Equals(FermionTerm x)
@@ -542,9 +542,10 @@ namespace Microsoft.Quantum.Chemistry
         {
             return !(x == y);
         }
+
         public override bool Equals(object x)
         {
-            return Equals((FermionTermType)x);
+            return (x is FermionTermType ft) ? Equals(ft) : false;
         }
 
         public bool Equals(FermionTermType x)


### PR DESCRIPTION
IntegralData (the datastructure representing a broombridge schema) is marked internal, but we would like to expose it to developers can manipulate broombridge data structures programmatically.
Made a small change to the internal representation to make it json friendly.
And fixing a bug on how FermionTerms check for Equals.