### PR TITLE
Missing return statement when compiling more than one Q# snippet from Python.

### DIFF
--- a/Interoperability/python/src/qsharp/__init__.py
+++ b/Interoperability/python/src/qsharp/__init__.py
@@ -57,6 +57,8 @@ def compile(code : str) -> Union[QSharpCallable, List[QSharpCallable]]:
     ]
     if len(ops) == 1:
         return ops[0]
+    else:
+        return ops
 
 
 def reload() -> None:

--- a/Interoperability/python/src/qsharp/serialization.py
+++ b/Interoperability/python/src/qsharp/serialization.py
@@ -18,7 +18,7 @@ def map_tuples(obj):
             '@type': 'tuple'
         }
         for i in range(len(obj)):
-            result[f"item{i+1}"] = map_tuples(obj[i])
+            result[f"Item{i+1}"] = map_tuples(obj[i])
         return result
 
     elif isinstance(obj, list):

--- a/Interoperability/python/src/qsharp/tests/Operations.qs
+++ b/Interoperability/python/src/qsharp/tests/Operations.qs
@@ -1,0 +1,43 @@
+﻿///
+/// Q# code should be in one or more .qs files that live 
+/// in the same directory as the python clasical driver.
+///
+
+namespace Microsoft.Quantum.SanityTests
+{
+    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Canon;
+
+    /// # Summary: 
+    ///     The simplest program. Just generate a debug Message on the console.
+    operation HelloQ() : Unit
+    {
+        Message($"Hello from quantum world!"); 
+    }
+
+    /// # Summary: 
+    ///     A more sophisticated program that shows how to 
+    ///     specify parameters, instantiate qubits, and return values.
+    operation HelloAgain(count: Int, name: String) : Result[]
+    {
+        Message($"Hello {name} again!"); 
+
+        mutable r = new Result[count];
+        using (q = Qubit()) {
+            for (i in 1..count) {
+                ApplyIf(X, i == 2, q);
+                set r[i-1] = M(q);
+                Reset(q);
+            }
+        }
+
+        return r;
+    }
+
+    /// # Summary: 
+    ///     Checks that built-in complex types (can be used as arguments.
+    operation HelloTuple(count: Int, tuples: (Result, String)[]) : (Result, String)
+    {
+        return tuples[count];
+    }
+}

--- a/Interoperability/python/src/qsharp/tests/test_iqsharp.py
+++ b/Interoperability/python/src/qsharp/tests/test_iqsharp.py
@@ -1,0 +1,99 @@
+import qsharp
+
+print ( qsharp.component_versions() )
+
+def test_simulate():
+    """
+    Checks that a simple simulate works correctly
+    """
+    from Microsoft.Quantum.SanityTests import HelloQ
+    r = HelloQ.simulate()
+    assert r == ()
+
+
+def test_tuples():
+    """
+    Checks that tuples are correctly encoded both ways.
+    """
+    from Microsoft.Quantum.SanityTests import HelloTuple
+    r = HelloTuple.simulate(count=2, tuples=[(0, "Zero"), (1, "One"), (0, "Two"), (0, "Three")])
+    assert r == (0, "Two")
+
+def test_estimate():
+    """
+    Verifies that resource estimation works.
+    """
+    from Microsoft.Quantum.SanityTests import HelloAgain
+    r = HelloAgain.estimate_resources(count=4, name="estimate test")
+    assert r['Measure'] == 8
+    assert r['QubitClifford'] == 1
+    assert r['BorrowedWidth'] == 0
+
+
+def test_simple_compile():
+    """
+    Verifies that compile works
+    """
+    op = qsharp.compile( """
+    operation HelloQ() : Result
+    {
+        Message($"Hello from quantum world!"); 
+        return Zero;
+    }
+""")
+    r = op.simulate()
+    assert r == 0
+    
+
+def test_multi_compile():
+    """
+    Verifies that compile works
+    """
+    ops = qsharp.compile( """
+    operation HelloQ() : Result
+    {
+        Message($"Hello from quantum world!"); 
+        return One;
+    }
+
+    operation Hello2() : Result
+    {
+        Message($"Will call hello."); 
+        return HelloQ();
+    }
+""")
+    assert "Hello2" == ops[0]._name
+    assert "HelloQ" == ops[1]._name
+
+    r = ops[1].simulate()
+    assert r == qsharp.Result.One
+
+
+def test_chemistry_compile():
+    """
+    Verifies that that adding packages and compile works
+    """
+    qsharp.packages.add("microsoft.quantum.chemistry")
+    op = qsharp.compile( """
+    open Microsoft.Quantum.Chemistry.JordanWigner;    
+    
+    /// # Summary
+    /// We can now use Canon's phase estimation algorithms to
+    /// learn the ground state energy using the above simulation.
+    operation TrotterEstimateEnergy (qSharpData: JordanWignerEncodingData, nBitsPrecision : Int, trotterStepSize : Double) : (Double, Double) {
+        
+        let (nSpinOrbitals, data, statePrepData, energyShift) = qSharpData!;
+        
+        // Order of integrator
+        let trotterOrder = 1;
+        let (nQubits, (rescaleFactor, oracle)) = TrotterStepOracle(qSharpData, trotterStepSize, trotterOrder);
+        
+        // Prepare ProductState
+        let statePrep =  PrepareTrialState(statePrepData, _);
+        let phaseEstAlgorithm = RobustPhaseEstimation(nBitsPrecision, _, _);
+        let estPhase = EstimateEnergy(nQubits, statePrep, oracle, phaseEstAlgorithm);
+        let estEnergy = estPhase * rescaleFactor + energyShift;
+        return (estPhase, estEnergy);
+    }
+""")
+    assert op._name == "TrotterEstimateEnergy"

--- a/Interoperability/python/src/qsharp/tests/test_serialization.py
+++ b/Interoperability/python/src/qsharp/tests/test_serialization.py
@@ -18,7 +18,7 @@ class TestSerialization(unittest.TestCase):
     def test_map_shallow_tuple(self):
         self.assertEqual(
             map_tuples((42, 'foo')),
-            {'@type': 'tuple', 'item1': 42, 'item2': 'foo'}
+            {'@type': 'tuple', 'Item1': 42, 'Item2': 'foo'}
         )
 
     def test_map_deep_tuple(self):
@@ -27,9 +27,9 @@ class TestSerialization(unittest.TestCase):
             'bar': {'a': ('a', 'a'), 'b': ()}
         }
         expected = {
-            'foo': [1, 3.14, {'@type': 'tuple', 'item1': 42, 'item2': 'baz'}],
+            'foo': [1, 3.14, {'@type': 'tuple', 'Item1': 42, 'Item2': 'baz'}],
             'bar': {
-                'a': {'@type': 'tuple', 'item1': 'a', 'item2': 'a'},
+                'a': {'@type': 'tuple', 'Item1': 'a', 'Item2': 'a'},
                 'b': {'@type': 'tuple'}
             }
         }


### PR DESCRIPTION
Fixing #59 