### PR TITLE
Add devcontainer config.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+    "image": "mcr.microsoft.com/quantum/iqsharp-base:latest",
+    "containerEnv": {
+        "IQSHARP_HOSTING_ENVIRONMENT": "libraries-devcontainer"
+    },
+    "extensions": [
+        "ms-dotnettools.csharp",
+        "quantum.quantum-devkit-vscode",
+        "ms-python.python"
+    ]
+}


### PR DESCRIPTION
This PR adds a .devcontainer configuration that can be used with either VS Code Remote Development or Visual Studio Online, making it easier to have reproducible builds for development and contributions. In particular, as per discussions with @KittyYeungQ, this will make it easier for first-time contributors to get up and running quickly (especially at events), without having to worry about local setups.