### PR TITLE
Add new skip tests variable.

### DIFF
--- a/Build/step-build-libs.yml
+++ b/Build/step-build-libs.yml
@@ -2,10 +2,6 @@
 # Builds, tests & package all libraries.
 ##
 
-steps:
-- script: |
-    echo Skip.Tests is $(Skip.Tests)
-
 ##
 # Build
 ##

--- a/Build/step-build-libs.yml
+++ b/Build/step-build-libs.yml
@@ -2,6 +2,7 @@
 # Builds, tests & package all libraries.
 ##
 
+steps:
 ##
 # Build
 ##

--- a/Build/step-build-libs.yml
+++ b/Build/step-build-libs.yml
@@ -20,13 +20,12 @@ steps:
         /p:QsharpDocsOutDir=$(DocsOutDir)
         /p:DefineConstants=$(Assembly.Constants)
 
-
-
 ##
 # Test
 ##
 - task: DotNetCoreCLI@2
   displayName: 'Test Libraries'
+  condition: and(succeeded(), ne(variables['Skip.Tests'], 'true'))
   inputs:
     command: test
     projects: |

--- a/Build/step-build-libs.yml
+++ b/Build/step-build-libs.yml
@@ -3,6 +3,9 @@
 ##
 
 steps:
+- script: |
+    echo Skip.Tests is $(Skip.Tests)
+
 ##
 # Build
 ##

--- a/Build/step-build-magic.yml
+++ b/Build/step-build-magic.yml
@@ -21,6 +21,7 @@ steps:
 ##
 - task: DotNetCoreCLI@2
   displayName: 'Test Chemistry Magic'
+  condition: and(succeeded(), ne(variables['Skip.Tests'], 'true'))
   inputs:
     command: test
     projects: '$(LibrariesRootFolder)/Chemistry/tests/JupyterTests/JupyterTests.csproj'

--- a/Numerics/src/Integer/Inversion.qs
+++ b/Numerics/src/Integer/Inversion.qs
@@ -51,8 +51,8 @@ namespace Microsoft.Quantum.Arithmetic {
         }
         controlled (controls, ...) {
             let n = Length(xs!);
-            AssertIntEqual(Length(result!), 2*n,
-                           "Result register must contain 2n qubits.");
+            EqualityFactI(Length(result!), 2*n,
+                          "Result register must contain 2n qubits.");
             AssertAllZero(result!);
             using ((lhs, padding) = (Qubit[2*n], Qubit[n])) {
                 let paddedxs = LittleEndian(xs! + padding);

--- a/build.yml
+++ b/build.yml
@@ -14,8 +14,6 @@ variables:
   Assembly.Version: $(Build.BuildNumber)
   Nuget.Version: $(Assembly.Version)-preview
   Python.Version: $(Assembly.Version)
-  Skip.Tests: "false"
-
 
 jobs:
 - job: Windows

--- a/build.yml
+++ b/build.yml
@@ -14,6 +14,7 @@ variables:
   Assembly.Version: $(Build.BuildNumber)
   Nuget.Version: $(Assembly.Version)-preview
   Python.Version: $(Assembly.Version)
+  Skip.Tests: "false"
 
 
 jobs:


### PR DESCRIPTION
This PR adds a new build variable that allows for skipping tests with a queue-time setting. This is useful when quickly checking changes to build pipelines.