### PR TITLE
Unit tests for new operations and functions in M.Q.Standard used to support QML

### DIFF
--- a/MachineLearning/src/Runtime/Runtime.csproj
+++ b/MachineLearning/src/Runtime/Runtime.csproj
@@ -2,6 +2,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
+    <AssemblyName>Microsoft.Quantum.MachineLearning.Runtime</AssemblyName>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <RunQDocGen>True</RunQDocGen>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Standard/src/Math/Functions.qs
+++ b/Standard/src/Math/Functions.qs
@@ -611,7 +611,7 @@ namespace Microsoft.Quantum.Math {
     }
 
 
-	/// # Summary
+    /// # Summary
     /// Returns the squared 2-norm of a vector.
     ///
     /// # Description
@@ -625,12 +625,12 @@ namespace Microsoft.Quantum.Math {
     /// # Output
     /// The squared 2-norm of `array`.
     function SquaredNorm(array : Double[]) : Double {
-		mutable ret = 0.0;
-		for (element in array) {
-			set ret += element * element;
-		}
-		return ret;
-	}
+        mutable ret = 0.0;
+        for (element in array) {
+            set ret += element * element;
+        }
+        return ret;
+    }
 
 
     /// # Summary

--- a/Standard/src/Measurement/Reset.qs
+++ b/Standard/src/Measurement/Reset.qs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.Measurement {
     }
 
 
-	/// # Summary
+    /// # Summary
     /// Sets a qubit to a given computational basis state by measuring the
     /// qubit and applying a bit flip if needed.
     ///
@@ -30,7 +30,7 @@ namespace Microsoft.Quantum.Measurement {
     /// # Remarks
     /// As an invariant of this operation, calling `M(q)` immediately
     /// after `SetToBasisState(result, q)` will return `result`.
-	operation SetToBasisState(desired : Result, target : Qubit) : Unit {
+    operation SetToBasisState(desired : Result, target : Qubit) : Unit {
         if (desired != M(target)) {
             X(target);
         }

--- a/Standard/tests/AmplitudeAmplificationTests.qs
+++ b/Standard/tests/AmplitudeAmplificationTests.qs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;

--- a/Standard/tests/Arithmetic/ReflectionTests.qs
+++ b/Standard/tests/Arithmetic/ReflectionTests.qs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Tests {
+    open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Arithmetic;
+    open Microsoft.Quantum.Diagnostics;
+
+    operation ManuallyReflectAboutFive(register : Qubit[]) : Unit is Adj + Ctl {
+        within {
+            X(register[1]);
+        } apply {
+            Controlled Z(register[0..1], register[2]);
+        }
+    }
+
+    operation ReflectAboutFiveUsingLibrary(register : Qubit[]) : Unit is Adj + Ctl {
+        let littleEndian = LittleEndian(register);
+        ReflectAboutInteger(5, littleEndian);
+    }
+
+    operation ReflectAboutIntegerTest() : Unit {
+        AssertOperationsEqualReferenced(3,
+            ReflectAboutFiveUsingLibrary,
+            ManuallyReflectAboutFive
+        );
+    }
+
+}

--- a/Standard/tests/ArrayTests.qs
+++ b/Standard/tests/ArrayTests.qs
@@ -156,7 +156,7 @@ namespace Microsoft.Quantum.Tests {
     function IsEmptyTest() : Unit {
         Fact(IsEmpty(new Int[0]), "Empty array marked as non-empty.");
         Fact(IsEmpty(new Qubit[0]), "Empty array marked as non-empty.");
-        Fact(IsEmpty(new (Double, Int -> String)[0]), "Empty array marked as non-empty.");
+        Fact(IsEmpty(new (Double, (Int -> String))[0]), "Empty array marked as non-empty.");
         Fact(not IsEmpty([PauliX, PauliZ]), "Non-empty array marked as empty.");
         Fact(not IsEmpty([""]), "Non-empty array marked as empty.");
     }

--- a/Standard/tests/ArrayTests.qs
+++ b/Standard/tests/ArrayTests.qs
@@ -154,11 +154,11 @@ namespace Microsoft.Quantum.Tests {
     }
 
     function IsEmptyTest() : Unit {
-        Fact(IsEmpty(new Int[0]));
-        Fact(IsEmpty(new Qubit[0]));
-        Fact(IsEmpty(new (Double, Int -> String)[0]));
-        Fact(not IsEmpty([PauliX, PauliZ]));
-        Fact(not IsEmpty([""]));
+        Fact(IsEmpty(new Int[0]), "Empty array marked as non-empty.");
+        Fact(IsEmpty(new Qubit[0]), "Empty array marked as non-empty.");
+        Fact(IsEmpty(new (Double, Int -> String)[0]), "Empty array marked as non-empty.");
+        Fact(not IsEmpty([PauliX, PauliZ]), "Non-empty array marked as empty.");
+        Fact(not IsEmpty([""]), "Non-empty array marked as empty.");
     }
 
 }

--- a/Standard/tests/ArrayTests.qs
+++ b/Standard/tests/ArrayTests.qs
@@ -153,6 +153,14 @@ namespace Microsoft.Quantum.Tests {
         }
     }
 
+    function IsEmptyTest() : Unit {
+        Fact(IsEmpty(new Int[0]));
+        Fact(IsEmpty(new Qubit[0]));
+        Fact(IsEmpty(new (Double, Int -> String)[0]));
+        Fact(not IsEmpty([PauliX, PauliZ]));
+        Fact(not IsEmpty([""]));
+    }
+
 }
 
 

--- a/Standard/tests/CombinatorTests.qs
+++ b/Standard/tests/CombinatorTests.qs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
 namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Canon;
@@ -347,6 +348,32 @@ namespace Microsoft.Quantum.Tests {
     operation ApplyIfElseBCATest() : Unit {
         AssertOperationsEqualReferenced(2, ApplyIfElseBCACase(true, _), ApplyToEachA(H, _));
         AssertOperationsEqualReferenced(2, ApplyIfElseBCACase(false, _), ApplyToEachA(X, _));
+    }
+
+    operation ApplyXToSecondQubit(qubits : Qubit[]) : Unit is Adj + Ctl {
+        X(qubits[1]);
+    }
+
+    operation ApplyToElementTest() : Unit {
+        AssertOperationsEqualReferenced(3,
+            ApplyToElement(X, 1, _),
+            ApplyXToSecondQubit
+        );
+        
+        AssertOperationsEqualReferenced(3,
+            ApplyToElementC(X, 1, _),
+            ApplyXToSecondQubit
+        );
+        
+        AssertOperationsEqualReferenced(3,
+            ApplyToElementA(X, 1, _),
+            ApplyXToSecondQubit
+        );
+        
+        AssertOperationsEqualReferenced(3,
+            ApplyToElementCA(X, 1, _),
+            ApplyXToSecondQubit
+        );
     }
 
 }

--- a/Standard/tests/Logical/PredicateTests.qs
+++ b/Standard/tests/Logical/PredicateTests.qs
@@ -98,7 +98,7 @@ namespace Microsoft.Quantum.Tests {
 
     function NearlyEqualDTest() : Unit {
         Fact(NearlyEqualD(1.0, 1.0), "Exactly equal numbers marked as not nearly equal.");
-        Fact(NearlyEqualDTest(1.0, 1.0 + 1e-15), "Nearly equal numbers marked as not nearly equal.");
+        Fact(NearlyEqualD(1.0, 1.0 + 1e-15), "Nearly equal numbers marked as not nearly equal.");
         Fact(not NearlyEqualD(1.0, 1000.0), "Not nearly equal numbers marked as nearly equal.");
     }
 

--- a/Standard/tests/Logical/PredicateTests.qs
+++ b/Standard/tests/Logical/PredicateTests.qs
@@ -96,4 +96,10 @@ namespace Microsoft.Quantum.Tests {
         Fact(not LessThanOrEqualL(32L, -13L), "LessThanOrEqualL returned wrong output.");
     }
 
+    function NearlyEqualDTest() : Unit {
+        Fact(NearlyEqualD(1.0, 1.0), "Exactly equal numbers marked as not nearly equal.");
+        Fact(NearlyEqualDTest(1.0, 1.0 + 1e-15), "Nearly equal numbers marked as not nearly equal.");
+        Fact(not NearlyEqualD(1.0, 1000.0), "Not nearly equal numbers marked as nearly equal.");
+    }
+
 }

--- a/Standard/tests/Math/MathTests.qs
+++ b/Standard/tests/Math/MathTests.qs
@@ -154,7 +154,7 @@ namespace Microsoft.Quantum.Canon {
     function SquaredNormTest() : Unit {
         NearEqualityFactD(SquaredNorm([2.0]), 4.0);
         NearEqualityFactD(SquaredNorm([1.0, 1.0]), 2.0);
-        NearEqualityFactD(SquaredNorm([3.0, 4.0], 25.0));
+        NearEqualityFactD(SquaredNorm([3.0, 4.0]), 25.0);
     }
     
 }

--- a/Standard/tests/Math/MathTests.qs
+++ b/Standard/tests/Math/MathTests.qs
@@ -150,6 +150,12 @@ namespace Microsoft.Quantum.Canon {
             }
         }
     }
+
+    function SquaredNormTest() : Unit {
+        NearEqualityFactD(SquaredNorm([2.0]), 4.0);
+        NearEqualityFactD(SquaredNorm([1.0, 1.0]), 2.0);
+        NearEqualityFactD(SquaredNorm([3.0, 4.0], 25.0));
+    }
     
 }
 

--- a/Standard/tests/Measurement/ResetTests.qs
+++ b/Standard/tests/Measurement/ResetTests.qs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Tests {
+    open Microsoft.Quantum.Measurement;
+    open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Diagnostics;
+
+    operation CheckSetToBasisState(desired : Result) : Unit {
+        using (q = Qubit()) {
+            Ry(0.1234, q);
+            SetToBasisState(desired, q);
+            AssertQubit(desired, q);
+            Reset(q);
+        }
+    }
+
+    operation SetToBasisStateTest() : Unit {
+        for (desired in [Zero, One]) {
+            CheckSetToBasisState(desired);
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds new unit tests to cover the functionality added to M.Q.Standard as a part of #176. In writing these tests, I also found and fixed a bug in ReflectAboutInteger that caused the operation to reflect about the binary negation of the given integer instead.