### PR TITLE
Port library and test code to new 0.6 names to reduce warning count.

### DIFF
--- a/Chemistry/src/DataModel/DataModel.csproj
+++ b/Chemistry/src/DataModel/DataModel.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.5.1903.2703" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1904.1008-beta" />
     <PackageReference Include="xunit.abstractions" Version="2.0.1" />
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />
     <PackageReference Include="YamlDotNet" Version="5.0.1" />

--- a/Chemistry/src/Runtime/JordanWigner/Convenience.qs
+++ b/Chemistry/src/Runtime/JordanWigner/Convenience.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Simulation;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Extensions.Math;

--- a/Chemistry/src/Runtime/JordanWigner/JordanWignerBlockEncoding.qs
+++ b/Chemistry/src/Runtime/JordanWigner/JordanWignerBlockEncoding.qs
@@ -8,8 +8,8 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Chemistry;
     open Microsoft.Quantum.Arrays;
-    
-    
+    open Microsoft.Quantum.Convert;
+
     // This block encoding for qubitization runs off data optimized for a jordan-wigner encoding.
     // This collects terms Z, ZZ, PQandPQQR, hpqrs separately.
     // This only apples the needed hpqrs XXXX XXYY terms.
@@ -72,7 +72,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
         let newCoeff = [coeff[0]];
         let qubitPidx = idxFermions[0];
         let qubitQidx = idxFermions[1];
-        let qubitIndices = IntArrayFromRange(qubitPidx .. qubitQidx);
+        let qubitIndices = RangeAsIntArray(qubitPidx .. qubitQidx);
         return [GeneratorIndex((([1] + ConstantArray(Length(qubitIndices) - 2, 3)) + [1], newCoeff), qubitIndices), GeneratorIndex((([2] + ConstantArray(Length(qubitIndices) - 2, 3)) + [2], newCoeff), qubitIndices)];
     }
     
@@ -103,13 +103,13 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
             if (qubitPidx < qubitQidx and qubitQidx < qubitRidx) {
                 
                 // Apply XZ..ZIZ..ZX
-                let qubitIndices = IntArrayFromRange(qubitPidx .. qubitQidx - 1) + IntArrayFromRange(qubitQidx + 1 .. qubitRidx);
+                let qubitIndices = RangeAsIntArray(qubitPidx .. qubitQidx - 1) + RangeAsIntArray(qubitQidx + 1 .. qubitRidx);
                 return [GeneratorIndex((([1] + ConstantArray(Length(qubitIndices) - 2, 3)) + [1], newCoeff), qubitIndices), GeneratorIndex((([2] + ConstantArray(Length(qubitIndices) - 2, 3)) + [2], newCoeff), qubitIndices)];
             }
             else {
                 
                 // Apply ZI..IXZ..ZX or XZ..ZXI..IZ
-                let qubitIndices = IntArrayFromRange(qubitPidx .. qubitRidx) + [qubitQidx];
+                let qubitIndices = RangeAsIntArray(qubitPidx .. qubitRidx) + [qubitQidx];
                 return [GeneratorIndex((([1] + ConstantArray(Length(qubitIndices) - 3, 3)) + [1, 3], newCoeff), qubitIndices), GeneratorIndex((([2] + ConstantArray(Length(qubitIndices) - 3, 3)) + [2, 3], newCoeff), qubitIndices)];
             }
         }
@@ -131,8 +131,8 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
         let ((idxTermType, v0123), idxFermions) = term!;
         let qubitsPQ = idxFermions[0 .. 1];
         let qubitsRS = idxFermions[2 .. 3];
-        let qubitsPQJW = IntArrayFromRange(qubitsPQ[0] + 1 .. qubitsPQ[1] - 1);
-        let qubitsRSJW = IntArrayFromRange(qubitsRS[0] + 1 .. qubitsRS[1] - 1);
+        let qubitsPQJW = RangeAsIntArray(qubitsPQ[0] + 1 .. qubitsPQ[1] - 1);
+        let qubitsRSJW = RangeAsIntArray(qubitsRS[0] + 1 .. qubitsRS[1] - 1);
         let ops = [[1, 1, 1, 1], [1, 1, 2, 2], [1, 2, 1, 2], [2, 1, 1, 2], [2, 2, 2, 2], [2, 2, 1, 1], [2, 1, 2, 1], [1, 2, 2, 1]];
         mutable genIdxes = new GeneratorIndex[8];
         mutable nonZero = 0;

--- a/Chemistry/src/Runtime/JordanWigner/JordanWignerBlockEncoding.qs
+++ b/Chemistry/src/Runtime/JordanWigner/JordanWignerBlockEncoding.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Simulation;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Chemistry;

--- a/Chemistry/src/Runtime/JordanWigner/JordanWignerEvolutionSet.qs
+++ b/Chemistry/src/Runtime/JordanWigner/JordanWignerEvolutionSet.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Simulation;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Chemistry;

--- a/Chemistry/src/Runtime/JordanWigner/JordanWignerOptimizedBlockEncoding.qs
+++ b/Chemistry/src/Runtime/JordanWigner/JordanWignerOptimizedBlockEncoding.qs
@@ -5,7 +5,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Simulation;
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Preparation;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Extensions.Math;

--- a/Chemistry/src/Runtime/JordanWigner/JordanWignerOptimizedBlockEncoding.qs
+++ b/Chemistry/src/Runtime/JordanWigner/JordanWignerOptimizedBlockEncoding.qs
@@ -12,6 +12,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Chemistry;
     open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Convert;
 
     /// # Summary
     /// Term data in the optimized block-encoding algorithm.
@@ -177,8 +178,8 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
         let ((idxTermType, v0123), idxFermions) = term!;
         let qubitsPQ = idxFermions[0 .. 1];
         let qubitsRS = idxFermions[2 .. 3];
-        let qubitsPQJW = IntArrayFromRange(qubitsPQ[0] + 1 .. qubitsPQ[1] - 1);
-        let qubitsRSJW = IntArrayFromRange(qubitsRS[0] + 1 .. qubitsRS[1] - 1);
+        let qubitsPQJW = RangeAsIntArray(qubitsPQ[0] + 1 .. qubitsPQ[1] - 1);
+        let qubitsRSJW = RangeAsIntArray(qubitsRS[0] + 1 .. qubitsRS[1] - 1);
         let ops = [[1, 1, 1, 1], [1, 1, 2, 2], [1, 2, 1, 2], [1, 2, 2, 1], [2, 2, 2, 2], [2, 2, 1, 1], [2, 1, 2, 1], [2, 1, 1, 2]];
         mutable majIdxes = new OptimizedBETermIndex[4];
         mutable nonZero = 0;

--- a/Chemistry/src/Runtime/JordanWigner/OptimizedBEOperator.qs
+++ b/Chemistry/src/Runtime/JordanWigner/OptimizedBEOperator.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Chemistry;
     open Microsoft.Quantum.Arrays;

--- a/Chemistry/src/Runtime/JordanWigner/StatePreparation.qs
+++ b/Chemistry/src/Runtime/JordanWigner/StatePreparation.qs
@@ -4,7 +4,7 @@
 namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Preparation;
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;

--- a/Chemistry/src/Runtime/JordanWigner/Utils.qs
+++ b/Chemistry/src/Runtime/JordanWigner/Utils.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Chemistry.JordanWigner {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Chemistry;

--- a/Chemistry/src/Runtime/Runtime.csproj
+++ b/Chemistry/src/Runtime/Runtime.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.5.1903.2703" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1904.1008-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chemistry/src/Runtime/Utils.qs
+++ b/Chemistry/src/Runtime/Utils.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Chemistry {
     open Microsoft.Quantum.Simulation;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Math;
     

--- a/Chemistry/tests/ChemistryTests/ChemistryTests.csproj
+++ b/Chemistry/tests/ChemistryTests/ChemistryTests.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.5.1903.2703" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.5.1903.2703" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1904.1008-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.6.1904.1008-beta" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/Chemistry/tests/ChemistryTests/InitialStatePrepTests.qs
+++ b/Chemistry/tests/ChemistryTests/InitialStatePrepTests.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Chemistry.Tests {
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Testing;
     open Microsoft.Quantum.Extensions.Math;

--- a/Chemistry/tests/ChemistryTests/MajoranaOperatorTests.qs
+++ b/Chemistry/tests/ChemistryTests/MajoranaOperatorTests.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Chemistry.Tests {
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Testing;
     open Microsoft.Quantum.Extensions.Math;
@@ -259,27 +259,22 @@ namespace Microsoft.Quantum.Chemistry.Tests {
     
     // Test SelectZ operator
     operation SelectZTest () : Unit {
-        
         let targetRegisterSize = 7;
         let indexRegisterSize = Ceiling(Lg(ToDouble(targetRegisterSize)));
-        
-        using (targetRegister = Qubit[targetRegisterSize]) {
-            
-            using (indexRegister = Qubit[indexRegisterSize]) {
-                
-                for (idxTest in 0 .. targetRegisterSize - 1) {
-                    H(targetRegister[idxTest]);
-                    InPlaceXorLE(idxTest, LittleEndian(Reversed(indexRegister)));
-                    SelectZ(BigEndian(indexRegister), targetRegister);
-                    AssertProb([PauliX], [targetRegister[idxTest]], One, 1.0, $"Error: Test {idxTest} X Pauli |+>", 1E-10);
-                    Z(targetRegister[idxTest]);
-                    Adjoint InPlaceXorLE(idxTest, LittleEndian(Reversed(indexRegister)));
-                    H(targetRegister[idxTest]);
-                }
+
+        using ((targetRegister, indexRegister) = (Qubit[targetRegisterSize], Qubit[indexRegisterSize])) {
+            for (idxTest in 0 .. targetRegisterSize - 1) {
+                H(targetRegister[idxTest]);
+                ApplyXorInPlace(idxTest, LittleEndian(Reversed(indexRegister)));
+                SelectZ(BigEndian(indexRegister), targetRegister);
+                AssertProb([PauliX], [targetRegister[idxTest]], One, 1.0, $"Error: Test {idxTest} X Pauli |+>", 1E-10);
+                Z(targetRegister[idxTest]);
+                Adjoint ApplyXorInPlace(idxTest, LittleEndian(Reversed(indexRegister)));
+                H(targetRegister[idxTest]);
             }
         }
     }
-    
+
 }
 
 

--- a/Chemistry/tests/DataModelTests/DataModelTests.csproj
+++ b/Chemistry/tests/DataModelTests/DataModelTests.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.5.1903.2703" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.5.1903.2703" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1904.1010-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.6.1904.1010-beta" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/Chemistry/tests/SystemTests/SystemTest.qs
+++ b/Chemistry/tests/SystemTests/SystemTest.qs
@@ -3,7 +3,7 @@
 
 namespace SystemTests {
     open Microsoft.Quantum.Simulation;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Chemistry.JordanWigner;    

--- a/Chemistry/tests/SystemTests/SystemTestBlockEncoding.qs
+++ b/Chemistry/tests/SystemTests/SystemTestBlockEncoding.qs
@@ -4,7 +4,7 @@
 namespace SystemTestsBlockEncoding {
     open Microsoft.Quantum.Simulation;
     open Microsoft.Quantum.Math;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;

--- a/Chemistry/tests/SystemTests/SystemTestOptimizedBlockEncoding.qs
+++ b/Chemistry/tests/SystemTests/SystemTestOptimizedBlockEncoding.qs
@@ -3,7 +3,7 @@
 
 namespace SystemTestsOptimizedBlockEncoding {
     
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;

--- a/Chemistry/tests/SystemTests/SystemTests.csproj
+++ b/Chemistry/tests/SystemTests/SystemTests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.5.1903.2703" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1904.1010-beta" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Standard/src/AmplitudeAmplification/AmplitudeAmplification.qs
+++ b/Standard/src/AmplitudeAmplification/AmplitudeAmplification.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.AmplitudeAmplification {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Math;

--- a/Standard/src/Arithmetic/ApplyDual.qs
+++ b/Standard/src/Arithmetic/ApplyDual.qs
@@ -7,7 +7,7 @@
 
 namespace Microsoft.Quantum.Arithmetic {
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
 
     /// # Summary
     /// Applies an operation that takes a

--- a/Standard/src/Arithmetic/ApplyReversed.qs
+++ b/Standard/src/Arithmetic/ApplyReversed.qs
@@ -7,7 +7,7 @@
 
 namespace Microsoft.Quantum.Arithmetic {
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
 
     /// # Summary
     /// Applies an operation that takes little-endian input to a register encoding

--- a/Standard/src/Arithmetic/Arithmetic.qs
+++ b/Standard/src/Arithmetic/Arithmetic.qs
@@ -33,22 +33,6 @@ namespace Microsoft.Quantum.Arithmetic {
     }
 
     /// # Summary
-    /// Applies `X` operations to qubits in a big-endian register based on 1 bits in an integer.
-    ///
-    /// Let us denote `value` by a and let y be an unsigned integer encoded in `target`,
-    /// then `InPlaceXorBE` performs an operation given by the following map:
-    /// $\ket{y}\rightarrow \ket{y\oplus a}$ , where $\oplus$ is the bitwise exclusive OR operator.
-    ///
-    /// # Input
-    /// ## value
-    /// An integer which is assumed to be non-negative.
-    /// ## target
-    /// A quantum register which is used to store `value` in big-endian encoding.
-    ///
-    /// # See Also
-    /// - InPlaceXorLE
-    
-    /// # Summary
     /// This computes the Majority function in-place on 3 qubits.
     ///
     /// If we denote output qubit as $z$ and input qubits as $x$ and $y$,

--- a/Standard/src/Arithmetic/Arithmetic.qs
+++ b/Standard/src/Arithmetic/Arithmetic.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arithmetic {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Convert;
     open Microsoft.Quantum.Arrays;

--- a/Standard/src/Arithmetic/Asserts.qs
+++ b/Standard/src/Arithmetic/Asserts.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arithmetic {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Convert;
     open Microsoft.Quantum.Arrays;
@@ -66,7 +66,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// The controlled version of this operation ignores controls.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Primitive.Assert
+    /// - Microsoft.Quantum.Intrinsic.Assert
     operation AssertMostSignificantBit(value : Result, number : LittleEndian) : Unit {
         body (...) {
             let mostSingificantQubit = Tail(number!);

--- a/Standard/src/Arithmetic/Asserts.qs
+++ b/Standard/src/Arithmetic/Asserts.qs
@@ -96,17 +96,16 @@ namespace Microsoft.Quantum.Arithmetic {
     operation AssertPhaseLessThan(value : Int, number : PhaseLittleEndian) : Unit {
         body (...) {
             let inner = ApplyLEOperationOnPhaseLEA(AssertHighestBit(One, _), _);
-            ApplyWithA(Adjoint IntegerIncrementPhaseLE(value, _), inner, number);
+            ApplyWithA(Adjoint IncrementPhaseByInteger(value, _), inner, number);
         }
-        
+
         adjoint self;
-        
+
         controlled (ctrls, ...) {
             AssertPhaseLessThan(value, number);
         }
-        
+
         controlled adjoint auto;
     }
-    
 
 }

--- a/Standard/src/Arithmetic/Comparators.qs
+++ b/Standard/src/Arithmetic/Comparators.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arithmetic {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Arrays;
 

--- a/Standard/src/Arithmetic/Convert.qs
+++ b/Standard/src/Arithmetic/Convert.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arithmetic {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Arrays;
 

--- a/Standard/src/Arithmetic/Deprecated.qs
+++ b/Standard/src/Arithmetic/Deprecated.qs
@@ -253,9 +253,9 @@ namespace Microsoft.Quantum.Canon {
         body (...) {
             Removed(
                 "Microsoft.Quantum.Canon.ApplyRippleCarryComparatorBE",
-                "ApplyRippleCarryComparatorLE(BigEndianAsLittleEndian(x), BigEndianAsLittleEndian(y), output)"
+                "CompareUsingRippleCarry(BigEndianAsLittleEndian(x), BigEndianAsLittleEndian(y), output)"
             );
-            ApplyRippleCarryComparatorLE(BigEndianAsLittleEndian(x), BigEndianAsLittleEndian(y), output);
+            CompareUsingRippleCarry(BigEndianAsLittleEndian(x), BigEndianAsLittleEndian(y), output);
         }
         adjoint auto;
         controlled auto;

--- a/Standard/src/Arithmetic/Increment.qs
+++ b/Standard/src/Arithmetic/Increment.qs
@@ -73,15 +73,8 @@ namespace Microsoft.Quantum.Arithmetic {
     ///
     /// # See Also
     /// - IncrementByIntegerPhaseLE
-    operation IncrementByInteger(increment : Int, target : LittleEndian) : Unit {
-        body (...) {
-            let inner = IntegerIncrementPhaseLE(increment, _);
-            ApplyPhaseLEOperationOnLECA(inner, target);
-        }
-
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
+    operation IncrementByInteger(increment : Int, target : LittleEndian) : Unit is Adj + Ctl {
+        ApplyPhaseLEOperationOnLECA(IncrementPhaseByInteger(increment, _), target);
     }
 
 }

--- a/Standard/src/Arithmetic/Increment.qs
+++ b/Standard/src/Arithmetic/Increment.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arithmetic {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
 
     /// # Summary
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.Arithmetic {
             let d = Length(target!);
 
             for (j in 0 .. d - 1) {
-                //  Use Microsoft.Quantum.Primitive.R1Frac
+                //  Use Microsoft.Quantum.Intrinsic.R1Frac
                 R1Frac(increment, (d - 1) - j, (target!)[j]);
             }
         }

--- a/Standard/src/Arithmetic/Modular.qs
+++ b/Standard/src/Arithmetic/Modular.qs
@@ -71,7 +71,7 @@ namespace Microsoft.Quantum.Arithmetic {
         adjoint auto;
 
         controlled (controls, ...) {
-            EqualityFactB(modulus <= 2 ^ (Length(target!) - 1), true, $"`multiplier` must be big enough to fit integers modulo `modulus`" + $"with highest bit set to 0");
+            Fact(modulus <= 2 ^ (Length(target!) - 1), $"`multiplier` must be big enough to fit integers modulo `modulus`" + $"with highest bit set to 0");
 
             if (_EnableExtraAssertsForArithmetic()) {
                 // assert that the highest bit is zero, by switching to computational basis
@@ -84,7 +84,7 @@ namespace Microsoft.Quantum.Arithmetic {
             // note that controlled version is correct only under the assumption
             // that the value of target is less than modulus
             using (lessThanModulusFlag = Qubit()) {
-                let copyMostSignificantBitPhaseLE = ApplyLEOperationOnPhaseLEA(CopyMostSignificantBitLE(_, lessThanModulusFlag), _);
+                let copyMostSignificantBitPhaseLE = ApplyLEOperationOnPhaseLEA(CopyMostSignificantBit(_, lessThanModulusFlag), _);
 
                 // lets track the state of target register through the computation
                 Controlled IncrementPhaseByInteger(controls, (increment, target));

--- a/Standard/src/Arithmetic/Shorthand.qs
+++ b/Standard/src/Arithmetic/Shorthand.qs
@@ -1,5 +1,5 @@
 namespace Microsoft.Quantum.Arithmetic {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
 
     /// # Summary

--- a/Standard/src/Arrays/Deprecated.qs
+++ b/Standard/src/Arrays/Deprecated.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Arrays;
 
     /// # Deprecated

--- a/Standard/src/Arrays/Search.qs
+++ b/Standard/src/Arrays/Search.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arrays {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
 
     /// # Summary

--- a/Standard/src/Canon/Combinators/ApplyMultiControlled.qs
+++ b/Standard/src/Canon/Combinators/ApplyMultiControlled.qs
@@ -105,31 +105,24 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # See Also
     /// - Microsoft.Quantum.Canon.ApplyMultiControlledC
-    operation ApplyMultiControlledCA (singlyControlledOp : (Qubit[] => Unit : Adjoint), ccnot : CCNOTop, controls : Qubit[], targets : Qubit[]) : Unit
-    {
-        body (...)
-        {
-            EqualityFactB(Length(controls) >= 1, true, $"Length of controls must be at least 1");
-            
-            if (Length(controls) == 1)
-            {
+    operation ApplyMultiControlledCA (singlyControlledOp : (Qubit[] => Unit : Adjoint), ccnot : CCNOTop, controls : Qubit[], targets : Qubit[]) : Unit {
+        body (...) {
+            Fact(Length(controls) >= 1, $"Length of controls must be at least 1");
+
+            if (Length(controls) == 1) {
                 singlyControlledOp(controls + targets);
-            }
-            else
-            {
-                using (ancillas = Qubit[Length(controls) - 1])
-                {
-                    AndLadder(ccnot, controls, ancillas);
-                    singlyControlledOp([Tail(ancillas)] + targets);
-                    Adjoint AndLadder(ccnot, controls, ancillas);
+            } else {
+                using (ladderRegister = Qubit[Length(controls) - 1]) {
+                    AndLadder(ccnot, controls, ladderRegister);
+                    singlyControlledOp([Tail(ladderRegister)] + targets);
+                    Adjoint AndLadder(ccnot, controls, ladderRegister);
                 }
             }
         }
         
         adjoint invert;
         
-        controlled (extraControls, ...)
-        {
+        controlled (extraControls, ...) {
             ApplyMultiControlledCA(singlyControlledOp, ccnot, extraControls + controls, targets);
         }
         
@@ -174,23 +167,16 @@ namespace Microsoft.Quantum.Canon {
     /// - Used as a part of <xref:microsoft.quantum.canon.applymulticontrolledc>
     ///   and <xref:microsoft.quantum.canon.applymulticontrolledca>.
     /// - For the explanation and circuit diagram see Figure 4.10, Section 4.3 in Nielsen & Chuang.
-    operation AndLadder (ccnot : CCNOTop, controls : Qubit[], targets : Qubit[]) : Unit
-    {
-        body (...)
-        {
-            EqualityFactB(Length(controls) == Length(targets) + 1, true, $"Length(controls) must be equal to Length(target) + 1");
-            EqualityFactB(Length(controls) >= 2, true, $"The operation is not defined for less than 2 controls");
-            ccnot!(controls[0], controls[1], targets[0]);
-            
-            for (k in 1 .. Length(targets) - 1)
-            {
-                ccnot!(controls[k + 1], targets[k - 1], targets[k]);
-            }
+    operation AndLadder (ccnot : CCNOTop, controls : Qubit[], targets : Qubit[]) : Unit is Adj {
+        EqualityFactI(Length(controls), Length(targets) + 1, $"Length(controls) must be equal to Length(target) + 1");
+        Fact(Length(controls) >= 2, $"The operation is not defined for less than 2 controls");
+        ccnot!(controls[0], controls[1], targets[0]);
+
+        for (k in 1 .. Length(targets) - 1) {
+            ccnot!(controls[k + 1], targets[k - 1], targets[k]);
         }
-        
-        adjoint invert;
     }
-    
+
 }
 
 

--- a/Standard/src/Canon/Combinators/With.qs
+++ b/Standard/src/Canon/Combinators/With.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
 
     /// # Summary
     /// Given two operations, applies one as conjugated with the other.

--- a/Standard/src/Canon/CommonGates.qs
+++ b/Standard/src/Canon/CommonGates.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Arithmetic;
 
     /// # Summary

--- a/Standard/src/Canon/Multiplexer.qs
+++ b/Standard/src/Canon/Multiplexer.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Arrays;

--- a/Standard/src/Canon/NoOp.qs
+++ b/Standard/src/Canon/NoOp.qs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.Canon {
     /// <xref:microsoft.quantum.primitive.i>.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Primitive.I
+    /// - Microsoft.Quantum.Intrinsic.I
     operation NoOp<'T>(input : 'T) : Unit {
         body (...) {}
 

--- a/Standard/src/Canon/NoOp.qs
+++ b/Standard/src/Canon/NoOp.qs
@@ -24,16 +24,11 @@ namespace Microsoft.Quantum.Canon {
     /// # Remarks
     /// In almost all cases, the type parameter for `NoOp` needs to be specified
     /// explicitly. For instance, `NoOp<Qubit>` is identical to
-    /// <xref:microsoft.quantum.primitive.i>.
+    /// <xref:microsoft.quantum.intrinsic.i>.
     ///
     /// # See Also
     /// - Microsoft.Quantum.Intrinsic.I
-    operation NoOp<'T>(input : 'T) : Unit {
-        body (...) {}
-
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
+    operation NoOp<'T>(input : 'T) : Unit is Adj + Ctl {
     }
 
 

--- a/Standard/src/Canon/Parity.qs
+++ b/Standard/src/Canon/Parity.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
 
     /// # Summary
     /// Computes the parity of an array of qubits in-place.

--- a/Standard/src/Canon/QFT.qs
+++ b/Standard/src/Canon/QFT.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Canon {
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Diagnostics;
 
     /// # Summary

--- a/Standard/src/Canon/Registers.qs
+++ b/Standard/src/Canon/Registers.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
 
     /// # Summary
     /// Uses SWAP gates to Reversed the order of the qubits in

--- a/Standard/src/Canon/Utils/ControlledOnBitString.qs
+++ b/Standard/src/Canon/Utils/ControlledOnBitString.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Canon {
     open Microsoft.Quantum.Convert;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     
     /// # Summary
     /// Applies a unitary operator on the target register if the control register state corresponds to a specified bit mask.

--- a/Standard/src/Canon/Utils/Deprecation.qs
+++ b/Standard/src/Canon/Utils/Deprecation.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
 
     /// # Summary
     /// When called from a deprecated function or operation, logs a message

--- a/Standard/src/Canon/Utils/Multiplexer.qs
+++ b/Standard/src/Canon/Utils/Multiplexer.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Canon {
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Arrays;
     

--- a/Standard/src/Canon/Utils/Paulis.qs
+++ b/Standard/src/Canon/Utils/Paulis.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
 
     /// # Summary
     /// Given a multi-qubit Pauli operator, applies the corresponding operation to

--- a/Standard/src/Characterization/PhaseEstimation/Iterative.qs
+++ b/Standard/src/Characterization/PhaseEstimation/Iterative.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Characterization {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Oracles;
     open Microsoft.Quantum.Canon;

--- a/Standard/src/Characterization/PhaseEstimation/Quantum.qs
+++ b/Standard/src/Characterization/PhaseEstimation/Quantum.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Characterization {
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Testing;
     open Microsoft.Quantum.Oracles;
     open Microsoft.Quantum.Canon;

--- a/Standard/src/Characterization/PhaseEstimation/Robust.qs
+++ b/Standard/src/Characterization/PhaseEstimation/Robust.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Characterization {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Oracles;

--- a/Standard/src/Characterization/ProcessTomography.qs
+++ b/Standard/src/Characterization/ProcessTomography.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Characterization {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Extensions.Math;

--- a/Standard/src/Convert/Convert.qs
+++ b/Standard/src/Convert/Convert.qs
@@ -213,7 +213,7 @@ namespace Microsoft.Quantum.Convert {
     /// ## Example
     /// ```qsharp
     /// // The following returns [1,3,5,7];
-    /// let array = IntArrayFromRange(1..2..8);
+    /// let array = RangeAsIntArray(1..2..8);
     /// ```
     function RangeAsIntArray(range: Range) : Int[] {
         let start = RangeStart(range);

--- a/Standard/src/Diagnostics/Deprecated.qs
+++ b/Standard/src/Diagnostics/Deprecated.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Diagnostics;
 
     /// # Deprecated

--- a/Standard/src/Diagnostics/Facts.qs
+++ b/Standard/src/Diagnostics/Facts.qs
@@ -6,6 +6,19 @@ namespace Microsoft.Quantum.Diagnostics {
     open Microsoft.Quantum.Arrays;
 
     /// # Summary
+    /// Declares that a classical condition is true.
+    ///
+    /// # Input
+    /// ## actual
+    /// The condition to be declared.
+    /// ## message
+    /// Failure message string to be printed in the case that the classical
+    /// condition is false.
+    function Fact(actual : Bool, message : String) : Unit {
+        if (not actual) { fail message; }
+    }
+
+    /// # Summary
     /// Represents the claim that a classical floating point value has the
     /// expected value up to a given
     /// absolute tolerance.

--- a/Standard/src/Diagnostics/Quantum.qs
+++ b/Standard/src/Diagnostics/Quantum.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Extensions.Math;
 

--- a/Standard/src/ErrorCorrection/5QubitCode.qs
+++ b/Standard/src/ErrorCorrection/5QubitCode.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.ErrorCorrection {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Measurement;
 

--- a/Standard/src/ErrorCorrection/7QubitCode.qs
+++ b/Standard/src/ErrorCorrection/7QubitCode.qs
@@ -6,6 +6,7 @@ namespace Microsoft.Quantum.ErrorCorrection {
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Measurement;
+    open Microsoft.Quantum.Convert;
 
     /// # Summary
     /// Private operation used to implement both the Steane code encoder and decoder.

--- a/Standard/src/ErrorCorrection/7QubitCode.qs
+++ b/Standard/src/ErrorCorrection/7QubitCode.qs
@@ -58,16 +58,12 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// - D. Gottesman, "Stabilizer Codes and Quantum Error Correction," Ph.D. Thesis, Caltech, 1997;
     /// https://arxiv.org/abs/quant-ph/9705052
     function SteaneCodeRecoveryX (syndrome : Syndrome) : Pauli[] {
-        let idxQubit = ResultAsInt(syndrome!);
-        
-        if (idxQubit == 0) {
-            return ConstantArray(7, PauliI);
-        }
-        
-        return EmbedPauli(PauliZ, idxQubit - 1, 7);
+        let idxQubit = ResultArrayAsInt(syndrome!);
+        return idxQubit == 0
+               ? ConstantArray(7, PauliI)
+               | EmbedPauli(PauliZ, idxQubit - 1, 7);
     }
-    
-    
+
     /// # Summary
     /// Decoder for the Z-part of the stabilizer group of the ⟦7, 1, 3⟧ Steane quantum code.
     ///
@@ -75,17 +71,12 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// - SteaneCodeRecoveryX
     /// - SteaneCodeRecoveryFns
     function SteaneCodeRecoveryZ (syndrome : Syndrome) : Pauli[] {
-        let idxQubit = ResultAsInt(syndrome!);
-        
-        if (idxQubit == 0)
-        {
-            return ConstantArray(7, PauliI);
-        }
-        
-        return EmbedPauli(PauliX, idxQubit - 1, 7);
+        let idxQubit = ResultArrayAsInt(syndrome!);
+        return idxQubit == 0
+               ? ConstantArray(7, PauliI)
+               | EmbedPauli(PauliX, idxQubit - 1, 7);
     }
-    
-    
+
     /// # Summary
     /// Decoder for combined X- and Z-parts of the stabilizer group of the
     /// ⟦7, 1, 3⟧ Steane quantum code.

--- a/Standard/src/ErrorCorrection/7QubitCode.qs
+++ b/Standard/src/ErrorCorrection/7QubitCode.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.ErrorCorrection {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Measurement;

--- a/Standard/src/ErrorCorrection/BitFlipCode.qs
+++ b/Standard/src/ErrorCorrection/BitFlipCode.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.ErrorCorrection {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Measurement;
 

--- a/Standard/src/ErrorCorrection/KnillDistill.qs
+++ b/Standard/src/ErrorCorrection/KnillDistill.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.ErrorCorrection {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Measurement;

--- a/Standard/src/ErrorCorrection/Types.qs
+++ b/Standard/src/ErrorCorrection/Types.qs
@@ -40,16 +40,16 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// The argument to a DecodeOp is the same as the return from an
     /// EncodeOp, and vice versa.
     newtype DecodeOp = (LogicalRegister => (Qubit[], Qubit[]));
-    
+
     /// # Summary
     /// Represents an operation that is used to measure the syndrome
     /// of an error-correcting code block.
     ///
     /// # Remarks
     /// The signature `(LogicalRegister => Syndrome)` represents an operation
-    /// that acts jointly on the qubits in `LogicalRegister` and some ancilla
-    /// qubits followed by a measurements of the ancilla to extract a `Syndrome`
-    /// type representing the `Result[]` of these measurements.
+    /// that acts jointly on the qubits in `LogicalRegister` and some auxillary
+    /// qubits followed by a measurements of the auxillary qubits to extract a
+    /// `Syndrome` value representing the `Result[]` of these measurements.
     ///
     /// ## Example
     /// Measure syndromes for the bit-flip code
@@ -63,10 +63,10 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// ```
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.LogicalRegister
-    /// - Microsoft.Quantum.Canon.Syndrome
+    /// - LogicalRegister
+    /// - Syndrome
     newtype SyndromeMeasOp = (LogicalRegister => Syndrome);
-    
+
     /// # Summary
     /// Represents an error-correcting code as defined by its encoder,
     /// decoder, and syndrome measurement procedure.

--- a/Standard/src/ErrorCorrection/Utils.qs
+++ b/Standard/src/ErrorCorrection/Utils.qs
@@ -5,6 +5,7 @@ namespace Microsoft.Quantum.ErrorCorrection {
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Measurement;
+    open Microsoft.Quantum.Convert;
 
     /// # Summary
     /// Measures the given set of generators of a stabilizer group.
@@ -95,7 +96,7 @@ namespace Microsoft.Quantum.ErrorCorrection {
     
     function TableLookupRecoveryImpl (table : Pauli[][], syndrome : Syndrome) : Pauli[]
     {
-        return table[ResultAsInt(syndrome!)];
+        return table[ResultArrayAsInt(syndrome!)];
     }
     
     

--- a/Standard/src/ErrorCorrection/Utils.qs
+++ b/Standard/src/ErrorCorrection/Utils.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.ErrorCorrection {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Measurement;
 

--- a/Standard/src/Math/Random.qs
+++ b/Standard/src/Math/Random.qs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.Math {
     /// that is, with $\Pr(x) = \frac{1}{2^{\texttt{maxBits}}}$.
     ///
     /// # Remarks
-    /// This function calls <xref:microsoft.quantum.primitive.random>, so
+    /// This function calls <xref:microsoft.quantum.intrinsic.random>, so
     /// its randomness depends on the implementation of `Random`.
     operation RandomIntPow2 (maxBits : Int) : Int
     {
@@ -63,7 +63,7 @@ namespace Microsoft.Quantum.Math {
     /// underlying source of random classical bits.
     ///
     /// # Remarks
-    /// This function calls <xref:microsoft.quantum.primitive.random>, so
+    /// This function calls <xref:microsoft.quantum.intrinsic.random>, so
     /// its randomness depends on the implementation of `Random`.
     operation RandomInt (maxInt : Int) : Int
     {
@@ -99,7 +99,7 @@ namespace Microsoft.Quantum.Math {
     /// with probability $\Pr(k) = 1 / 2^{\texttt{bitsRandom}}$.
     ///
     /// # Remarks
-    /// This function calls <xref:microsoft.quantum.primitive.random>, so
+    /// This function calls <xref:microsoft.quantum.intrinsic.random>, so
     /// its randomness depends on the implementation of `Random`.
     operation RandomReal (bitsRandom : Int) : Double
     {
@@ -119,7 +119,7 @@ namespace Microsoft.Quantum.Math {
     /// A `Pauli` operator that is one of `[PauliI, PauliX, PauliY, PauliZ]`.
     ///
     /// # Remarks
-    /// This function calls <xref:microsoft.quantum.primitive.random>, so
+    /// This function calls <xref:microsoft.quantum.intrinsic.random>, so
     /// its randomness depends on the implementation of `Random`.
     operation RandomSingleQubitPauli () : Pauli {
         let probs = [0.5, 0.5, 0.5, 0.5];

--- a/Standard/src/Math/Random.qs
+++ b/Standard/src/Math/Random.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Math {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Extensions.Math;
     

--- a/Standard/src/Measurement/Registers.qs
+++ b/Standard/src/Measurement/Registers.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Measurement {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Arrays;
 

--- a/Standard/src/Measurement/Reset.qs
+++ b/Standard/src/Measurement/Reset.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Measurement {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
 
     operation _BasisChangeZtoY (target : Qubit) : Unit {

--- a/Standard/src/Oracles/CommonOracles.qs
+++ b/Standard/src/Oracles/CommonOracles.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.AmplitudeAmplification {
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Oracles;
 
     /// # Summary

--- a/Standard/src/Preparation/Mixed.qs
+++ b/Standard/src/Preparation/Mixed.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Preparation {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Math;
 

--- a/Standard/src/Preparation/QuantumROM.qs
+++ b/Standard/src/Preparation/QuantumROM.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Preparation {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Extensions.Math;

--- a/Standard/src/Preparation/QuantumROM.qs
+++ b/Standard/src/Preparation/QuantumROM.qs
@@ -9,6 +9,7 @@ namespace Microsoft.Quantum.Preparation {
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Arrays;
+    open Microsoft.Quantum.Convert;
 
     /// # Summary
 	/// Uses the Quantum ROM technique to represent a given density matrix.
@@ -122,8 +123,8 @@ namespace Microsoft.Quantum.Preparation {
         }
 
         let barHeight = 2^bitsPrecision - 1;
-        
-        mutable altIndex = IntArrayFromRange(0..nCoefficients-1);
+
+        mutable altIndex = RangeAsIntArray(0..nCoefficients-1);
         mutable keepCoeff = Mapped(QuantumROMDiscretizationRoundCoefficients_(_, oneNorm, nCoefficients, barHeight), coefficients);
 
         // Calculate difference between number of discretized bars vs. maximum

--- a/Standard/src/Preparation/Reference.qs
+++ b/Standard/src/Preparation/Reference.qs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Quantum.Preparation {
     open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Arrays;
 
     /// # Summary
 	/// Pairwise entangles two qubit registers.
@@ -16,28 +17,17 @@ namespace Microsoft.Quantum.Preparation {
     /// A qubit array in the $\ket{0\cdots 0}$ state
     /// ## right
     /// A qubit array in the $\ket{0\cdots 0}$ state
-    operation PrepareEntangledState (left : Qubit[], right : Qubit[]) : Unit
-    {
-        body (...)
-        {
-            if (Length(left) != Length(right))
-            {
-                fail $"Left and right registers must be the same length.";
-            }
-            
-            for (idxQubit in 0 .. Length(left) - 1)
-            {
-                H(left[idxQubit]);
-                Controlled X([left[idxQubit]], right[idxQubit]);
-            }
+    operation PrepareEntangledState (left : Qubit[], right : Qubit[]) : Unit is Adj + Ctl {
+        if (Length(left) != Length(right)) {
+            fail $"Left and right registers must be the same length.";
         }
-        
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
+
+        for ((leftQubit, rightQubit) in Zip(left, right)) {
+            H(leftQubit);
+            Controlled X([leftQubit], rightQubit);
+        }
     }
-    
-    
+
     /// # Summary
     /// Prepares the Choi–Jamiłkowski state for a given operation onto given reference
     /// and target registers.

--- a/Standard/src/Preparation/Reference.qs
+++ b/Standard/src/Preparation/Reference.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Preparation {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
 
     /// # Summary
 	/// Pairwise entangles two qubit registers.

--- a/Standard/src/Preparation/StatePreparation.qs
+++ b/Standard/src/Preparation/StatePreparation.qs
@@ -4,7 +4,7 @@
 namespace Microsoft.Quantum.Preparation {
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Arrays;

--- a/Standard/src/Preparation/UniformSuperposition.qs
+++ b/Standard/src/Preparation/UniformSuperposition.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Preparation {
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Arithmetic;

--- a/Standard/src/Simulation/BlockEncoding.qs
+++ b/Standard/src/Simulation/BlockEncoding.qs
@@ -4,7 +4,7 @@
 namespace Microsoft.Quantum.Simulation {
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Arrays;
 

--- a/Standard/src/Simulation/PauliEvolutionSet.qs
+++ b/Standard/src/Simulation/PauliEvolutionSet.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Simulation {
     open Microsoft.Quantum.Canon;    
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     
     
     // Convention for GeneratorIndex = ((Int[],Double[]), Int[])

--- a/Standard/src/Simulation/QubitizationPauliEvolutionSet.qs
+++ b/Standard/src/Simulation/QubitizationPauliEvolutionSet.qs
@@ -10,6 +10,7 @@ namespace Microsoft.Quantum.Simulation {
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Arrays;
+    open Microsoft.Quantum.Convert;
 
     /// # Summary
     /// Extracts the coefficient of a Pauli term described by a `GeneratorIndex`.
@@ -104,7 +105,7 @@ namespace Microsoft.Quantum.Simulation {
         multiplexer: ((Int, (Int -> (Qubit[] => Unit : Adjoint, Controlled))) -> ((BigEndian, Qubit[]) => Unit : Adjoint, Controlled))) : (Double, BlockEncodingReflection) {
         let (nTerms, intToGenIdx) = generatorSystem!;
         let op = IdxToCoeff_(_, intToGenIdx, PauliCoefficientFromGenIdx);
-        let coefficients = Mapped(op, IntArrayFromRange(0..nTerms-1));
+        let coefficients = Mapped(op, RangeAsIntArray(0..nTerms-1));
         let oneNorm = PowD(PNorm(2.0, coefficients),2.0);
         let unitaryGenerator = (nTerms, IdxToUnitary_(_, intToGenIdx, PauliLCUUnitary_));
         let statePreparation = statePrepUnitary(coefficients);

--- a/Standard/src/Simulation/QubitizationPauliEvolutionSet.qs
+++ b/Standard/src/Simulation/QubitizationPauliEvolutionSet.qs
@@ -5,7 +5,7 @@ namespace Microsoft.Quantum.Simulation {
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Preparation;
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;

--- a/Standard/src/Simulation/Techniques.qs
+++ b/Standard/src/Simulation/Techniques.qs
@@ -3,7 +3,7 @@
 
 namespace Microsoft.Quantum.Simulation {
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Oracles;

--- a/Standard/src/Standard.csproj
+++ b/Standard/src/Standard.csproj
@@ -19,6 +19,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.5.1903.2703" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1904.1008-beta" />
   </ItemGroup>
 </Project>

--- a/Standard/tests/AmplitudeAmplificationTests.qs
+++ b/Standard/tests/AmplitudeAmplificationTests.qs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Tests {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Extensions.Math;

--- a/Standard/tests/ApplyMultiControlledTests.qs
+++ b/Standard/tests/ApplyMultiControlledTests.qs
@@ -3,14 +3,14 @@
 namespace Microsoft.Quantum.Tests {
     
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Testing;
     
     
     /// # Summary
     /// Tests multiply controlled not implementation that uses
     /// ApplyMultiControlledCA against multiply controlled version of
-    /// the Microsoft.Quantum.Primitive.X
+    /// the Microsoft.Quantum.Intrinsic.X
     operation ApplyMultiControlledTest () : Unit {
         
         let twoQubitOp = CNOT;

--- a/Standard/tests/ArithmeticTests.qs
+++ b/Standard/tests/ArithmeticTests.qs
@@ -4,7 +4,7 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Math;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Diagnostics;
     
     

--- a/Standard/tests/ArithmeticTests.qs
+++ b/Standard/tests/ArithmeticTests.qs
@@ -12,14 +12,14 @@ namespace Microsoft.Quantum.Tests {
         
         using (register = Qubit[numberOfQubits]) {
             let registerLE = LittleEndian(register);
-            InPlaceXorLE(testValue, registerLE);
+            ApplyXorInPlace(testValue, registerLE);
             let measuredValue = MeasureInteger(registerLE);
             EqualityFactI(testValue, measuredValue, $"Did not measure the integer we expected.");
         }
     }
     
     
-    operation InPlaceXorLETest () : Unit {
+    operation ApplyXorInPlaceTest () : Unit {
         
         ApplyToEach(InPlaceXorTestHelper, [(63, 6), (42, 6)]);
     }
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.Tests {
         
         using (register = Qubit[numberOfQubits]) {
             let registerLE = LittleEndian(register);
-            InPlaceXorLE(summand1, registerLE);
+            ApplyXorInPlace(summand1, registerLE);
             IntegerIncrementLE(summand2, registerLE);
             let expected = Modulus(summand1 + summand2, 2 ^ numberOfQubits);
             let actual = MeasureInteger(registerLE);
@@ -58,20 +58,20 @@ namespace Microsoft.Quantum.Tests {
         
         using (register = Qubit[numberOfQubits]) {
             let registerLE = LittleEndian(register);
-            InPlaceXorLE(summand1, registerLE);
+            ApplyXorInPlace(summand1, registerLE);
             ModularIncrementLE(summand2, modulus, registerLE);
             let expected = Modulus(summand1 + summand2, modulus);
             let actual = MeasureInteger(registerLE);
             EqualityFactI(expected, actual, $"Expected {expected}, got {actual}");
             
             using (controls = Qubit[2]) {
-                InPlaceXorLE(summand1, registerLE);
+                ApplyXorInPlace(summand1, registerLE);
                 Controlled ModularIncrementLE(controls, (summand2, modulus, registerLE));
                 let actual2 = MeasureInteger(registerLE);
                 EqualityFactI(summand1, actual2, $"Expected {summand1}, got {actual2}");
                 
                 // now set all controls to 1
-                InPlaceXorLE(summand1, registerLE);
+                ApplyXorInPlace(summand1, registerLE);
                 (ControlledOnInt(0, ModularIncrementLE(summand2, modulus, _)))(controls, registerLE);
                 let actual3 = MeasureInteger(registerLE);
                 EqualityFactI(expected, actual3, $"Expected {expected}, got {actual3}");
@@ -103,8 +103,8 @@ namespace Microsoft.Quantum.Tests {
         using (register = Qubit[numberOfQubits * 2]) {
             let summandLE = LittleEndian(register[0 .. numberOfQubits - 1]);
             let multiplierLE = LittleEndian(register[numberOfQubits .. 2 * numberOfQubits - 1]);
-            InPlaceXorLE(summand, summandLE);
-            InPlaceXorLE(multiplier1, multiplierLE);
+            ApplyXorInPlace(summand, summandLE);
+            ApplyXorInPlace(multiplier1, multiplierLE);
             ModularAddProductLE(multiplier2, modulus, multiplierLE, summandLE);
             let expected = Modulus(summand + multiplier1 * multiplier2, modulus);
             let actual = MeasureInteger(summandLE);
@@ -141,7 +141,7 @@ namespace Microsoft.Quantum.Tests {
             
             if (IsCoprime(multiplier2, modulus)) {
                 let multiplierLE = LittleEndian(register);
-                InPlaceXorLE(multiplier1, multiplierLE);
+                ApplyXorInPlace(multiplier1, multiplierLE);
                 ModularMultiplyByConstantLE(multiplier2, modulus, multiplierLE);
                 let expected = Modulus(multiplier1 * multiplier2, modulus);
                 let actualMult = MeasureInteger(multiplierLE);

--- a/Standard/tests/ArrayTests.qs
+++ b/Standard/tests/ArrayTests.qs
@@ -3,7 +3,7 @@
 namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Arrays;
     
     

--- a/Standard/tests/AssertTests.qs
+++ b/Standard/tests/AssertTests.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Testing;
     open Microsoft.Quantum.Diagnostics;

--- a/Standard/tests/AssertTests.qs
+++ b/Standard/tests/AssertTests.qs
@@ -38,14 +38,12 @@ namespace Microsoft.Quantum.Tests {
     
     
     function AssertBoolEqualTestShouldFail () : Unit {
-        
         EqualityFactB(true, false, $"OK");
     }
     
     
-    function AssertResultEqualTestShouldFail () : Unit {
-        
-        AssertResultEqual(Zero, One, $"OK");
+    function EqualityFactRTestShouldFail () : Unit {
+        EqualityFactR(Zero, One, $"OK");
     }
     
     

--- a/Standard/tests/CombinatorTests.qs
+++ b/Standard/tests/CombinatorTests.qs
@@ -3,7 +3,7 @@
 namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Testing;
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Arrays;

--- a/Standard/tests/CommonGateTests.qs
+++ b/Standard/tests/CommonGateTests.qs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Tests {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Testing;
     open Microsoft.Quantum.Diagnostics;

--- a/Standard/tests/ConversionTests.qs
+++ b/Standard/tests/ConversionTests.qs
@@ -5,28 +5,23 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Convert;
 
-    function ResultAsIntTest () : Unit {
-        
-        EqualityFactI(ResultAsInt([Zero, Zero]), 0, $"Expected [Zero, Zero] to be represented by 0.");
-        EqualityFactI(ResultAsInt([One, Zero]), 1, $"Expected [One, Zero] to be represented by 1.");
-        EqualityFactI(ResultAsInt([Zero, One]), 2, $"Expected [Zero, One] to be represented by 2.");
-        EqualityFactI(ResultAsInt([One, One]), 3, $"Expected [One, One] to be represented by 3.");
+    function ResultArrayAsIntTest () : Unit {
+        EqualityFactI(ResultArrayAsInt([Zero, Zero]), 0, $"Expected [Zero, Zero] to be represented by 0.");
+        EqualityFactI(ResultArrayAsInt([One, Zero]), 1, $"Expected [One, Zero] to be represented by 1.");
+        EqualityFactI(ResultArrayAsInt([Zero, One]), 2, $"Expected [Zero, One] to be represented by 2.");
+        EqualityFactI(ResultArrayAsInt([One, One]), 3, $"Expected [One, One] to be represented by 3.");
     }
-    
-    
+
     function BoolArrFromPositiveIntTest () : Unit {
-        
         for (number in 0 .. 100) {
             let bits = IntAsBoolArray(number, 9);
-            let inte = PositiveIntFromBoolArr(bits);
+            let inte = BoolArrayAsInt(bits);
             EqualityFactI(inte, number, $"Integer converted to bit string and back should be identical");
         }
-        
+
         let bits70 = [false, true, true, false, false, false, true, false];
-        let number70 = PositiveIntFromBoolArr(bits70);
+        let number70 = BoolArrayAsInt(bits70);
         EqualityFactI(70, number70, $"Integer from 01000110 in little Endian should be 70");
     }
-    
+
 }
-
-

--- a/Standard/tests/IntegerTests.qs
+++ b/Standard/tests/IntegerTests.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arithmetic {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Diagnostics;

--- a/Standard/tests/MathTests.qs
+++ b/Standard/tests/MathTests.qs
@@ -131,7 +131,7 @@ namespace Microsoft.Quantum.Canon {
             let (p, array, pNormExpected) = testCases[idxTest];
             NearEqualityFact(PNorm(p, array), pNormExpected);
             
-            // if PNorm fails, PNormalize will fail.
+            // if PNorm fails, PNormalized will fail.
             let arrayNormalized = PNormalized(p, array);
             
             for (idxCoeff in 0 .. Length(array) - 1) {

--- a/Standard/tests/MathTests.qs
+++ b/Standard/tests/MathTests.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Canon {
     open Microsoft.Quantum.Math;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Arrays;

--- a/Standard/tests/MultiplexerTests.qs
+++ b/Standard/tests/MultiplexerTests.qs
@@ -3,7 +3,7 @@
 namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Measurement;

--- a/Standard/tests/PauliTests.qs
+++ b/Standard/tests/PauliTests.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Preparation;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Measurement;
     

--- a/Standard/tests/QFTTests.qs
+++ b/Standard/tests/QFTTests.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Testing;
     open Microsoft.Quantum.Diagnostics;

--- a/Standard/tests/QcvvTests.qs
+++ b/Standard/tests/QcvvTests.qs
@@ -9,13 +9,11 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Characterization;
     open Microsoft.Quantum.Preparation;
     open Microsoft.Quantum.Diagnostics;
-    
-    
+
     operation ChoiStateTest () : Unit {
-        
         using (register = Qubit[2]) {
             PrepareChoiStateCA(NoOp<Qubit[]>, [register[0]], [register[1]]);
-            
+
             // As usual, the same confusion about {+1, -1} and {0, 1}
             // labeling bites us here.
             Assert([PauliX, PauliX], register, Zero, $"XX");
@@ -23,43 +21,26 @@ namespace Microsoft.Quantum.Tests {
             ResetAll(register);
         }
     }
-    
-    
+
     operation EstimateFrequencyTest () : Unit {
-        
         let freq = EstimateFrequency(ApplyToEach(H, _), MeasureAllZ, 1, 1000);
         EqualityWithinToleranceFact(freq, 0.5, 0.1);
     }
-    
-    
-    operation _RobustPhaseEstimationTestOp (phase : Double, power : Int, qubits : Qubit[]) : Unit {
-        
-        body (...) {
-            //Rz(- 2.0* phase * ToDouble(power), qubits[0])
-            Exp([PauliZ], phase * ToDouble(power), qubits);
-            //Exp([PauliI], phase * ToDouble(power), qubits);
-        }
-        
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
+
+    operation _RobustPhaseEstimationTestOp (phase : Double, power : Int, qubits : Qubit[]) : Unit is Adj + Ctl {
+        Exp([PauliZ], phase * ToDouble(power), qubits);
     }
-    
-    
+
     operation RobustPhaseEstimationDemoImpl (phaseSet : Double, bitsPrecision : Int) : Double {
-        
         let op = DiscreteOracle(_RobustPhaseEstimationTestOp(phaseSet, _, _));
-        mutable phaseEst = ToDouble(0);
-        
-        using (q = Qubit[1]) {
-            set phaseEst = RobustPhaseEstimation(bitsPrecision, op, q);
-            ResetAll(q);
+
+        using (q = Qubit()) {
+            let phaseEst = RobustPhaseEstimation(bitsPrecision, op, [q]);
+            Reset(q);
+            return phaseEst;
         }
-        
-        return phaseEst;
     }
-    
-    
+
     // Probabilistic test. Might fail occasionally
     operation RobustPhaseEstimationTest () : Unit {
         
@@ -74,32 +55,27 @@ namespace Microsoft.Quantum.Tests {
     
     
     operation PrepareQubitTest () : Unit {
-        
-        using (register = Qubit[1]) {
-            let qubit = register[0];
+        using (qubit = Qubit()) {
             let bases = [PauliI, PauliX, PauliY, PauliZ];
-            
-            for (idxBasis in 0 .. Length(bases) - 1) {
-                let basis = bases[idxBasis];
+
+            for (basis in bases) {
                 PrepareQubit(basis, qubit);
-                Assert([basis], register, Zero, $"Did not prepare in {basis} correctly.");
+                Assert([basis], [qubit], Zero, $"Did not prepare in {basis} correctly.");
                 Reset(qubit);
             }
         }
     }
-    
-    
+
     operation SingleQubitProcessTomographyMeasurementTest () : Unit {
-        
-        AssertResultEqual(SingleQubitProcessTomographyMeasurement(PauliI, PauliI, H), Zero, $"Failed at ⟪I | H | I⟫.");
-        AssertResultEqual(SingleQubitProcessTomographyMeasurement(PauliX, PauliI, H), Zero, $"Failed at ⟪I | H | X⟫.");
-        AssertResultEqual(SingleQubitProcessTomographyMeasurement(PauliY, PauliI, H), Zero, $"Failed at ⟪I | H | Y⟫.");
-        AssertResultEqual(SingleQubitProcessTomographyMeasurement(PauliZ, PauliI, H), Zero, $"Failed at ⟪I | H | Z⟫.");
-        AssertResultEqual(SingleQubitProcessTomographyMeasurement(PauliX, PauliZ, H), Zero, $"Failed at ⟪Z | H | X⟫.");
-        AssertResultEqual(SingleQubitProcessTomographyMeasurement(PauliY, PauliY, H), One, $"Failed at -⟪Y | H | Y⟫.");
-        AssertResultEqual(SingleQubitProcessTomographyMeasurement(PauliX, PauliZ, H), Zero, $"Failed at ⟪Z | H | X⟫.");
+        EqualityFactR(SingleQubitProcessTomographyMeasurement(PauliI, PauliI, H), Zero, $"Failed at ⟪I | H | I⟫.");
+        EqualityFactR(SingleQubitProcessTomographyMeasurement(PauliX, PauliI, H), Zero, $"Failed at ⟪I | H | X⟫.");
+        EqualityFactR(SingleQubitProcessTomographyMeasurement(PauliY, PauliI, H), Zero, $"Failed at ⟪I | H | Y⟫.");
+        EqualityFactR(SingleQubitProcessTomographyMeasurement(PauliZ, PauliI, H), Zero, $"Failed at ⟪I | H | Z⟫.");
+        EqualityFactR(SingleQubitProcessTomographyMeasurement(PauliX, PauliZ, H), Zero, $"Failed at ⟪Z | H | X⟫.");
+        EqualityFactR(SingleQubitProcessTomographyMeasurement(PauliY, PauliY, H), One, $"Failed at -⟪Y | H | Y⟫.");
+        EqualityFactR(SingleQubitProcessTomographyMeasurement(PauliX, PauliZ, H), Zero, $"Failed at ⟪Z | H | X⟫.");
     }
-    
+
 }
 
 

--- a/Standard/tests/QcvvTests.qs
+++ b/Standard/tests/QcvvTests.qs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Tests {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Extensions.Math;

--- a/Standard/tests/QeccTests.qs
+++ b/Standard/tests/QeccTests.qs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Tests {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Testing;

--- a/Standard/tests/QuantumPhaseEstimationTests.qs
+++ b/Standard/tests/QuantumPhaseEstimationTests.qs
@@ -1,5 +1,5 @@
 namespace Microsoft.Quantum.Tests {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Extensions.Convert;

--- a/Standard/tests/QuantumROMTests.qs
+++ b/Standard/tests/QuantumROMTests.qs
@@ -3,7 +3,7 @@
 
 
 namespace Microsoft.Quantum.Tests {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Preparation;
     open Microsoft.Quantum.Extensions.Testing;

--- a/Standard/tests/QubitizationTests.qs
+++ b/Standard/tests/QubitizationTests.qs
@@ -26,7 +26,7 @@ namespace Microsoft.Quantum.Tests {
         return (eigenvalues, prob, inverseAngle, statePreparation, selector);
     }
 
-    // This checks that BlockEncodingByLCU encodes the correct Hamiltonian. 
+    // This checks that BlockEncodingByLCU encodes the correct Hamiltonian.
     operation BlockEncodingByLCUTest() : Unit {
         body (...) {
             let (eigenvalues, prob, inverseAngle, statePreparation, selector) = LCUTestHelper();
@@ -80,10 +80,7 @@ namespace Microsoft.Quantum.Tests {
         body (...) {
             let (eigenvalues, prob, inverseAngle, statePreparation, selector) = LCUTestHelper();
             let LCU = QuantumWalkByQubitization(BlockEncodingReflectionByLCU(statePreparation, selector));
-            using(qubits = Qubit[4]){
-                let auxiliary = qubits[2..3];
-                let system = [qubits[0]];
-                let flag = qubits[1];
+            using ((system, flag, auxiliary) = (Qubit[1], Qubit(), Qubit[2])) {
 
                 for(rep in 0..5){
                     LCU(auxiliary, system);
@@ -95,7 +92,9 @@ namespace Microsoft.Quantum.Tests {
                         Exp([PauliY],1.0 * inverseAngle, system);
                         AssertProb([PauliZ], system, Zero, 1.0, "Error1: Z Success probability does not match theory", 1e-10);
                     }
-                    ResetAll(qubits);
+                    ResetAll(system);
+                    Reset(flag);
+                    ResetAll(auxiliary);
                 }
             }
         }

--- a/Standard/tests/QubitizationTests.qs
+++ b/Standard/tests/QubitizationTests.qs
@@ -136,7 +136,7 @@ namespace Microsoft.Quantum.Tests {
     }
 
     // Array.qs tests
-    function IntArrayFromRangeTest() : Unit {
+    function RangeAsIntArrayTest() : Unit {
         mutable testCases = new (Int[], Range)[4];
         let e = new Int[0];
         set testCases[0] = ([1, 3, 5, 7], 1..2..8);
@@ -145,7 +145,7 @@ namespace Microsoft.Quantum.Tests {
         set testCases[3] = ([0], 0..4..3);
         for (idxTest in 0..Length(testCases) - 1) {
             let (expected, range) = testCases[idxTest];
-            let output = IntArrayFromRange(range);
+            let output = RangeAsIntArray(range);
             Ignore(Mapped(EqualityFactI(_, _, "Padded failed."), Zip(output, expected)));
         }
     }

--- a/Standard/tests/QubitizationTests.qs
+++ b/Standard/tests/QubitizationTests.qs
@@ -4,7 +4,7 @@
 namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Simulation;
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Testing;
     open Microsoft.Quantum.Extensions.Math;

--- a/Standard/tests/QubitizationTests.qs
+++ b/Standard/tests/QubitizationTests.qs
@@ -11,6 +11,7 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Convert;
 
     // BlockEncoding.qs tests
 

--- a/Standard/tests/RandomTests.qs
+++ b/Standard/tests/RandomTests.qs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Math;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     
     

--- a/Standard/tests/Standard.Tests.csproj
+++ b/Standard/tests/Standard.Tests.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.5.1903.2703" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.5.1903.2703" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1904.1008-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.6.1904.1008-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/Standard/tests/StatePreparationTests.qs
+++ b/Standard/tests/StatePreparationTests.qs
@@ -3,7 +3,7 @@
 namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Preparation;
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Extensions.Math;

--- a/Standard/tests/StatePreparationTests.qs
+++ b/Standard/tests/StatePreparationTests.qs
@@ -102,7 +102,7 @@ namespace Microsoft.Quantum.Tests {
                     set coefficientsPositive[idxCoeff] = coefficientsAmplitude[idxCoeff];
                 }
                 
-                let normalizedCoefficients = PNormalize(2.0, coefficientsAmplitude);
+                let normalizedCoefficients = PNormalized(2.0, coefficientsAmplitude);
                 
                 // Test phase factor on uniform superposition
                 let phase = 0.5 * (coefficientsPhase[0] - coefficientsPhase[1]);
@@ -154,7 +154,7 @@ namespace Microsoft.Quantum.Tests {
                     set coefficientsPositive[idxCoeff] = coefficientsAmplitude[idxCoeff];
                 }
                 
-                let normalizedCoefficients = PNormalize(2.0, coefficientsAmplitude);
+                let normalizedCoefficients = PNormalized(2.0, coefficientsAmplitude);
                 
                 // Test probability and phases of uniform superposition
                 let op = StatePreparationComplexCoefficients(coefficients);
@@ -226,7 +226,7 @@ namespace Microsoft.Quantum.Tests {
                     set coefficientsPositive[idxCoeff] = coefficientsAmplitude[idxCoeff];
                 }
                 
-                let normalizedCoefficients = PNormalize(2.0, coefficientsAmplitude);
+                let normalizedCoefficients = PNormalized(2.0, coefficientsAmplitude);
                 
                 // Test probability and phases of arbitrary superposition
                 let opComplex = StatePreparationComplexCoefficients(coefficients);

--- a/Standard/tests/TypeConversionTests.qs
+++ b/Standard/tests/TypeConversionTests.qs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Tests {
-    open Microsoft.Quantum.Primitive;
+    open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Convert;
     open Microsoft.Quantum.Diagnostics;


### PR DESCRIPTION
This PR updates library and test code to use 0.6 names and syntax in order to reduce the number of warnings generated during builds.