### PR TITLE
Update packages to avoid downgrade errors

### DIFF
--- a/Chemistry/src/DataModel/DataModel.csproj
+++ b/Chemistry/src/DataModel/DataModel.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1603-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1804-beta" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="1.1.0" />

--- a/Chemistry/src/Jupyter/Jupyter.csproj
+++ b/Chemistry/src/Jupyter/Jupyter.csproj
@@ -26,9 +26,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Jupyter.Core" Version="1.2.20112" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.1910.1603-alpha" />
-    <PackageReference Include="Microsoft.Quantum.IQSharp.Core" Version="0.9.1909.3002" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.1910.1804-beta" />
+    <PackageReference Include="Microsoft.Quantum.IQSharp.Core" Version="0.10.1910.1804-beta" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
   </ItemGroup>
 
 

--- a/Chemistry/src/Runtime/Runtime.csproj
+++ b/Chemistry/src/Runtime/Runtime.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1603-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1804-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chemistry/tests/ChemistryTests/QSharpTests.csproj
+++ b/Chemistry/tests/ChemistryTests/QSharpTests.csproj
@@ -11,8 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1603-alpha" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.1910.1603-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1804-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.1910.1804-beta" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/Chemistry/tests/DataModelTests/CSharpTests.csproj
+++ b/Chemistry/tests/DataModelTests/CSharpTests.csproj
@@ -24,8 +24,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1603-alpha" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.1910.1603-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1804-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.1910.1804-beta" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />    
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Chemistry/tests/SamplesTests/SamplesTests.csproj
+++ b/Chemistry/tests/SamplesTests/SamplesTests.csproj
@@ -18,8 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1603-alpha" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.1910.1603-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1804-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.1910.1804-beta" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />    
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />

--- a/Chemistry/tests/SystemTests/SystemTests.csproj
+++ b/Chemistry/tests/SystemTests/SystemTests.csproj
@@ -18,8 +18,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1603-alpha" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.1910.1603-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1804-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.1910.1804-beta" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />

--- a/Numerics/src/Numerics.csproj
+++ b/Numerics/src/Numerics.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1603-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1804-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Numerics/tests/NumericsTests.csproj
+++ b/Numerics/tests/NumericsTests.csproj
@@ -15,8 +15,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1603-alpha" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.1910.1603-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1804-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.1910.1804-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/Standard/src/Standard.csproj
+++ b/Standard/src/Standard.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1603-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1804-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Standard/tests/Standard.Tests.csproj
+++ b/Standard/tests/Standard.Tests.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1603-alpha" />
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.1910.1603-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.10.1910.1804-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.10.1910.1804-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />


### PR DESCRIPTION
This PR parallels microsoft/qsharp-runtime#72 by updating package references to avoid downgrade errors with the upcoming 0.10 release.