### PR TITLE
Explicitly call new QArray.

### DIFF
--- a/Chemistry/src/DataModel/Extensions.cs
+++ b/Chemistry/src/DataModel/Extensions.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Quantum.Chemistry
                             newCoefficients[idxCoeff] += coeffs[idxCoeff];
                         }
                         // Package the newly modified coefficients back up as a new Q# array.
-                        curr = new HTerm((currentIndexes, newCoefficients.ToQArray()));
+                        curr = new HTerm((currentIndexes, new QArray<double> (newCoefficients)));
                         output[nElements - 1] = curr;
                     }
                     else


### PR DESCRIPTION
This PR provides an improved fix for #88 that no longer depends on extension methods on IEnumerable<T> to convert to QArray<T>.