### PR TITLE
Explicitly qualify all names in M.Q.Ext.Math.

### DIFF
--- a/Chemistry/src/DataModel/DataModel.csproj
+++ b/Chemistry/src/DataModel/DataModel.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.5.1903.2703" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1904.1010-beta" />
     <PackageReference Include="xunit.abstractions" Version="2.0.1" />
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />
     <PackageReference Include="YamlDotNet" Version="5.0.1" />

--- a/Chemistry/src/Runtime/JordanWigner/Convenience.qs
+++ b/Chemistry/src/Runtime/JordanWigner/Convenience.qs
@@ -6,7 +6,6 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Convert;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Chemistry;
     open Microsoft.Quantum.Math;
     
@@ -48,7 +47,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
         let (nTerms, genIdxFunction) = generatorSystem!;
         let (oneNorm, blockEncodingReflection) = PauliBlockEncoding(generatorSystem);
         let nTargetRegisterQubits = nSpinOrbitals;
-        let nCtrlRegisterQubits = Ceiling(Lg(ToDouble(nTerms)));
+        let nCtrlRegisterQubits = Microsoft.Quantum.Extensions.Math.Ceiling(Lg(ToDouble(nTerms)));
         return ((nCtrlRegisterQubits, nTargetRegisterQubits), (oneNorm, QuantumWalkByQubitization(blockEncodingReflection)));
     }
     

--- a/Chemistry/src/Runtime/JordanWigner/JordanWignerBlockEncoding.qs
+++ b/Chemistry/src/Runtime/JordanWigner/JordanWignerBlockEncoding.qs
@@ -5,7 +5,6 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Simulation;
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Chemistry;
     open Microsoft.Quantum.Arrays;
     

--- a/Chemistry/src/Runtime/JordanWigner/JordanWignerEvolutionSet.qs
+++ b/Chemistry/src/Runtime/JordanWigner/JordanWignerEvolutionSet.qs
@@ -133,7 +133,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
             }
             else {
                 
-                if (idxFermions[0] < qubitQidx && qubitQidx < idxFermions[3]) {
+                if (idxFermions[0] < qubitQidx and qubitQidx < idxFermions[3]) {
                     let termPR1 = GeneratorIndex((idxTermType, [1.0]), [idxFermions[0], idxFermions[3] - 1]);
                     _ApplyJordanWignerPQTerm_(termPR1, angle, new Qubit[0], Exclude([qubitQidx], qubits));
                 }

--- a/Chemistry/src/Runtime/JordanWigner/JordanWignerEvolutionSet.qs
+++ b/Chemistry/src/Runtime/JordanWigner/JordanWignerEvolutionSet.qs
@@ -5,7 +5,6 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Simulation;
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Chemistry;
     open Microsoft.Quantum.Arrays;
 

--- a/Chemistry/src/Runtime/JordanWigner/JordanWignerOptimizedBlockEncoding.qs
+++ b/Chemistry/src/Runtime/JordanWigner/JordanWignerOptimizedBlockEncoding.qs
@@ -8,7 +8,6 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Convert;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Chemistry;
     open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Math;
@@ -261,7 +260,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
         mutable oneNorm = 0.0;
         
         for (idx in 0 .. finalIdx - 1) {
-            set oneNorm = oneNorm + AbsD(_GetOptimizedBETermIndexCoeff_(majIdxes[idx]));
+            set oneNorm = oneNorm + Microsoft.Quantum.Extensions.Math.AbsD(_GetOptimizedBETermIndexCoeff_(majIdxes[idx]));
         }
         
         return OptimizedBEGeneratorSystem(finalIdx, oneNorm, LookupFunction(majIdxes[0 .. finalIdx - 1]));
@@ -441,7 +440,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
         let nMaj = 4;
         let optimizedBEGeneratorSystem = OptimizedBlockEncodingGeneratorSystem(data);
         let (nCoeffs, oneNorm, tmp) = optimizedBEGeneratorSystem!;
-        let nIdxRegQubits = Ceiling(Lg(ToDouble(nSpinOrbitals)));
+        let nIdxRegQubits = Microsoft.Quantum.Extensions.Math.Ceiling(Lg(ToDouble(nSpinOrbitals)));
         let ((nCtrlRegisterQubits, nTargetRegisterQubits), rest) = _JordanWignerOptimizedBlockEncodingQubitCount_(targetError, nCoeffs, nZ, nMaj, nIdxRegQubits, nSpinOrbitals);
         let statePrepOp = _JordanWignerOptimizedBlockEncodingStatePrep_(targetError, nCoeffs, optimizedBEGeneratorSystem, nZ, nMaj, nIdxRegQubits, _);
         let selectOp = _JordanWignerOptimizedBlockEncodingSelect_(targetError, nCoeffs, optimizedBEGeneratorSystem, nZ, nMaj, nIdxRegQubits, _, _);

--- a/Chemistry/src/Runtime/JordanWigner/StatePreparation.qs
+++ b/Chemistry/src/Runtime/JordanWigner/StatePreparation.qs
@@ -6,7 +6,6 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Math;
@@ -78,12 +77,12 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
         
         for (idx in 0 .. nExcitations - 1) {
             let (x, excitation) = excitations[idx]!;
-            set coefficientsSqrtAbs[idx] = Sqrt(AbsComplexPolar(ComplexToComplexPolar(Complex(x))));
-            set coefficientsNewComplexPolar[idx] = ComplexPolar(coefficientsSqrtAbs[idx], ArgComplexPolar(ComplexToComplexPolar(Complex(x))));
+            set coefficientsSqrtAbs[idx] = Microsoft.Quantum.Extensions.Math.Sqrt(AbsComplexPolar(ComplexToComplexPolar(Microsoft.Quantum.Extensions.Math.Complex(x))));
+            set coefficientsNewComplexPolar[idx] = ComplexPolar(coefficientsSqrtAbs[idx], ArgComplexPolar(ComplexToComplexPolar(Microsoft.Quantum.Extensions.Math.Complex(x))));
             set applyFlips[idx] = excitation;
         }
         
-        let nBitsIndices = Ceiling(Lg(ToDouble(nExcitations)));
+        let nBitsIndices = Microsoft.Quantum.Extensions.Math.Ceiling(Lg(ToDouble(nExcitations)));
         
         repeat {
             mutable success = false;

--- a/Chemistry/src/Runtime/JordanWigner/Utils.qs
+++ b/Chemistry/src/Runtime/JordanWigner/Utils.qs
@@ -4,7 +4,6 @@
 namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Chemistry;
     
     

--- a/Chemistry/src/Runtime/Runtime.csproj
+++ b/Chemistry/src/Runtime/Runtime.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.5.1903.2703" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1904.1010-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chemistry/src/Runtime/Utils.qs
+++ b/Chemistry/src/Runtime/Utils.qs
@@ -5,7 +5,6 @@ namespace Microsoft.Quantum.Chemistry {
     open Microsoft.Quantum.Simulation;
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Extensions.Math;
     
     
     /// # Summary
@@ -81,13 +80,7 @@ namespace Microsoft.Quantum.Chemistry {
     /// # Output
     /// Returns true if `number` has an absolute value greater than `1e-15`.
     function IsNotZero (number : Double) : Bool {
-        
-        if (AbsD(number) > PowD(10.0, -15.0)) {
-            return true;
-        }
-        else {
-            return false;
-        }
+        return (Microsoft.Quantum.Extensions.Math.AbsD(number) > Microsoft.Quantum.Extensions.Math.PowD(10.0, -15.0));
     }
     
 }

--- a/Chemistry/tests/ChemistryTests/ChemistryTests.csproj
+++ b/Chemistry/tests/ChemistryTests/ChemistryTests.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.5.1903.2703" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.5.1903.2703" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1904.1010-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.6.1904.1010-beta" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/Chemistry/tests/ChemistryTests/InitialStatePrepTests.qs
+++ b/Chemistry/tests/ChemistryTests/InitialStatePrepTests.qs
@@ -6,7 +6,6 @@ namespace Microsoft.Quantum.Chemistry.Tests {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Testing;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Chemistry.JordanWigner;
     open Microsoft.Quantum.Arrays;
@@ -22,7 +21,7 @@ namespace Microsoft.Quantum.Chemistry.Tests {
             PrepareTrialStateCoupledCluster(NoOp<Qubit[]>, excitations, qubits);
             
             for (idx in 0 .. Length(excitations) - 1) {
-                AssertProbIntBE(intTest[idx], AbsD(1.0), BigEndian(Reversed(qubits)), 1E-05);
+                AssertProbIntBE(intTest[idx], Microsoft.Quantum.Extensions.Math.AbsD(1.0), BigEndian(Reversed(qubits)), 1E-05);
             }
             
             ResetAll(qubits);
@@ -77,7 +76,23 @@ namespace Microsoft.Quantum.Chemistry.Tests {
         let intTest = [39, 21, 10];
         let expectedProb = [0.047619, 0.190476, 0.761905];
         let p = [0.3, 0.9, 2.4];
-        let excitations = [JordanWignerInputState((0.1 * Cos(p[0]), 0.1 * Sin(p[0])), [0, 1, 2, 5]), JordanWignerInputState((0.2 * Cos(p[1]), 0.2 * Sin(p[1])), [0, 2, 4]), JordanWignerInputState((0.4 * Cos(p[2]), 0.4 * Sin(p[2])), [3, 1])];
+        let excitations = [
+            JordanWignerInputState(
+                (0.1 * Microsoft.Quantum.Extensions.Math.Cos(p[0]),
+                0.1 * Microsoft.Quantum.Extensions.Math.Sin(p[0])),
+                [0, 1, 2, 5]
+            ),
+            
+            JordanWignerInputState(
+                (0.2 * Microsoft.Quantum.Extensions.Math.Cos(p[1]),
+                0.2 * Microsoft.Quantum.Extensions.Math.Sin(p[1])),
+                [0, 2, 4]
+            ),
+            
+            JordanWignerInputState(
+                (0.4 * Microsoft.Quantum.Extensions.Math.Cos(p[2]), 0.4 * Microsoft.Quantum.Extensions.Math.Sin(p[2])),
+                [3, 1]
+            )];
         
         using (qubits = Qubit[nQubits]) {
             PrepareTrialStateCoupledCluster(NoOp<Qubit[]>, excitations, qubits);
@@ -97,7 +112,7 @@ namespace Microsoft.Quantum.Chemistry.Tests {
         let nQubits = 1;
         let intTest = [39, 21, 10];
         let phase = 2.453;
-        let excitations = [JordanWignerInputState((0.1, 0.0), new Int[0]), JordanWignerInputState((0.1 * Cos(phase), 0.1 * Sin(phase)), [0])];
+        let excitations = [JordanWignerInputState((0.1, 0.0), new Int[0]), JordanWignerInputState((0.1 * Microsoft.Quantum.Extensions.Math.Cos(phase), 0.1 * Microsoft.Quantum.Extensions.Math.Sin(phase)), [0])];
         
         using (qubits = Qubit[nQubits]) {
             PrepareTrialStateCoupledCluster(NoOp<Qubit[]>, excitations, qubits);

--- a/Chemistry/tests/ChemistryTests/MajoranaOperatorTests.qs
+++ b/Chemistry/tests/ChemistryTests/MajoranaOperatorTests.qs
@@ -6,7 +6,6 @@ namespace Microsoft.Quantum.Chemistry.Tests {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Testing;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Chemistry.JordanWigner;
     open Microsoft.Quantum.Math;
@@ -14,7 +13,7 @@ namespace Microsoft.Quantum.Chemistry.Tests {
 
     // Test OptimizedBEXY operator.
     operation OptimizedBEOperatorZeroTestHelper (pauliBasis : Pauli, targetRegisterSize : Int, targetIndex : Int) : Unit {
-        let indexRegisterSize = Ceiling(Lg(ToDouble(targetRegisterSize)));
+        let indexRegisterSize = Microsoft.Quantum.Extensions.Math.Ceiling(Lg(ToDouble(targetRegisterSize)));
         using (pauliBasisQubit = Qubit[1]) {
             using (indexRegister = Qubit[indexRegisterSize]) {
                 using (targetRegister = Qubit[targetRegisterSize]) {
@@ -85,15 +84,15 @@ namespace Microsoft.Quantum.Chemistry.Tests {
     // Test OptimizedBEXY operator.
     operation OptimizedBEOperatorPlusTestHelper (pauliBasis : Pauli, targetRegisterSize : Int, targetIndex : Int) : Unit {
         
-        let indexRegisterSize = Ceiling(Lg(ToDouble(targetRegisterSize)));
-        using(pauliBasisQubit = Qubit[1]){
-            using(indexRegister = Qubit[indexRegisterSize]){
-                using(targetRegister = Qubit[targetRegisterSize]){            
+        let indexRegisterSize = Microsoft.Quantum.Extensions.Math.Ceiling(Lg(ToDouble(targetRegisterSize)));
+        using (pauliBasisQubit = Qubit[1]) {
+            using (indexRegister = Qubit[indexRegisterSize]) {
+                using (targetRegister = Qubit[targetRegisterSize]) { 
                     // Choose X or Y operator.
-                    if(pauliBasis == PauliX){
+                    if(pauliBasis == PauliX) {
                         // no op
                     }
-                    elif(pauliBasis == PauliY){
+                    elif(pauliBasis == PauliY) {
                         X(pauliBasisQubit[0]);
                     }
 
@@ -191,7 +190,7 @@ namespace Microsoft.Quantum.Chemistry.Tests {
     // Test phase of controlled OptimizedBEXY operator.
     operation ControlledOptimizedBEOperatorTestHelper (pauliBasis : Pauli, targetRegisterSize : Int, targetIndex : Int) : Unit {
         
-        let indexRegisterSize = Ceiling(Lg(ToDouble(targetRegisterSize)));
+        let indexRegisterSize = Microsoft.Quantum.Extensions.Math.Ceiling(Lg(ToDouble(targetRegisterSize)));
         
         using (pauliBasisQubit = Qubit[1]) {
             
@@ -261,7 +260,7 @@ namespace Microsoft.Quantum.Chemistry.Tests {
     operation SelectZTest () : Unit {
         
         let targetRegisterSize = 7;
-        let indexRegisterSize = Ceiling(Lg(ToDouble(targetRegisterSize)));
+        let indexRegisterSize = Microsoft.Quantum.Extensions.Math.Ceiling(Lg(ToDouble(targetRegisterSize)));
         
         using (targetRegister = Qubit[targetRegisterSize]) {
             

--- a/Chemistry/tests/DataModelTests/DataModelTests.csproj
+++ b/Chemistry/tests/DataModelTests/DataModelTests.csproj
@@ -14,8 +14,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.5.1903.2703" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.5.1903.2703" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1904.1010-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.6.1904.1010-beta" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/Chemistry/tests/SystemTests/SystemTest.qs
+++ b/Chemistry/tests/SystemTests/SystemTest.qs
@@ -5,7 +5,6 @@ namespace SystemTests {
     open Microsoft.Quantum.Simulation;
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Chemistry.JordanWigner;    
     
     // Test phase of PP term.
@@ -42,7 +41,7 @@ namespace SystemTests {
     operation PQTermABFromGeneralHamiltonianTestOp (data : JWOptimizedHTerms) : Unit {
         
         // Test probability
-        let time = 0.5 * PI();
+        let time = 0.5 * Microsoft.Quantum.Extensions.Math.PI();
         mutable arrPrep = new Int[4];
         set arrPrep = [0, 1, 2, 3];
         mutable arrMeasure = new Int[4];
@@ -75,7 +74,7 @@ namespace SystemTests {
             CNOT(ctrl, qubitsC[0]);
             CNOT(ctrl, qubitsC[1]);
             AssertProb([PauliZ], [qubitsC[arrMeasure[0]]], One, 0.0, "PQTermTest probability failed.", 1E-10);
-            AssertPhase(-0.25 * PI(), ctrl, 1E-10);
+            AssertPhase(-0.25 * Microsoft.Quantum.Extensions.Math.PI(), ctrl, 1E-10);
             ResetAll(qubitsC);
         }
     }
@@ -85,7 +84,7 @@ namespace SystemTests {
     operation PQTermACFromGeneralHamiltonianTestOp (data : JWOptimizedHTerms) : Unit {
         
         // Test probability
-        let time = 0.5 * PI();
+        let time = 0.5 * Microsoft.Quantum.Extensions.Math.PI();
         mutable arrPrep = new Int[4];
         set arrPrep = [0, 2, 3, 5];
         mutable arrMeasure = new Int[4];
@@ -118,7 +117,7 @@ namespace SystemTests {
             CNOT(ctrl, qubitsC[0]);
             CNOT(ctrl, qubitsC[2]);
             AssertProb([PauliZ], [qubitsC[arrMeasure[0]]], One, 0.0, "PQTermTest probability failed.", 1E-10);
-            AssertPhase(-0.25 * PI(), ctrl, 1E-10);
+            AssertPhase(-0.25 * Microsoft.Quantum.Extensions.Math.PI(), ctrl, 1E-10);
             ResetAll(qubitsC);
             H(ctrl);
             X(qubitsC[arrPrep[0]]);
@@ -132,7 +131,7 @@ namespace SystemTests {
             CNOT(ctrl, qubitsC[0]);
             CNOT(ctrl, qubitsC[2]);
             AssertProb([PauliZ], [qubitsC[arrMeasure[0]]], One, 0.0, "PQTermTest probability failed.", 1E-10);
-            AssertPhase(0.25 * PI(), ctrl, 1E-10);
+            AssertPhase(0.25 * Microsoft.Quantum.Extensions.Math.PI(), ctrl, 1E-10);
             ResetAll(qubitsC);
         }
     }
@@ -189,7 +188,7 @@ namespace SystemTests {
     operation PQQRTermFromGeneralHamiltonianTestOp (data : JWOptimizedHTerms) : Unit {
         
         // Test probability
-        mutable time = (4.0 * 0.5) * PI();
+        mutable time = (4.0 * 0.5) * Microsoft.Quantum.Extensions.Math.PI();
         mutable arrPrep = new Int[4];
         set arrPrep = [0, 2, 1, 3];
         mutable arrMeasure = new Int[4];
@@ -206,7 +205,7 @@ namespace SystemTests {
             }
             
             // Create |1100>
-            set time = PI();
+            set time = Microsoft.Quantum.Extensions.Math.PI();
             X(qubits[arrPrep[0]]);
             X(qubits[1]);
             JordanWignerApplyTrotterStep(data, time, 0.01 * time, qubits);
@@ -214,7 +213,7 @@ namespace SystemTests {
             ResetAll(qubits);
             
             // Create |1001>
-            set time = PI();
+            set time = Microsoft.Quantum.Extensions.Math.PI();
             X(qubits[arrPrep[0]]);
             X(qubits[3]);
             JordanWignerApplyTrotterStep(data, time, 0.01 * time, qubits);
@@ -228,7 +227,7 @@ namespace SystemTests {
         
         // Test probability
         mutable time = 1.0;
-        mutable prob = Sin(time) * Sin(time);
+        mutable prob = Microsoft.Quantum.Extensions.Math.Sin(time) * Microsoft.Quantum.Extensions.Math.Sin(time);
         
         using (qubits = Qubit[4]) {
             
@@ -277,7 +276,7 @@ namespace SystemTests {
     operation PQTermABFromLiquidOrbitalTestOp (data : JWOptimizedHTerms) : Unit {
         
         // Test probability
-        let time = 0.5 * PI();
+        let time = 0.5 * Microsoft.Quantum.Extensions.Math.PI();
         mutable arrPrep = new Int[4];
         set arrPrep = [0, 1, 2, 3];
         mutable arrMeasure = new Int[4];
@@ -310,7 +309,7 @@ namespace SystemTests {
             CNOT(ctrl, qubitsC[0]);
             CNOT(ctrl, qubitsC[1]);
             AssertProb([PauliZ], [qubitsC[arrMeasure[0]]], One, 0.0, "PQTermTest probability failed.", 1E-10);
-            AssertPhase(-0.25 * PI(), ctrl, 1E-10);
+            AssertPhase(-0.25 * Microsoft.Quantum.Extensions.Math.PI(), ctrl, 1E-10);
             ResetAll(qubitsC);
         }
     }
@@ -320,7 +319,7 @@ namespace SystemTests {
     operation PQTermACFromLiquidOrbitalTestOp (data : JWOptimizedHTerms) : Unit {
         
         // Test probability
-        let time = 0.5 * PI();
+        let time = 0.5 * Microsoft.Quantum.Extensions.Math.PI();
         mutable arrPrep = new Int[4];
         set arrPrep = [0, 2, 3, 5];
         mutable arrMeasure = new Int[4];
@@ -353,7 +352,7 @@ namespace SystemTests {
             CNOT(ctrl, qubitsC[0]);
             CNOT(ctrl, qubitsC[2]);
             AssertProb([PauliZ], [qubitsC[arrMeasure[0]]], One, 0.0, "PQTermTest probability failed.", 1E-10);
-            AssertPhase(-0.25 * PI(), ctrl, 1E-10);
+            AssertPhase(-0.25 * Microsoft.Quantum.Extensions.Math.PI(), ctrl, 1E-10);
             ResetAll(qubitsC);
             H(ctrl);
             X(qubitsC[arrPrep[0]]);
@@ -367,7 +366,7 @@ namespace SystemTests {
             CNOT(ctrl, qubitsC[0]);
             CNOT(ctrl, qubitsC[2]);
             AssertProb([PauliZ], [qubitsC[arrMeasure[0]]], One, 0.0, "PQTermTest probability failed.", 1E-10);
-            AssertPhase(0.25 * PI(), ctrl, 1E-10);
+            AssertPhase(0.25 * Microsoft.Quantum.Extensions.Math.PI(), ctrl, 1E-10);
             ResetAll(qubitsC);
         }
     }
@@ -424,7 +423,7 @@ namespace SystemTests {
     operation PQQRTermFromLiquidOrbitalTestOp (data : JWOptimizedHTerms) : Unit {
         
         // Test probability
-        mutable time = (4.0 * 0.5) * PI();
+        mutable time = (4.0 * 0.5) * Microsoft.Quantum.Extensions.Math.PI();
         mutable arrPrep = new Int[4];
         set arrPrep = [0, 1, 2, 3];
         mutable arrMeasure = new Int[4];
@@ -441,7 +440,7 @@ namespace SystemTests {
             }
             
             // Create |1010>
-            set time = (0.5 * PI()) / Sqrt(2.0);
+            set time = (0.5 * Microsoft.Quantum.Extensions.Math.PI()) / Microsoft.Quantum.Extensions.Math.Sqrt(2.0);
             X(qubits[arrPrep[0]]);
             X(qubits[2]);
             JordanWignerApplyTrotterStep(data, time, 0.01 * time, qubits);
@@ -449,7 +448,7 @@ namespace SystemTests {
             ResetAll(qubits);
             
             // Create |1001>
-            set time = (0.5 * PI()) / Sqrt(2.0);
+            set time = (0.5 * Microsoft.Quantum.Extensions.Math.PI()) / Microsoft.Quantum.Extensions.Math.Sqrt(2.0);
             X(qubits[arrPrep[0]]);
             X(qubits[3]);
             JordanWignerApplyTrotterStep(data, time, 0.01 * time, qubits);
@@ -463,7 +462,7 @@ namespace SystemTests {
         
         // Test probability
         mutable time = 1.0;
-        mutable prob = Sin(time) * Sin(time);
+        mutable prob = Microsoft.Quantum.Extensions.Math.Sin(time) * Microsoft.Quantum.Extensions.Math.Sin(time);
         
         using (qubits = Qubit[4]) {
             

--- a/Chemistry/tests/SystemTests/SystemTestBlockEncoding.qs
+++ b/Chemistry/tests/SystemTests/SystemTestBlockEncoding.qs
@@ -6,7 +6,6 @@ namespace SystemTestsBlockEncoding {
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Chemistry.JordanWigner;   
     
@@ -22,7 +21,7 @@ namespace SystemTestsBlockEncoding {
         let (l1Norm, blockEncodingReflection) = PauliBlockEncoding(generatorSystem);
         let (nTerms, genIdxFunction) = generatorSystem!;
         let systemQubits = nSpinOrbitals;
-        let auxillaryQubits = Ceiling(Lg(ToDouble(nTerms)));
+        let auxillaryQubits = Microsoft.Quantum.Extensions.Math.Ceiling(Lg(ToDouble(nTerms)));
         let nQubits = systemQubits + auxillaryQubits;
         
         using (qubits = Qubit[nQubits]) {

--- a/Chemistry/tests/SystemTests/SystemTestOptimizedBlockEncoding.qs
+++ b/Chemistry/tests/SystemTests/SystemTestOptimizedBlockEncoding.qs
@@ -5,7 +5,6 @@ namespace SystemTestsOptimizedBlockEncoding {
     
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Chemistry.JordanWigner;  
     

--- a/Chemistry/tests/SystemTests/SystemTests.csproj
+++ b/Chemistry/tests/SystemTests/SystemTests.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.5.1903.2703" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1904.1010-beta" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Standard/src/AmplitudeAmplification/AmplitudeAmplification.qs
+++ b/Standard/src/AmplitudeAmplification/AmplitudeAmplification.qs
@@ -4,7 +4,6 @@
 namespace Microsoft.Quantum.AmplitudeAmplification {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Extensions.Convert;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Oracles;
@@ -37,17 +36,17 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
         
         mutable phasesTarget = new Double[nPhasesRef];
         mutable phasesStart = new Double[nPhasesRef];
-        set phasesTarget[0] = ((rotPhases!)[0] - (rotPhases!)[1]) - PI();
-        set phasesStart[0] = -(rotPhases!)[0] + 0.5 * PI();
+        set phasesTarget[0] = ((rotPhases!)[0] - (rotPhases!)[1]) - Microsoft.Quantum.Extensions.Math.PI();
+        set phasesStart[0] = -(rotPhases!)[0] + 0.5 * Microsoft.Quantum.Extensions.Math.PI();
         
         for (idxPhases in 1 .. nPhasesRef - 2)
         {
-            set phasesTarget[idxPhases] = ((rotPhases!)[2 * idxPhases] - (rotPhases!)[2 * idxPhases + 1]) - PI();
-            set phasesStart[idxPhases] = ((rotPhases!)[2 * idxPhases - 1] - (rotPhases!)[2 * idxPhases]) + PI();
+            set phasesTarget[idxPhases] = ((rotPhases!)[2 * idxPhases] - (rotPhases!)[2 * idxPhases + 1]) - Microsoft.Quantum.Extensions.Math.PI();
+            set phasesStart[idxPhases] = ((rotPhases!)[2 * idxPhases - 1] - (rotPhases!)[2 * idxPhases]) + Microsoft.Quantum.Extensions.Math.PI();
         }
         
-        set phasesTarget[nPhasesRef - 1] = (rotPhases!)[2 * nPhasesRef - 2] - 0.5 * PI();
-        set phasesStart[nPhasesRef - 1] = ((rotPhases!)[2 * nPhasesRef - 3] - (rotPhases!)[2 * nPhasesRef - 2]) + PI();
+        set phasesTarget[nPhasesRef - 1] = (rotPhases!)[2 * nPhasesRef - 2] - 0.5 * Microsoft.Quantum.Extensions.Math.PI();
+        set phasesStart[nPhasesRef - 1] = ((rotPhases!)[2 * nPhasesRef - 3] - (rotPhases!)[2 * nPhasesRef - 2]) + Microsoft.Quantum.Extensions.Math.PI();
         return ReflectionPhases(phasesStart, phasesTarget);
     }
     
@@ -74,8 +73,8 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
         
         for (idxPhases in 0 .. nIterations)
         {
-            set phasesTarget[idxPhases] = PI();
-            set phasesStart[idxPhases] = PI();
+            set phasesTarget[idxPhases] = Microsoft.Quantum.Extensions.Math.PI();
+            set phasesStart[idxPhases] = Microsoft.Quantum.Extensions.Math.PI();
         }
         
         set phasesTarget[nIterations] = 0.0;
@@ -116,11 +115,11 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
         mutable phasesRot = new Double[nQueries];
         let nQueriesDouble = ToDouble(nQueries);
         set phasesRot[0] = 0.0;
-        let beta = Cosh((1.0 / nQueriesDouble) * ArcCosh(Sqrt(successMin)));
+        let beta = Microsoft.Quantum.Extensions.Math.Cosh((1.0 / nQueriesDouble) * ArcCosh(Microsoft.Quantum.Extensions.Math.Sqrt(successMin)));
         
         for (idxPhases in 1 .. nQueries - 1)
         {
-            set phasesRot[idxPhases] = phasesRot[idxPhases - 1] + 2.0 * ArcTan(Tan((((2.0 * 1.0) * ToDouble(idxPhases)) * PI()) / nQueriesDouble) * Sqrt(1.0 - beta * beta));
+            set phasesRot[idxPhases] = phasesRot[idxPhases - 1] + 2.0 * Microsoft.Quantum.Extensions.Math.ArcTan(Microsoft.Quantum.Extensions.Math.Tan((((2.0 * 1.0) * ToDouble(idxPhases)) * Microsoft.Quantum.Extensions.Math.PI()) / nQueriesDouble) * Microsoft.Quantum.Extensions.Math.Sqrt(1.0 - beta * beta));
         }
         
         return AmpAmpRotationToReflectionPhases(RotationPhases(phasesRot));
@@ -150,7 +149,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     /// particular ancilla target state $\ket{\text{target}}\_a$, and any
     /// system state $\ket{\psi}\_s$, suppose that
     /// \begin{align}
-    /// O\ket{\text{start}}\_a\ket{\psi}\_s= \lambda\ket{\text{target}}\_a U \ket{\psi}\_s + \sqrt{1-|\lambda|^2}\ket{\text{target}^\perp}\_a\cdots
+    /// O\ket{\text{start}}\_a\ket{\psi}\_s= \lambda\ket{\text{target}}\_a U \ket{\psi}\_s + \Microsoft.Quantum.Extensions.Math.sqrt{1-|\lambda|^2}\ket{\text{target}^\perp}\_a\cdots
     /// \end{align}
     /// for some unitary $U$.
     /// By a sequence of reflections about the start and target states on the
@@ -241,7 +240,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     /// It is assumed that the target state is marked by $\ket{1}\_f$.
     /// It is assumed that
     /// \begin{align}
-    /// O\ket{\text{start}}\_{fa}\ket{\psi}\_s= \lambda\ket{1}\_f\ket{\text{anything}}\_a\ket{\text{target}}\_s U \ket{\psi}\_s + \sqrt{1-|\lambda|^2}\ket{0}\_f\cdots,
+    /// O\ket{\text{start}}\_{fa}\ket{\psi}\_s= \lambda\ket{1}\_f\ket{\text{anything}}\_a\ket{\text{target}}\_s U \ket{\psi}\_s + \Microsoft.Quantum.Extensions.Math.sqrt{1-|\lambda|^2}\ket{0}\_f\cdots,
     /// \end{align}
     /// for some unitary $U$.
     function AmpAmpObliviousByOraclePhases (phases : ReflectionPhases, ancillaOracle : DeterministicStateOracle, signalOracle : ObliviousOracle, idxFlagQubit : Int) : ((Qubit[], Qubit[]) => Unit : Adjoint, Controlled)
@@ -303,7 +302,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     /// It is assumed that the target state is marked by $\ket{1}\_f$.
     /// It is assumed that
     /// \begin{align}
-    /// A\ket{0}\_{f}\ket{0}\_s= \lambda\ket{1}\_f\ket{\text{target}}\_s + \sqrt{1-|\lambda|^2}\ket{0}\_f\cdots,
+    /// A\ket{0}\_{f}\ket{0}\_s= \lambda\ket{1}\_f\ket{\text{target}}\_s + \Microsoft.Quantum.Extensions.Math.sqrt{1-|\lambda|^2}\ket{0}\_f\cdots,
     /// \end{align}
     /// In most cases, `flagQubit` and `ancillaRegister` is initialized in the state $\ket{0}\_{f}\ket{0}\_s$.
     function AmpAmpByOraclePhases (phases : ReflectionPhases, stateOracle : StateOracle, idxFlagQubit : Int) : (Qubit[] => Unit : Adjoint, Controlled)
@@ -335,7 +334,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     /// This is the standard amplitude amplification algorithm obtained by a choice of reflection phases computed by `AmpAmpPhasesStandard`
     /// Assuming that
     /// \begin{align}
-    /// A\ket{0}\_{f}\ket{0}\_s= \lambda\ket{1}\_f\ket{\text{target}}\_s + \sqrt{1-|\lambda|^2}\ket{0}\_f\cdots,
+    /// A\ket{0}\_{f}\ket{0}\_s= \lambda\ket{1}\_f\ket{\text{target}}\_s + \Microsoft.Quantum.Extensions.Math.sqrt{1-|\lambda|^2}\ket{0}\_f\cdots,
     /// \end{align}
     /// this operation prepares the state
     /// \begin{align}
@@ -373,7 +372,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
         mutable exponentMax = 0;
         mutable exponentCurrent = 0;
         
-        //Complexity: Let \theta = \mathcal{O}(\sqrt{lambda})
+        //Complexity: Let \theta = \mathcal{O}(\Microsoft.Quantum.Extensions.Math.sqrt{lambda})
         // Number of Measurements = O( Log^2(1/\theta) )
         // Number of Queries = O(1/\theta)
         using (flagQubit = Qubit[1])

--- a/Standard/src/Arrays/Arrays.qs
+++ b/Standard/src/Arrays/Arrays.qs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arrays {
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Diagnostics;
 
     /// # Summary
@@ -236,7 +235,7 @@ namespace Microsoft.Quantum.Arrays {
     /// ```
     function Padded<'T> (nElementsTotal : Int, defaultElement : 'T, inputArray : 'T[]) : 'T[] {
         let nElementsInitial = Length(inputArray);
-        let nAbsElementsTotal = AbsI(nElementsTotal);
+        let nAbsElementsTotal = Microsoft.Quantum.Extensions.Math.AbsI(nElementsTotal);
         EqualityFactB(nAbsElementsTotal >= nElementsInitial, true, $"Specified output array length must be longer than `inputArray` length.");
         let nElementsPad = nAbsElementsTotal - nElementsInitial;
         let padArray = ConstantArray(nElementsPad, defaultElement);

--- a/Standard/src/Arrays/Zip.qs
+++ b/Standard/src/Arrays/Zip.qs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arrays {
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Math;
 
     /// # Summary

--- a/Standard/src/Canon/Enumeration/Trotter.qs
+++ b/Standard/src/Canon/Enumeration/Trotter.qs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace Microsoft.Quantum.Canon
-{
-    open Microsoft.Quantum.Extensions.Math;
+namespace Microsoft.Quantum.Canon {
     open Microsoft.Quantum.Extensions.Convert;
 
     /// # Summary
@@ -154,7 +152,7 @@ namespace Microsoft.Quantum.Canon
     /// Computes Trotter step size in recursive implementation of
     /// Trotter simulation algorithm.
     function _TrotterStepSize (order: Int) : Double {
-        return 1.0 / (4.0 - PowD(4.0, 1.0 / (2.0 * ToDouble(order) - 1.0)));
+        return 1.0 / (4.0 - Microsoft.Quantum.Extensions.Math.PowD(4.0, 1.0 / (2.0 * ToDouble(order) - 1.0)));
     }
     
     

--- a/Standard/src/Canon/Multiplexer.qs
+++ b/Standard/src/Canon/Multiplexer.qs
@@ -62,8 +62,8 @@ namespace Microsoft.Quantum.Canon {
             
             let (nUnitaries, unitaryOffset, unitaryFunction) = unitaryGenerator;
 
-            let nUnitariesLeft = MinI(nUnitaries, nStates/2);
-            let nUnitariesRight = MinI(nUnitaries, nStates);
+            let nUnitariesLeft = Microsoft.Quantum.Extensions.Math.MinI(nUnitaries, nStates/2);
+            let nUnitariesRight = Microsoft.Quantum.Extensions.Math.MinI(nUnitaries, nStates);
 
             let leftUnitaries = (nUnitariesLeft, unitaryOffset, unitaryFunction);
             let rightUnitaries = (nUnitariesRight-nUnitariesLeft, unitaryOffset + nUnitariesLeft, unitaryFunction);
@@ -140,7 +140,7 @@ namespace Microsoft.Quantum.Canon {
             let nIndex = Length(index!);
             let nStates = 2^nIndex;
             let (nUnitaries, unitaryFunction) = unitaryGenerator;
-            for(idxOp in 0..MinI(nStates,nUnitaries)-1){
+            for(idxOp in 0..Microsoft.Quantum.Extensions.Math.MinI(nStates,nUnitaries)-1){
                 (ControlledOnInt(idxOp, unitaryFunction(idxOp)))(Reversed(index!),target);
             }
         }

--- a/Standard/src/Canon/Multiplexer.qs
+++ b/Standard/src/Canon/Multiplexer.qs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Quantum.Canon {
     open Microsoft.Quantum.Primitive;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Arrays;
 

--- a/Standard/src/Canon/Utils/Multiplexer.qs
+++ b/Standard/src/Canon/Utils/Multiplexer.qs
@@ -4,7 +4,6 @@
 namespace Microsoft.Quantum.Canon {
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Primitive;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Arrays;
     
     
@@ -279,8 +278,8 @@ namespace Microsoft.Quantum.Canon {
             let nIndex = Length(index!);
             let nStates = 2 ^ nIndex;
             let nUnitaries = Length(unitaries);
-            let nUnitariesRight = MinI(nUnitaries, nStates / 2);
-            let nUnitariesLeft = MinI(nUnitaries, nStates);
+            let nUnitariesRight = Microsoft.Quantum.Extensions.Math.MinI(nUnitaries, nStates / 2);
+            let nUnitariesLeft = Microsoft.Quantum.Extensions.Math.MinI(nUnitaries, nStates);
             let rightUnitaries = unitaries[0 .. nUnitariesRight - 1];
             let leftUnitaries = unitaries[nUnitariesRight .. nUnitariesLeft - 1];
             let newControls = BigEndian((index!)[1 .. nIndex - 1]);

--- a/Standard/src/Characterization/PhaseEstimation/Robust.qs
+++ b/Standard/src/Characterization/PhaseEstimation/Robust.qs
@@ -71,7 +71,7 @@ namespace Microsoft.Quantum.Characterization {
                 }
 
                 let deltaTheta = Microsoft.Quantum.Extensions.Math.ArcTan2(pPlus - ToDouble(nRepeats) / 2.0, pZero - ToDouble(nRepeats) / 2.0);
-                let delta = RealMod(deltaTheta - thetaEst * ToDouble(power), 2.0 * PI(), -PI());
+                let delta = RealMod(deltaTheta - thetaEst * ToDouble(power), 2.0 * Microsoft.Quantum.Extensions.Math.PI(), -Microsoft.Quantum.Extensions.Math.PI());
                 set thetaEst = thetaEst + delta / ToDouble(power);
             }
 

--- a/Standard/src/Characterization/PhaseEstimation/Robust.qs
+++ b/Standard/src/Characterization/PhaseEstimation/Robust.qs
@@ -4,7 +4,6 @@
 namespace Microsoft.Quantum.Characterization {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Extensions.Convert;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Oracles;
     open Microsoft.Quantum.Math;
 
@@ -42,7 +41,7 @@ namespace Microsoft.Quantum.Characterization {
 
             for (exponent in 0 .. bitsPrecision - 1) {
                 let power = 2 ^ exponent;
-                mutable nRepeats = Ceiling(alpha * ToDouble(bitsPrecision - exponent) + beta);
+                mutable nRepeats = Microsoft.Quantum.Extensions.Math.Ceiling(alpha * ToDouble(bitsPrecision - exponent) + beta);
 
                 if (nRepeats % 2 == 1) {
                     // Ensures that nRepeats is even.
@@ -55,7 +54,7 @@ namespace Microsoft.Quantum.Characterization {
                 for (idxRep in 0 .. nRepeats - 1) {
                     for (idxExperiment in 0 .. 1) {
                         // Divide rotation by power to cancel the multiplication by power in DiscretePhaseEstimationIteration
-                        let rotation = ((PI() * ToDouble(idxExperiment)) / 2.0) / ToDouble(power);
+                        let rotation = ((Microsoft.Quantum.Extensions.Math.PI() * ToDouble(idxExperiment)) / 2.0) / ToDouble(power);
                         DiscretePhaseEstimationIteration(oracle, power, rotation, targetState, controlQubit);
                         let result = M(controlQubit);
 
@@ -71,7 +70,7 @@ namespace Microsoft.Quantum.Characterization {
                     }
                 }
 
-                let deltaTheta = ArcTan2(pPlus - ToDouble(nRepeats) / 2.0, pZero - ToDouble(nRepeats) / 2.0);
+                let deltaTheta = Microsoft.Quantum.Extensions.Math.ArcTan2(pPlus - ToDouble(nRepeats) / 2.0, pZero - ToDouble(nRepeats) / 2.0);
                 let delta = RealMod(deltaTheta - thetaEst * ToDouble(power), 2.0 * PI(), -PI());
                 set thetaEst = thetaEst + delta / ToDouble(power);
             }

--- a/Standard/src/Characterization/ProcessTomography.qs
+++ b/Standard/src/Characterization/ProcessTomography.qs
@@ -5,7 +5,6 @@ namespace Microsoft.Quantum.Characterization {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Convert;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Preparation;
     open Microsoft.Quantum.Arrays;
 

--- a/Standard/src/Diagnostics/Quantum.qs
+++ b/Standard/src/Diagnostics/Quantum.qs
@@ -4,7 +4,6 @@
 namespace Microsoft.Quantum.Canon {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Extensions.Convert;
-    open Microsoft.Quantum.Extensions.Math;
 
     /// # Summary
 	/// Asserts that the phase of an equal superposition state has the expected value.
@@ -36,8 +35,8 @@ namespace Microsoft.Quantum.Canon {
     /// `qubit` is in state $\ket{\psi}=e^{-i 2.2}\sqrt{1/2}\ket{0}+e^{i 0.2}\sqrt{1/2}\ket{1}$;
     /// - `AssertPhase(-1.2,qubit,10e-10);`
     operation AssertPhase (expected : Double, qubit : Qubit, tolerance : Double) : Unit {
-        let exptectedProbX = Cos(expected) * Cos(expected);
-        let exptectedProbY = Sin(-1.0 * expected + PI() / 4.0) * Sin(-1.0 * expected + PI() / 4.0);
+        let exptectedProbX = Microsoft.Quantum.Extensions.Math.Cos(expected) * Microsoft.Quantum.Extensions.Math.Cos(expected);
+        let exptectedProbY = Microsoft.Quantum.Extensions.Math.Sin(-1.0 * expected + Microsoft.Quantum.Extensions.Math.PI() / 4.0) * Microsoft.Quantum.Extensions.Math.Sin(-1.0 * expected + Microsoft.Quantum.Extensions.Math.PI() / 4.0);
         AssertProb([PauliZ], [qubit], Zero, 0.5, $"AssertPhase failed. Was not given a uniform superposition.", tolerance);
         AssertProb([PauliY], [qubit], Zero, exptectedProbY, $"AssertPhase failed. PauliY Zero basis did not give probability {exptectedProbY}.", tolerance);
         AssertProb([PauliX], [qubit], Zero, exptectedProbX, $"AssertPhase failed. PauliX Zero basis did not give probability {exptectedProbX}.", tolerance);

--- a/Standard/src/ErrorCorrection/KnillDistill.qs
+++ b/Standard/src/ErrorCorrection/KnillDistill.qs
@@ -4,7 +4,6 @@
 namespace Microsoft.Quantum.ErrorCorrection {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Measurement;
 
 

--- a/Standard/src/Math/Complex.qs
+++ b/Standard/src/Math/Complex.qs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Math {
-    open Microsoft.Quantum.Extensions.Math;
 
     /// # Summary
 	/// Represents a complex number in polar form.
@@ -26,7 +25,7 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Output
     /// Squared absolute value $|c|^2 = x^2 + y^2$.
-    function AbsSquaredComplex (input : Complex) : Double {
+    function AbsSquaredComplex (input : Microsoft.Quantum.Extensions.Math.Complex) : Double {
         let (real, imaginary) = input!;
         return real * real + imaginary * imaginary;
     }
@@ -41,7 +40,7 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Output
     /// Absolute value $|c| = \sqrt{x^2 + y^2}$.
-    function AbsComplex (input : Complex) : Double {
+    function AbsComplex (input : Microsoft.Quantum.Extensions.Math.Complex) : Double {
         return Sqrt(AbsSquaredComplex(input));
     }
 
@@ -55,7 +54,7 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Output
     /// Phase $\text{Arg}[c] = \text{ArcTan}(y,x) \in (-\pi,\pi]$.
-    function ArgComplex (input : Complex) : Double {
+    function ArgComplex (input : Microsoft.Quantum.Extensions.Math.Complex) : Double {
         let (real, imaginary) = input!;
         return ArcTan2(imaginary, real);
     }
@@ -121,10 +120,10 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Output
     /// Complex number $c = x + i y$.
-    function ComplexPolarToComplex (input : ComplexPolar) : Complex
+    function ComplexPolarToComplex (input : ComplexPolar) : Microsoft.Quantum.Extensions.Math.Complex
     {
         let (abs, arg) = input!;
-        return Complex(abs * Cos(arg), abs * Sin(arg));
+        return Microsoft.Quantum.Extensions.Math.Complex(abs * Microsoft.Quantum.Extensions.Math.Cos(arg), abs * Microsoft.Quantum.Extensions.Math.Sin(arg));
     }
     
     
@@ -138,7 +137,7 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Output
     /// Complex number $c = r e^{i t}$.
-    function ComplexToComplexPolar (input : Complex) : ComplexPolar
+    function ComplexToComplexPolar (input : Microsoft.Quantum.Extensions.Math.Complex) : ComplexPolar
     {
         return ComplexPolar(AbsComplex(input), ArgComplex(input));
     }

--- a/Standard/src/Math/Complex.qs
+++ b/Standard/src/Math/Complex.qs
@@ -41,7 +41,7 @@ namespace Microsoft.Quantum.Math {
     /// # Output
     /// Absolute value $|c| = \sqrt{x^2 + y^2}$.
     function AbsComplex (input : Microsoft.Quantum.Extensions.Math.Complex) : Double {
-        return Sqrt(AbsSquaredComplex(input));
+        return Microsoft.Quantum.Extensions.Math.Sqrt(AbsSquaredComplex(input));
     }
 
     /// # Summary
@@ -56,7 +56,7 @@ namespace Microsoft.Quantum.Math {
     /// Phase $\text{Arg}[c] = \text{ArcTan}(y,x) \in (-\pi,\pi]$.
     function ArgComplex (input : Microsoft.Quantum.Extensions.Math.Complex) : Double {
         let (real, imaginary) = input!;
-        return ArcTan2(imaginary, real);
+        return Microsoft.Quantum.Extensions.Math.ArcTan2(imaginary, real);
     }
 
     /// # Summary

--- a/Standard/src/Math/Deprecated.qs
+++ b/Standard/src/Math/Deprecated.qs
@@ -3,20 +3,19 @@
 
 namespace Microsoft.Quantum.Canon {
     open Microsoft.Quantum.Math;
-    open Microsoft.Quantum.Extensions.Math;
 
     /// # Deprecated
     /// This function has been removed.
     function IntAbs(input : Int) : Int {
         // TODO: add call to _Removed.
-        return AbsI(input);
+        return Microsoft.Quantum.Extensions.Math.AbsI(input);
     }
 
     /// # Deprecated
     /// This function has been removed.
     function IntMax(a : Int, b : Int) : Int {
         // TODO: add call to _Removed.
-        return MaxI(a, b);
+        return Microsoft.Quantum.Extensions.Math.MaxI(a, b);
     }
 
     /// # Deprecated

--- a/Standard/src/Math/Functions.qs
+++ b/Standard/src/Math/Functions.qs
@@ -4,7 +4,6 @@
 namespace Microsoft.Quantum.Math {
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Convert;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Diagnostics;
 
     /// # Summary
@@ -23,7 +22,7 @@ namespace Microsoft.Quantum.Math {
     /// # Output
     /// The base-2 logarithm $y = \log_2(x)$ such that $x = 2^y$.
     function Lg (input : Double) : Double {
-        return Log(input) / LogOf2();
+        return Microsoft.Quantum.Extensions.Math.Log(input) / LogOf2();
     }
 
     /// # Summary
@@ -102,10 +101,10 @@ namespace Microsoft.Quantum.Math {
     /// ```
     function RealMod(value : Double, modulo : Double, minValue : Double) : Double
     {
-        let fractionalValue = (2.0 * PI()) * ((value - minValue) / modulo - 0.5);
-        let cosFracValue = Cos(fractionalValue);
-        let sinFracValue = Sin(fractionalValue);
-        let moduloValue = 0.5 + ArcTan2(sinFracValue, cosFracValue) / (2.0 * PI());
+        let fractionalValue = (2.0 * Microsoft.Quantum.Extensions.Math.PI()) * ((value - minValue) / modulo - 0.5);
+        let cosFracValue = Microsoft.Quantum.Extensions.Math.Cos(fractionalValue);
+        let sinFracValue = Microsoft.Quantum.Extensions.Math.Sin(fractionalValue);
+        let moduloValue = 0.5 + Microsoft.Quantum.Extensions.Math.ArcTan2(sinFracValue, cosFracValue) / (2.0 * Microsoft.Quantum.Extensions.Math.PI());
         let output = moduloValue * modulo + minValue;
         return output;
     }
@@ -123,7 +122,7 @@ namespace Microsoft.Quantum.Math {
     /// # Output
     /// A real number $y$ such that $x = \cosh(y)$.
     function ArcCosh (x : Double) : Double {
-        return Log(x + Sqrt(x * x - 1.0));
+        return Microsoft.Quantum.Extensions.Math.Log(x + Microsoft.Quantum.Extensions.Math.Sqrt(x * x - 1.0));
     }
     
     
@@ -138,7 +137,7 @@ namespace Microsoft.Quantum.Math {
     /// A real number $y$ such that $x = \operatorname{sinh}(y)$.
     function ArcSinh (x : Double) : Double
     {
-        return Log(x + Sqrt(x * x + 1.0));
+        return Microsoft.Quantum.Extensions.Math.Log(x + Microsoft.Quantum.Extensions.Math.Sqrt(x * x + 1.0));
     }
     
     
@@ -153,7 +152,7 @@ namespace Microsoft.Quantum.Math {
     /// A real number $y$ such that $x = \tanh(y)$.
     function ArcTanh (x : Double) : Double
     {
-        return Log((1.0 + x) / (1.0 - x)) * 0.5;
+        return Microsoft.Quantum.Extensions.Math.Log((1.0 + x) / (1.0 - x)) * 0.5;
     }
     
     
@@ -256,8 +255,8 @@ namespace Microsoft.Quantum.Math {
     /// - This implementation is according to https://en.wikipedia.org/wiki/Extended_Euclidean_algorithm
     function ExtendedGCD (a : Int, b : Int) : (Int, Int)
     {
-        let signA = SignI(a);
-        let signB = SignI(b);
+        let signA = Microsoft.Quantum.Extensions.Math.SignI(a);
+        let signB = Microsoft.Quantum.Extensions.Math.SignI(b);
         let s = (1, 0);
         let t = (0, 1);
         let r = (a * signA, b * signB);
@@ -287,9 +286,9 @@ namespace Microsoft.Quantum.Math {
     /// Internal recursive call to calculate the GCD with a bound
     function _gcd_continued (signA : Int, signB : Int, r : (Int, Int), s : (Int, Int), t : (Int, Int), denominatorBound : Int) : Fraction
     {
-        if (Snd(r) == 0 or AbsI(Snd(s)) > denominatorBound)
+        if (Snd(r) == 0 or Microsoft.Quantum.Extensions.Math.AbsI(Snd(s)) > denominatorBound)
         {
-            if (Snd(r) == 0 and AbsI(Snd(s)) <= denominatorBound)
+            if (Snd(r) == 0 and Microsoft.Quantum.Extensions.Math.AbsI(Snd(s)) <= denominatorBound)
             {
                 return Fraction(-Snd(t) * signB, Snd(s) * signA);
             }
@@ -319,8 +318,8 @@ namespace Microsoft.Quantum.Math {
     {
         EqualityFactB(denominatorBound > 0, true, $"Denominator bound must be positive");
         let (a, b) = fraction!;
-        let signA = SignI(a);
-        let signB = SignI(b);
+        let signA = Microsoft.Quantum.Extensions.Math.SignI(a);
+        let signB = Microsoft.Quantum.Extensions.Math.SignI(b);
         let s = (1, 0);
         let t = (0, 1);
         let r = (a * signA, b * signB);
@@ -411,22 +410,18 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Output
     /// The $p$-norm $\|x\|_p$.
-    function PNorm (p : Double, array : Double[]) : Double
-    {
-        if (p < 1.0)
-        {
+    function PNorm (p : Double, array : Double[]) : Double {
+        if (p < 1.0) {
             fail $"PNorm failed. `p` must be >= 1.0";
         }
         
-        let nElements = Length(array);
         mutable norm = 0.0;
         
-        for (idx in 0 .. nElements - 1)
-        {
-            set norm = norm + PowD(AbsD(array[idx]), p);
+        for (element in array) {
+            set norm = norm + Microsoft.Quantum.Extensions.Math.PowD(Microsoft.Quantum.Extensions.Math.AbsD(element), p);
         }
         
-        return PowD(norm, 1.0 / p);
+        return Microsoft.Quantum.Extensions.Math.PowD(norm, 1.0 / p);
     }
 
     /// # Summary

--- a/Standard/src/Math/Random.qs
+++ b/Standard/src/Math/Random.qs
@@ -4,7 +4,6 @@
 namespace Microsoft.Quantum.Math {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Extensions.Convert;
-    open Microsoft.Quantum.Extensions.Math;
     
     
     // DESIGN NOTES:
@@ -29,12 +28,10 @@ namespace Microsoft.Quantum.Math {
     /// # Remarks
     /// This function calls <xref:microsoft.quantum.primitive.random>, so
     /// its randomness depends on the implementation of `Random`.
-    operation RandomIntPow2 (maxBits : Int) : Int
-    {
+    operation RandomIntPow2 (maxBits : Int) : Int {
         mutable number = 0;
         
-        for (idxBit in 0 .. maxBits - 1)
-        {
+        for (idxBit in 0 .. maxBits - 1) {
             let bit = Random([0.5, 0.5]);
             set number = number + bit * 2 ^ idxBit;
         }
@@ -69,7 +66,7 @@ namespace Microsoft.Quantum.Math {
     {
         mutable nBits = 0;
         mutable output = 0;
-        set nBits = Ceiling(Lg(ToDouble(maxInt)));
+        set nBits = Microsoft.Quantum.Extensions.Math.Ceiling(Lg(ToDouble(maxInt)));
         
         repeat
         {
@@ -108,7 +105,7 @@ namespace Microsoft.Quantum.Math {
             fail $"Number of random bits must be greater than 0.";
         }
         
-        return ToDouble(RandomIntPow2(bitsRandom)) / PowD(2.0, ToDouble(bitsRandom));
+        return ToDouble(RandomIntPow2(bitsRandom)) / Microsoft.Quantum.Extensions.Math.PowD(2.0, ToDouble(bitsRandom));
     }
 
     /// # Summary

--- a/Standard/src/Preparation/QuantumROM.qs
+++ b/Standard/src/Preparation/QuantumROM.qs
@@ -5,7 +5,6 @@ namespace Microsoft.Quantum.Preparation {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Arithmetic;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Arrays;
@@ -63,10 +62,10 @@ namespace Microsoft.Quantum.Preparation {
     ///   Ryan Babbush, Craig Gidney, Dominic W. Berry, Nathan Wiebe, Jarrod McClean, Alexandru Paler, Austin Fowler, Hartmut Neven
     ///   https://arxiv.org/abs/1805.03662
     function QuantumROM(targetError: Double, coefficients: Double[]) : ((Int, (Int, Int)), Double, ((BigEndian, Qubit[]) => Unit : Adjoint, Controlled)) {
-        let nBitsPrecision = -Ceiling(Lg(0.5*targetError))+1;
+        let nBitsPrecision = -Microsoft.Quantum.Extensions.Math.Ceiling(Lg(0.5*targetError))+1;
         let (oneNorm, keepCoeff, altIndex) = _QuantumROMDiscretization(nBitsPrecision, coefficients);
         let nCoeffs = Length(coefficients);
-        let nBitsIndices = Ceiling(Lg(ToDouble(nCoeffs)));
+        let nBitsIndices = Microsoft.Quantum.Extensions.Math.Ceiling(Lg(ToDouble(nCoeffs)));
 
         let op =  QuantumROMImpl_(nBitsPrecision, nCoeffs, nBitsIndices, keepCoeff, altIndex, _, _);
         let qubitCounts = QuantumROMQubitCount(targetError, nCoeffs);
@@ -90,8 +89,8 @@ namespace Microsoft.Quantum.Preparation {
     /// of garbage qubits.
     function QuantumROMQubitCount(targetError: Double, nCoeffs: Int) : (Int, (Int, Int))
     {
-        let nBitsPrecision = -Ceiling(Lg(0.5*targetError))+1;
-        let nBitsIndices = Ceiling(Lg(ToDouble(nCoeffs)));
+        let nBitsPrecision = -Microsoft.Quantum.Extensions.Math.Ceiling(Lg(0.5*targetError))+1;
+        let nBitsIndices = Microsoft.Quantum.Extensions.Math.Ceiling(Lg(ToDouble(nCoeffs)));
         let nGarbageQubits = nBitsIndices + 2 * nBitsPrecision + 1;
         let nTotal = nGarbageQubits + nBitsIndices;
         return (nTotal, (nBitsIndices, nGarbageQubits));
@@ -122,7 +121,7 @@ namespace Microsoft.Quantum.Preparation {
         }
 
         let barHeight = 2^bitsPrecision - 1;
-        
+
         mutable altIndex = IntArrayFromRange(0..nCoefficients-1);
         mutable keepCoeff = Mapped(QuantumROMDiscretizationRoundCoefficients_(_, oneNorm, nCoefficients, barHeight), coefficients);
 
@@ -133,13 +132,8 @@ namespace Microsoft.Quantum.Preparation {
         }
         //Message($"Excess bars {bars}.");
         // Uniformly distribute excess bars across coefficients.
-        for(idx in 0..AbsI(bars)-1){
-            if(bars > 0){
-                set keepCoeff[idx] = keepCoeff[idx]-1;
-            }
-            else{
-                set keepCoeff[idx] = keepCoeff[idx]+1;
-            }
+        for (idx in 0..Microsoft.Quantum.Extensions.Math.AbsI(bars) - 1) {
+            set keepCoeff[idx] = keepCoeff[idx] + bars > 0 ? -1 | +1;
         }
 
         mutable barSink = new Int[nCoefficients];
@@ -194,17 +188,13 @@ namespace Microsoft.Quantum.Preparation {
         
     // Used in QuantumROM implementation.
     function QuantumROMDiscretizationRoundCoefficients_(coefficient: Double, oneNorm: Double, nCoefficients: Int, barHeight: Int) : Int {
-
-        return Round((AbsD(coefficient) / oneNorm) * ToDouble(nCoefficients) * ToDouble(barHeight));
+        return Microsoft.Quantum.Extensions.Math.Round((Microsoft.Quantum.Extensions.Math.AbsD(coefficient) / oneNorm) * ToDouble(nCoefficients) * ToDouble(barHeight));
     }
 
     // Used in QuantumROM implementation.
     operation QuantumROMImpl_(nBitsPrecision: Int, nCoeffs: Int, nBitsIndices: Int, keepCoeff: Int[], altIndex: Int[], indexRegister: BigEndian, garbageRegister: Qubit[]) : Unit {
         body (...) {
             let unitaryGenerator = (nCoeffs, QuantumROMWriteBitStringUnitary_(_, keepCoeff, altIndex));
-
-            
-            
             let garbageIdx0 = nBitsIndices;
             let garbageIdx1 = garbageIdx0 + nBitsPrecision;
             let garbageIdx2 = garbageIdx1 + nBitsPrecision;

--- a/Standard/src/Preparation/QuantumROM.qs
+++ b/Standard/src/Preparation/QuantumROM.qs
@@ -133,7 +133,11 @@ namespace Microsoft.Quantum.Preparation {
         //Message($"Excess bars {bars}.");
         // Uniformly distribute excess bars across coefficients.
         for (idx in 0..Microsoft.Quantum.Extensions.Math.AbsI(bars) - 1) {
-            set keepCoeff[idx] = keepCoeff[idx] + bars > 0 ? -1 | +1;
+            if (bars > 0) {
+                set keepCoeff[idx] = keepCoeff[idx] - 1;
+            } else {
+                set keepCoeff[idx] = keepCoeff[idx] + 1;
+            }
         }
 
         mutable barSink = new Int[nCoefficients];

--- a/Standard/src/Preparation/StatePreparation.qs
+++ b/Standard/src/Preparation/StatePreparation.qs
@@ -5,7 +5,6 @@ namespace Microsoft.Quantum.Preparation {
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Primitive;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Arrays;
 
@@ -50,20 +49,17 @@ namespace Microsoft.Quantum.Preparation {
     ///     op(qubitsBE);
     /// }
     /// ```
-    function StatePreparationPositiveCoefficients (coefficients : Double[]) : (BigEndian => Unit : Adjoint, Controlled)
-    {
+    function StatePreparationPositiveCoefficients (coefficients : Double[]) : (BigEndian => Unit : Adjoint, Controlled) {
         let nCoefficients = Length(coefficients);
         mutable coefficientsComplexPolar = new ComplexPolar[nCoefficients];
-        
-        for (idx in 0 .. nCoefficients - 1)
-        {
-            set coefficientsComplexPolar[idx] = ComplexPolar(AbsD(coefficients[idx]), 0.0);
+
+        for (idx in 0 .. nCoefficients - 1) {
+            set coefficientsComplexPolar[idx] = ComplexPolar(Microsoft.Quantum.Extensions.Math.AbsD(coefficients[idx]), 0.0);
         }
-        
+
         return PrepareArbitraryState(coefficientsComplexPolar, _);
     }
-    
-    
+
     /// # Summary
 	/// Returns an operation that prepares a specific quantum state.
 	/// 
@@ -148,33 +144,26 @@ namespace Microsoft.Quantum.Preparation {
     /// - Synthesis of Quantum Logic Circuits
     ///   Vivek V. Shende, Stephen S. Bullock, Igor L. Markov
     ///   https://arxiv.org/abs/quant-ph/0406176
-    operation PrepareArbitraryState (coefficients : ComplexPolar[], qubits : BigEndian) : Unit
-    {
-        body (...)
-        {
+    operation PrepareArbitraryState (coefficients : ComplexPolar[], qubits : BigEndian) : Unit {
+        body (...) {
             // pad coefficients at tail length to a power of 2.
             let coefficientsPadded = Padded(-2 ^ Length(qubits!), ComplexPolar(0.0, 0.0), coefficients);
             let target = (qubits!)[Length(qubits!) - 1];
             let op = (Adjoint PrepareArbitraryState_(coefficientsPadded, _, _))(_, target);
-            
-            if (Length(qubits!) > 1)
-            {
-                let control = BigEndian((qubits!)[0 .. Length(qubits!) - 2]);
-                op(control);
-            }
-            else
-            {
-                let control = BigEndian(new Qubit[0]);
-                op(control);
-            }
+
+            op(
+                // Determine what controls to apply to `op`.
+                Length(qubits!) > 1
+                ? BigEndian((qubits!)[0 .. Length(qubits!) - 2])
+                | BigEndian(new Qubit[0])
+            );
         }
-        
+
         adjoint invert;
         controlled distribute;
         controlled adjoint distribute;
     }
-    
-    
+
     /// # Summary
     /// Implementation step of arbitrary state preparation procedure.
     ///
@@ -233,10 +222,10 @@ namespace Microsoft.Quantum.Preparation {
         let abs1 = AbsComplexPolar(a1);
         let arg0 = ArgComplexPolar(a0);
         let arg1 = ArgComplexPolar(a1);
-        let r = Sqrt(abs0 * abs0 + abs1 * abs1);
+        let r = Microsoft.Quantum.Extensions.Math.Sqrt(abs0 * abs0 + abs1 * abs1);
         let t = 0.5 * (arg0 + arg1);
         let phi = arg1 - arg0;
-        let theta = 2.0 * ArcTan2(abs1, abs0);
+        let theta = 2.0 * Microsoft.Quantum.Extensions.Math.ArcTan2(abs1, abs0);
         return (ComplexPolar(r, t), phi, theta);
     }
 

--- a/Standard/src/Preparation/UniformSuperposition.qs
+++ b/Standard/src/Preparation/UniformSuperposition.qs
@@ -4,7 +4,6 @@
 namespace Microsoft.Quantum.Preparation {
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Primitive;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.AmplitudeAmplification;
@@ -52,7 +51,7 @@ namespace Microsoft.Quantum.Preparation {
                 H(indexRegister![Length(indexRegister!) - 1]);
             }
             else{
-                let nQubits = Ceiling(Lg(ToDouble(nIndices)));
+                let nQubits = Microsoft.Quantum.Extensions.Math.Ceiling(Lg(ToDouble(nIndices)));
                 if (nQubits > Length(indexRegister!)){
                     fail $"Cannot prepare uniform superposition over {nIndices} states as it is larger than the qubit register.";
                 }
@@ -82,7 +81,7 @@ namespace Microsoft.Quantum.Preparation {
             let targetQubits = qubits[3..3 + nQubits-1];
             let flagQubit = qubits[0];
             let auxillaryQubits = qubits[1..2];
-            let theta = ArcSin(Sqrt(ToDouble(2^nQubits)/ToDouble(nIndices))*Sin(PI() / 6.0));
+            let theta = Microsoft.Quantum.Extensions.Math.ArcSin(Microsoft.Quantum.Extensions.Math.Sqrt(ToDouble(2^nQubits)/ToDouble(nIndices)) * Microsoft.Quantum.Extensions.Math.Sin(Microsoft.Quantum.Extensions.Math.PI() / 6.0));
             //let theta = PI() * 0.5;
 
             ApplyToEachCA(H, targetQubits);

--- a/Standard/src/Simulation/Algorithms.qs
+++ b/Standard/src/Simulation/Algorithms.qs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.Quantum.Simulation {
     open Microsoft.Quantum.Canon;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;
 
     // A simulation technique converts an EvolutionGenerator to time evolution
@@ -22,19 +21,11 @@ namespace Microsoft.Quantum.Simulation {
     /// Multiplier on duration of time-evolution by term indexed by `idx`.
     /// ## qubits
     /// Qubits acted on by simulation.
-    operation TrotterStepImpl (evolutionGenerator : EvolutionGenerator, idx : Int, stepsize : Double, qubits : Qubit[]) : Unit
-    {
-        body (...)
-        {
-            let (evolutionSet, generatorSystem) = evolutionGenerator!;
-            let (nTerms, generatorSystemFunction) = generatorSystem!;
-            let generatorIndex = generatorSystemFunction(idx);
-            (evolutionSet!(generatorIndex))!(stepsize, qubits);
-        }
-        
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
+    operation TrotterStepImpl (evolutionGenerator : EvolutionGenerator, idx : Int, stepsize : Double, qubits : Qubit[]) : Unit is Adj + Ctl {
+        let (evolutionSet, generatorSystem) = evolutionGenerator!;
+        let (nTerms, generatorSystemFunction) = generatorSystem!;
+        let generatorIndex = generatorSystemFunction(idx);
+        (evolutionSet!(generatorIndex))!(stepsize, qubits);
     }
     
     
@@ -94,7 +85,7 @@ namespace Microsoft.Quantum.Simulation {
     {
         body (...)
         {
-            let nTimeSlices = Ceiling(maxTime / trotterStepSize);
+            let nTimeSlices = Microsoft.Quantum.Extensions.Math.Ceiling(maxTime / trotterStepSize);
             let resizedTrotterStepSize = maxTime / ToDouble(nTimeSlices);
             
             for (idxTimeSlice in 0 .. nTimeSlices - 1)
@@ -149,7 +140,7 @@ namespace Microsoft.Quantum.Simulation {
     {
         body (...)
         {
-            let nTimeSlices = Ceiling(maxTime / trotterStepSize);
+            let nTimeSlices = Microsoft.Quantum.Extensions.Math.Ceiling(maxTime / trotterStepSize);
             let resizedTrotterStepSize = maxTime / ToDouble(nTimeSlices);
             
             for (idxTimeSlice in 0 .. nTimeSlices - 1)

--- a/Standard/src/Simulation/BlockEncoding.qs
+++ b/Standard/src/Simulation/BlockEncoding.qs
@@ -5,7 +5,6 @@ namespace Microsoft.Quantum.Simulation {
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Primitive;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Arrays;
 
     // This library defines types for block-encoding an arbitrary operator.
@@ -164,8 +163,8 @@ namespace Microsoft.Quantum.Simulation {
     /// Implementation of `Qubitization`.
     operation QuantumWalkByQubitization_(blockEncoding: BlockEncodingReflection, auxiliary: Qubit[], system: Qubit[]) : Unit {    
         body (...){
-            Exp([PauliI], -0.5 * PI(), [system[0]]);
-            RAll0(PI(), auxiliary);
+            Exp([PauliI], -0.5 * Microsoft.Quantum.Extensions.Math.PI(), [system[0]]);
+            RAll0(Microsoft.Quantum.Extensions.Math.PI(), auxiliary);
             // NB: We unwrap twice here, since BlockEncodingReflection wraps BlockEncoding.
             blockEncoding!!(auxiliary, system);    
         }

--- a/Standard/src/Simulation/Data/GeneratorRepresentation.qs
+++ b/Standard/src/Simulation/Data/GeneratorRepresentation.qs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Simulation {
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Arrays;
 

--- a/Standard/src/Simulation/QubitizationPauliEvolutionSet.qs
+++ b/Standard/src/Simulation/QubitizationPauliEvolutionSet.qs
@@ -7,7 +7,6 @@ namespace Microsoft.Quantum.Simulation {
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Math;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Arrays;
 
@@ -105,7 +104,7 @@ namespace Microsoft.Quantum.Simulation {
         let (nTerms, intToGenIdx) = generatorSystem!;
         let op = IdxToCoeff_(_, intToGenIdx, PauliCoefficientFromGenIdx);
         let coefficients = Mapped(op, IntArrayFromRange(0..nTerms-1));
-        let oneNorm = PowD(PNorm(2.0, coefficients),2.0);
+        let oneNorm = Microsoft.Quantum.Extensions.Math.PowD(PNorm(2.0, coefficients),2.0);
         let unitaryGenerator = (nTerms, IdxToUnitary_(_, intToGenIdx, PauliLCUUnitary_));
         let statePreparation = statePrepUnitary(coefficients);
         let selector = multiplexer(unitaryGenerator); 
@@ -118,7 +117,7 @@ namespace Microsoft.Quantum.Simulation {
     /// # See Also
     /// - Microsoft.Quantum.Canon.PauliBlockEncoding
     function IdxToCoeff_(idx: Int, genFun: (Int -> GeneratorIndex), genIdxToCoeff: (GeneratorIndex -> Double)) : Double {
-        return Sqrt(AbsD(genIdxToCoeff(genFun(idx))));
+        return Microsoft.Quantum.Extensions.Math.Sqrt(Microsoft.Quantum.Extensions.Math.AbsD(genIdxToCoeff(genFun(idx))));
     }
 
     /// # Summary
@@ -147,12 +146,12 @@ namespace Microsoft.Quantum.Simulation {
             let ((idxPaulis, coeff), idxQubits) = generatorIndex!;
             let pauliString = IntsToPaulis(idxPaulis);
             let pauliQubits = Subarray(idxQubits, qubits);
-            
+
             ApplyPauli(pauliString, pauliQubits);
 
-            if(coeff[0] < 0.0){
+            if (coeff[0] < 0.0) {
                 // -1 phase
-                Exp([PauliI], PI(), [pauliQubits[0]]);
+                Exp([PauliI], Microsoft.Quantum.Extensions.Math.PI(), [pauliQubits[0]]);
             }
         }
         adjoint auto;

--- a/Standard/src/Simulation/Techniques.qs
+++ b/Standard/src/Simulation/Techniques.qs
@@ -5,7 +5,6 @@ namespace Microsoft.Quantum.Simulation {
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Extensions.Convert;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Oracles;
     
     

--- a/Standard/src/Standard.csproj
+++ b/Standard/src/Standard.csproj
@@ -19,6 +19,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.5.1903.2703" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1904.1010-beta" />
   </ItemGroup>
 </Project>

--- a/Standard/tests/AmplitudeAmplificationTests.qs
+++ b/Standard/tests/AmplitudeAmplificationTests.qs
@@ -4,7 +4,6 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Convert;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.AmplitudeAmplification;
     open Microsoft.Quantum.Oracles;
 
@@ -14,16 +13,9 @@ namespace Microsoft.Quantum.Tests {
     /// The goal is to amplify the |1> state
     /// We can do this either by synthesizing the reflection about the start and target states ourselves,
     /// We can also do it by passing the oracle for state preparation
-    operation ExampleStatePrepImpl (lambda : Double, idxFlagQubit : Int, qubitStart : Qubit[]) : Unit {
-        
-        body (...) {
-            let rotAngle = 2.0 * ArcSin(lambda);
-            Ry(rotAngle, qubitStart[idxFlagQubit]);
-        }
-        
-        adjoint invert;
-        controlled distribute;
-        controlled adjoint distribute;
+    operation ExampleStatePrepImpl (lambda : Double, idxFlagQubit : Int, qubitStart : Qubit[]) : Unit is Adj + Ctl {
+        let rotAngle = 2.0 * Microsoft.Quantum.Extensions.Math.ArcSin(lambda);
+        Ry(rotAngle, qubitStart[idxFlagQubit]);
     }
     
     
@@ -45,12 +37,12 @@ namespace Microsoft.Quantum.Tests {
                 
                 for (idx in 1 .. 20) {
                     let lambda = ToDouble(idx) / 20.0;
-                    let rotAngle = ArcSin(lambda);
+                    let rotAngle = Microsoft.Quantum.Extensions.Math.ArcSin(lambda);
                     let idxFlag = 0;
                     let startQubits = qubits;
                     let stateOracle = ExampleStatePrep(lambda);
                     (AmpAmpByOracle(nIterations, stateOracle, idxFlag))(startQubits);
-                    let successAmplitude = Sin(ToDouble(2 * nIterations + 1) * rotAngle);
+                    let successAmplitude = Microsoft.Quantum.Extensions.Math.Sin(ToDouble(2 * nIterations + 1) * rotAngle);
                     let successProbability = successAmplitude * successAmplitude;
                     AssertProb([PauliZ], [startQubits[idxFlag]], One, successProbability, $"Error: Success probability does not match theory", 1E-10);
                     ResetAll(qubits);
@@ -69,14 +61,14 @@ namespace Microsoft.Quantum.Tests {
                 let phases = AmpAmpPhasesStandard(nIterations);
                 
                 for (idx in 0 .. 20) {
-                    let rotAngle = (ToDouble(idx) * PI()) / 20.0;
+                    let rotAngle = (ToDouble(idx) * Microsoft.Quantum.Extensions.Math.PI()) / 20.0;
                     let idxFlag = 0;
                     let ancillaRegister = qubits;
                     let systemRegister = new Qubit[0];
                     let ancillaOracle = DeterministicStateOracle(Exp([PauliY], rotAngle * 0.5, _));
                     let signalOracle = ObliviousOracle(NoOp<(Qubit[], Qubit[])>(_, _));
                     (AmpAmpObliviousByOraclePhases(phases, ancillaOracle, signalOracle, idxFlag))(ancillaRegister, systemRegister);
-                    let successAmplitude = Sin((ToDouble(2 * nIterations + 1) * rotAngle) * 0.5);
+                    let successAmplitude = Microsoft.Quantum.Extensions.Math.Sin((ToDouble(2 * nIterations + 1) * rotAngle) * 0.5);
                     let successProbability = successAmplitude * successAmplitude;
                     AssertProb([PauliZ], [ancillaRegister[idxFlag]], One, successProbability, $"Error: Success probability does not match theory", 1E-10);
                     ResetAll(qubits);
@@ -92,9 +84,9 @@ namespace Microsoft.Quantum.Tests {
             ResetAll(qubits);
             
             for (idx in 0 .. 20) {
-                let rotangle = (ToDouble(idx) * PI()) / 20.0;
+                let rotangle = (ToDouble(idx) * Microsoft.Quantum.Extensions.Math.PI()) / 20.0;
                 let targetStateReflection = TargetStateReflectionOracle(0);
-                let success = Cos(0.5 * rotangle) * Cos(0.5 * rotangle);
+                let success = Microsoft.Quantum.Extensions.Math.Cos(0.5 * rotangle) * Microsoft.Quantum.Extensions.Math.Cos(0.5 * rotangle);
                 H(qubits[0]);
                 targetStateReflection!(rotangle, qubits);
                 AssertProb([PauliX], qubits, Zero, success, $"Error: Success probability does not match theory", 1E-10);

--- a/Standard/tests/MathTests.qs
+++ b/Standard/tests/MathTests.qs
@@ -3,25 +3,24 @@
 namespace Microsoft.Quantum.Canon {
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Primitive;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Arrays;
 
     function NativeFnsAreCallableTest () : Unit {
         
-        let arg = PI() / 2.0;
-        NearEqualityFact(Sin(arg), 1.0);
-        NearEqualityFact(Cos(arg), 0.0);
+        let arg = Microsoft.Quantum.Extensions.Math.PI() / 2.0;
+        NearEqualityFact(Microsoft.Quantum.Extensions.Math.Sin(arg), 1.0);
+        NearEqualityFact(Microsoft.Quantum.Extensions.Math.Cos(arg), 0.0);
         let arcArg = 1.0;
-        NearEqualityFact(ArcCos(arcArg), 0.0);
-        NearEqualityFact(ArcSin(arcArg), arg);
+        NearEqualityFact(Microsoft.Quantum.Extensions.Math.ArcCos(arcArg), 0.0);
+        NearEqualityFact(Microsoft.Quantum.Extensions.Math.ArcSin(arcArg), arg);
     }
     
     
     function RealModTest () : Unit {
         
-        NearEqualityFact(RealMod(5.5 * PI(), 2.0 * PI(), 0.0), 1.5 * PI());
-        NearEqualityFact(RealMod(0.5 * PI(), 2.0 * PI(), -PI() / 2.0), 0.5 * PI());
+        NearEqualityFact(RealMod(5.5 * Microsoft.Quantum.Extensions.Math.PI(), 2.0 * Microsoft.Quantum.Extensions.Math.PI(), 0.0), 1.5 * Microsoft.Quantum.Extensions.Math.PI());
+        NearEqualityFact(RealMod(0.5 * Microsoft.Quantum.Extensions.Math.PI(), 2.0 * Microsoft.Quantum.Extensions.Math.PI(), -Microsoft.Quantum.Extensions.Math.PI() / 2.0), 0.5 * Microsoft.Quantum.Extensions.Math.PI());
     }
     
     
@@ -39,8 +38,8 @@ namespace Microsoft.Quantum.Canon {
         
         Message($"Testing {a}, {b}, {gcd} ");
         let (u, v) = ExtendedGCD(a, b);
-        let expected = AbsI(gcd);
-        let actual = AbsI(u * a + v * b);
+        let expected = Microsoft.Quantum.Extensions.Math.AbsI(gcd);
+        let actual = Microsoft.Quantum.Extensions.Math.AbsI(u * a + v * b);
         EqualityFactI(expected, actual, $"Expected absolute value of gcd to be {expected}, got {actual}");
     }
     
@@ -72,14 +71,14 @@ namespace Microsoft.Quantum.Canon {
         let bitSize = 2 * BitSize(denominator);
         let numeratorDyadic = (numerator * 2 ^ bitSize) / denominator;
         let (u, v) = (ContinuedFractionConvergent(Fraction(numeratorDyadic, 2 ^ bitSize), denominator))!;
-        EqualityFactB(AbsI(u) == numerator and AbsI(v) == denominator, true, $"The result must be ±{numerator}/±{denominator} got {u}/{v}");
+        EqualityFactB(Microsoft.Quantum.Extensions.Math.AbsI(u) == numerator and Microsoft.Quantum.Extensions.Math.AbsI(v) == denominator, true, $"The result must be ±{numerator}/±{denominator} got {u}/{v}");
     }
     
     
     function ContinuedFractionConvergentEdgeCaseTestHelper (numerator : Int, denominator : Int, bound : Int) : Unit {
         
         let (num, denom) = (ContinuedFractionConvergent(Fraction(numerator, denominator), bound))!;
-        EqualityFactB(AbsI(num) == numerator and AbsI(denom) == denominator, true, $"The result must be ±{numerator}/±{denominator} got {num}/{denom}");
+        EqualityFactB(Microsoft.Quantum.Extensions.Math.AbsI(num) == numerator and Microsoft.Quantum.Extensions.Math.AbsI(denom) == denominator, true, $"The result must be ±{numerator}/±{denominator} got {num}/{denom}");
     }
     
     
@@ -98,9 +97,9 @@ namespace Microsoft.Quantum.Canon {
         
         for (idxCases in 0 .. Length(complexCases) - 1) {
             let (complexRe, complexIm) = complexCases[idxCases];
-            let complexAbs = Sqrt(complexRe * complexRe + complexIm * complexIm);
-            let complexArg = ArcTan2(complexIm, complexRe);
-            let complex = Complex(complexRe, complexIm);
+            let complexAbs = Microsoft.Quantum.Extensions.Math.Sqrt(complexRe * complexRe + complexIm * complexIm);
+            let complexArg = Microsoft.Quantum.Extensions.Math.ArcTan2(complexIm, complexRe);
+            let complex = Microsoft.Quantum.Extensions.Math.Complex(complexRe, complexIm);
             let complexPolar = ComplexPolar(complexAbs, complexArg);
             NearEqualityFact(AbsSquaredComplex(complex), complexAbs * complexAbs);
             NearEqualityFact(AbsComplex(complex), complexAbs);

--- a/Standard/tests/QcvvTests.qs
+++ b/Standard/tests/QcvvTests.qs
@@ -4,7 +4,6 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Convert;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Oracles;
     open Microsoft.Quantum.Characterization;
     open Microsoft.Quantum.Preparation;
@@ -66,7 +65,7 @@ namespace Microsoft.Quantum.Tests {
         let bitsPrecision = 10;
         
         for (idxTest in 0 .. 9) {
-            let phaseSet = ((2.0 * PI()) * ToDouble(idxTest - 5)) / 12.0;
+            let phaseSet = ((2.0 * Microsoft.Quantum.Extensions.Math.PI()) * ToDouble(idxTest - 5)) / 12.0;
             let phaseEst = RobustPhaseEstimationDemoImpl(phaseSet, bitsPrecision);
             EqualityWithinToleranceFact(phaseEst, phaseSet, 0.01);
         }

--- a/Standard/tests/QeccTests.qs
+++ b/Standard/tests/QeccTests.qs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Primitive;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Testing;
     open Microsoft.Quantum.ErrorCorrection;
@@ -88,7 +87,7 @@ namespace Microsoft.Quantum.Tests {
         let s = SyndromeMeasOp(MeasureStabilizerGenerators([[PauliX, PauliZ, PauliZ, PauliX, PauliI], [PauliI, PauliX, PauliZ, PauliZ, PauliX], [PauliX, PauliI, PauliX, PauliZ, PauliZ], [PauliZ, PauliX, PauliI, PauliX, PauliZ]], _, MeasureWithScratch));
         
         using (anc = Qubit[6]) {
-            Ry(PI() / 2.5, anc[0]);
+            Ry(Microsoft.Quantum.Extensions.Math.PI() / 2.5, anc[0]);
             FiveQubitCodeEncoderImpl([anc[0]], anc[1 .. 4]);
             let m = anc[5];
             mutable n = 0;
@@ -173,7 +172,7 @@ namespace Microsoft.Quantum.Tests {
         using (anc = Qubit[5]) {
             
             // let's start with an arbitrary logical state.
-            Ry(PI() / 2.5, anc[0]);
+            Ry(Microsoft.Quantum.Extensions.Math.PI() / 2.5, anc[0]);
             FiveQubitCodeEncoderImpl([anc[0]], anc[1 .. 4]);
             let syn = s!(LogicalRegister(anc));
             let a = ResultAsInt(syn!);
@@ -252,8 +251,8 @@ namespace Microsoft.Quantum.Tests {
         using (anc = Qubit[2]) {
             
             // magic state in anc[1]
-            Ry(PI() / 4.0, anc[1]);
-            let expected = ApplyToEachA(Ry(PI() / 4.0, _), _);
+            Ry(Microsoft.Quantum.Extensions.Math.PI() / 4.0, anc[1]);
+            let expected = ApplyToEachA(Ry(Microsoft.Quantum.Extensions.Math.PI() / 4.0, _), _);
             let actual = ApplyToEach(InjectPi4YRotation(_, anc[1]), _);
             AssertOperationsEqualReferenced(actual, expected, 1);
             
@@ -272,8 +271,8 @@ namespace Microsoft.Quantum.Tests {
         using (anc = Qubit[2]) {
             
             // magic state in anc[1]
-            Ry(PI() / 4.0, anc[1]);
-            let expected = ApplyToEachA(Ry(-PI() / 4.0, _), _);
+            Ry(Microsoft.Quantum.Extensions.Math.PI() / 4.0, anc[1]);
+            let expected = ApplyToEachA(Ry(-Microsoft.Quantum.Extensions.Math.PI() / 4.0, _), _);
             let actual = ApplyToEach(Adjoint InjectPi4YRotation(_, anc[1]), _);
             AssertOperationsEqualReferenced(actual, expected, 1);
             
@@ -345,9 +344,9 @@ namespace Microsoft.Quantum.Tests {
         using (register = Qubit[15]) {
             
             // Prepare the perfect magic states.
-            ApplyToEach(Ry(PI() / 4.0, _), register);
+            ApplyToEach(Ry(Microsoft.Quantum.Extensions.Math.PI() / 4.0, _), register);
             let accept = KnillDistill(register);
-            Ry(-PI() / 4.0, register[0]);
+            Ry(-Microsoft.Quantum.Extensions.Math.PI() / 4.0, register[0]);
             EqualityFactB(true, accept, $"Distillation failure");
             ApplyToEach(AssertQubit(Zero, _), register);
             // NB: no need to reset, we just asserted everything
@@ -366,20 +365,20 @@ namespace Microsoft.Quantum.Tests {
     operation KDTest () : Unit {
         
         using (rm = Qubit[15]) {
-            ApplyToEach(Ry(PI() / 4.0, _), rm);
+            ApplyToEach(Ry(Microsoft.Quantum.Extensions.Math.PI() / 4.0, _), rm);
             let acc = KnillDistill(rm);
             
             // Check that the rough magic states were
             // successfully reset to |0〉.
             ApplyToEach(AssertQubit(Zero, _), Rest(rm));
-            Ry(-PI() / 4.0, rm[0]);
+            Ry(-Microsoft.Quantum.Extensions.Math.PI() / 4.0, rm[0]);
             EqualityFactB(true, acc, $"Distillation failure");
             AssertQubit(Zero, rm[0]);
             
             // Cases where a single magic state is wrong
             for (idx in 0 .. 14) {
                 ResetAll(rm);
-                ApplyToEach(Ry(PI() / 4.0, _), rm);
+                ApplyToEach(Ry(Microsoft.Quantum.Extensions.Math.PI() / 4.0, _), rm);
                 Y(rm[idx]);
                 let acc1 = KnillDistill(rm);
                 
@@ -394,7 +393,7 @@ namespace Microsoft.Quantum.Tests {
                 
                 for (idxSecond in idxFirst + 1 .. 14) {
                     ResetAll(rm);
-                    ApplyToEach(Ry(PI() / 4.0, _), rm);
+                    ApplyToEach(Ry(Microsoft.Quantum.Extensions.Math.PI() / 4.0, _), rm);
                     Y(rm[idxFirst]);
                     Y(rm[idxSecond]);
                     let acc1 = KnillDistill(rm);

--- a/Standard/tests/QuantumPhaseEstimationTests.qs
+++ b/Standard/tests/QuantumPhaseEstimationTests.qs
@@ -4,7 +4,6 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Extensions.Testing;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Oracles;
     open Microsoft.Quantum.Characterization;
     
@@ -21,8 +20,8 @@ namespace Microsoft.Quantum.Tests {
             let phase = BigEndian(qPhase[0 .. 3]);
             let state = qPhase[4];
             QuantumPhaseEstimation(oracle, [state], phase);
-            let complexOne = Complex(1.0, 0.0);
-            let complexZero = Complex(0.0, 0.0);
+            let complexOne = Microsoft.Quantum.Extensions.Math.Complex(1.0, 0.0);
+            let complexZero = Microsoft.Quantum.Extensions.Math.Complex(0.0, 0.0);
             
             for (idxPhase in 0 .. 4) {
                 AssertQubitState((complexOne, complexZero), qPhase[idxPhase], 1E-06);

--- a/Standard/tests/QuantumROMTests.qs
+++ b/Standard/tests/QuantumROMTests.qs
@@ -7,7 +7,6 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Preparation;
     open Microsoft.Quantum.Extensions.Testing;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Extensions.Convert;
 
@@ -49,9 +48,9 @@ namespace Microsoft.Quantum.Tests {
             for (i in 0..coeffs-1)
             {
                 set coefficientsOut[i] = oneNorm * ToDouble(coefficientsOutInt[i]) / ToDouble(barHeight * coeffs);
-                let error = AbsD(coefficients[i] - coefficientsOut[i]) / oneNorm  /( PowD(2.0, ToDouble(-bitsPrecision)) / ToDouble(coeffs));
+                let error = Microsoft.Quantum.Extensions.Math.AbsD(coefficients[i] - coefficientsOut[i]) / oneNorm  /( Microsoft.Quantum.Extensions.Math.PowD(2.0, ToDouble(-bitsPrecision)) / ToDouble(coeffs));
                 set errors[i] = error;
-                if(AbsD(error) > AbsD(maxError)){
+                if(Microsoft.Quantum.Extensions.Math.AbsD(error) > Microsoft.Quantum.Extensions.Math.AbsD(maxError)){
                     set maxError = error;
                 }
             }
@@ -70,7 +69,7 @@ namespace Microsoft.Quantum.Tests {
     operation QuantumROMTest() : Unit {
         for(coeffs in 2..7){
             for(nBitsPrecision in -1..-1..-2){
-                let targetError = PowD(2.0, ToDouble(nBitsPrecision));
+                let targetError = Microsoft.Quantum.Extensions.Math.PowD(2.0, ToDouble(nBitsPrecision));
                 let probtargetError = targetError / ToDouble(coeffs);
                 mutable coefficients = new Double[coeffs];
                 for (idx in 0..coeffs-1)
@@ -81,7 +80,7 @@ namespace Microsoft.Quantum.Tests {
                 Message($"Test case coeffs {coeffs}, bitsPrecision {nCoeffQubits}, global targetError {targetError}, probability error {probtargetError}.");
                 for (idx in 0..coeffs-1)
                 {
-                    let tmp = AbsD(coefficients[idx]) / oneNorm;
+                    let tmp = Microsoft.Quantum.Extensions.Math.AbsD(coefficients[idx]) / oneNorm;
                     Message($"{idx} expected prob = {tmp}.");
                 }
 
@@ -92,9 +91,9 @@ namespace Microsoft.Quantum.Tests {
                     op(register);
                     // Now check that probability of each number state in nCoeffQubits is as expected.
                     for(stateIndex in 0..coeffs-1){
-                        let prob = AbsD(coefficients[stateIndex]) / oneNorm;
+                        let prob = Microsoft.Quantum.Extensions.Math.AbsD(coefficients[stateIndex]) / oneNorm;
                         Message($"Testing probability {prob} on index {stateIndex}");
-                        //BAssertProbIntBE(stateIndex, AbsD(coefficients[stateIndex]) / oneNorm, BigEndian(coeffQubits), targetError / ToDouble(coeffs));
+                        //BAssertProbIntBE(stateIndex, Microsoft.Quantum.Extensions.Math.AbsD(coefficients[stateIndex]) / oneNorm, BigEndian(coeffQubits), targetError / ToDouble(coeffs));
                     }
 
                     (Adjoint op)(register);

--- a/Standard/tests/QubitizationTests.qs
+++ b/Standard/tests/QubitizationTests.qs
@@ -7,7 +7,6 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Testing;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Extensions.Convert;
     open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Diagnostics;
@@ -17,9 +16,9 @@ namespace Microsoft.Quantum.Tests {
     // The returned operations encode the Hamiltonian (cos^2(angle) I+sin^2(angle) X)/2.
     function LCUTestHelper() : (Double[], Double, Double, (Qubit[] => Unit : Adjoint, Controlled), ((Qubit[], Qubit[]) => Unit : Adjoint, Controlled)){
         let angle = 1.789;
-        let eigenvalues = [0.5, 0.5 * Cos(angle * 2.0)];
-        let prob = PowD(Cos(angle),4.0)+PowD(Sin(angle),4.0);
-        let inverseAngle = ArcSin(PowD(Sin(angle),2.0)/Sqrt(prob));
+        let eigenvalues = [0.5, 0.5 * Microsoft.Quantum.Extensions.Math.Cos(angle * 2.0)];
+        let prob = Microsoft.Quantum.Extensions.Math.PowD(Microsoft.Quantum.Extensions.Math.Cos(angle),4.0)+Microsoft.Quantum.Extensions.Math.PowD(Microsoft.Quantum.Extensions.Math.Sin(angle),4.0);
+        let inverseAngle = Microsoft.Quantum.Extensions.Math.ArcSin(Microsoft.Quantum.Extensions.Math.PowD(Microsoft.Quantum.Extensions.Math.Sin(angle),2.0)/Microsoft.Quantum.Extensions.Math.Sqrt(prob));
         let statePreparation = Exp([PauliY], angle, _);
         let selector = Controlled (ApplyToEachCA(X, _))(_, _);
         return (eigenvalues, prob, inverseAngle, statePreparation, selector);
@@ -106,13 +105,14 @@ namespace Microsoft.Quantum.Tests {
     operation PauliBlockEncodingLCUTest() : Unit {
         body (...) {
             let angle = 0.123;
-            let cosSquared = Cos(angle) * Cos(angle);
-            let prob = PowD(Cos(angle),4.0)+PowD(Sin(angle),4.0);
-            let inverseAngle = ArcSin(PowD(Sin(angle),2.0)/Sqrt(prob));
+            let cosSquared = Microsoft.Quantum.Extensions.Math.Cos(angle) * Microsoft.Quantum.Extensions.Math.Cos(angle);
+            let prob = Microsoft.Quantum.Extensions.Math.PowD(Microsoft.Quantum.Extensions.Math.Cos(angle),4.0)+Microsoft.Quantum.Extensions.Math.PowD(Microsoft.Quantum.Extensions.Math.Sin(angle),4.0);
+            let inverseAngle = Microsoft.Quantum.Extensions.Math.ArcSin(Microsoft.Quantum.Extensions.Math.PowD(Microsoft.Quantum.Extensions.Math.Sin(angle),2.0)/Microsoft.Quantum.Extensions.Math.Sqrt(prob));
 
-            mutable genIndices = new GeneratorIndex[2];
-            set genIndices[0] = GeneratorIndex(([0],[cosSquared]),[0]);
-            set genIndices[1] = GeneratorIndex(([1],[1.0-cosSquared]),[0]);
+            let genIndices = [
+                GeneratorIndex(([0],[cosSquared]),[0]),
+                GeneratorIndex(([1],[1.0-cosSquared]),[0])
+            ];
             
             let generatorSystem = GeneratorSystem(2, LookupFunction(genIndices));
 

--- a/Standard/tests/Standard.Tests.csproj
+++ b/Standard/tests/Standard.Tests.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.5.1903.2703" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.5.1903.2703" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1904.1010-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.6.1904.1010-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/Standard/tests/StatePreparationTests.qs
+++ b/Standard/tests/StatePreparationTests.qs
@@ -6,10 +6,9 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Primitive;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Extensions.Convert;
-    open Microsoft.Quantum.Extensions.Math;
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Measurement;
-
+    open Microsoft.Quantum.Arrays;
 
     // number of qubits, abs(amplitude), phase
     newtype StatePreparationTestCase = (Int, Double[], Double[]);
@@ -131,7 +130,7 @@ namespace Microsoft.Quantum.Tests {
         set nTests = nTests + 1;
         set testCases[nTests] = StatePreparationTestCase(3, [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]);
         set nTests = nTests + 1;
-        set testCases[nTests] = StatePreparationTestCase(3, [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0], [PI(), PI(), PI(), PI(), PI(), PI(), PI(), PI()]);
+        set testCases[nTests] = StatePreparationTestCase(3, [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0], ConstantArray(8, Microsoft.Quantum.Extensions.Math.PI()));
         set nTests = nTests + 1;
         set testCases[nTests] = StatePreparationTestCase(3, [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0], [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.01]);
         set nTests = nTests + 1;


### PR DESCRIPTION
This PR helps migrate to 0.6 namespacing by explicitly qualifying all names in the Microsoft.Quantum.Extensions.Math namespace. Once migration to 0.6 is complete, these qualifications can be subsquently removed.