### PR TITLE
Fix incorrect Hamiltonian href

### DIFF
--- a/Chemistry/src/DataModel/JsonSerialization/FermionWavefunctionJsonConverter.cs
+++ b/Chemistry/src/DataModel/JsonSerialization/FermionWavefunctionJsonConverter.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Quantum.Chemistry.Json
     /// <summary>
     ///  This <see href="Newtonsoft.Json.JsonConverter" /> allows correctly serialized HamiltonianTerms.
     /// This terms are in general problematic because their keys are not strings, 
-    /// but <see href="HamiltonianTerm" /> instances, which <see href="Newtonsoft.Json" /> doesn't like by default.
+    /// but <see href="Microsoft.Quantum.Chemistry.Generic.HamiltonianTerm" /> instances, which <see href="Newtonsoft.Json" /> doesn't like by default.
     /// This converts the Dictionaries to List of Tuples, in which the first
     /// item of the tuple is the key and the second the value.
     /// </summary>


### PR DESCRIPTION
Warning produced by API docs build here:

https://ops.microsoft.com/#/repos/643865e0-2060-8ac7-69ae-90a4b9fe57da?tabName=builds

`Warning occurred: Invalid file link:(~/api/HamiltonianTerm)..`