### PR TITLE
Update to Jupyter Core 1.3.

### DIFF
--- a/Chemistry/src/Jupyter/BroombridgeMagic.cs
+++ b/Chemistry/src/Jupyter/BroombridgeMagic.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.Jupyter.Core;
+using System.Threading.Tasks;
 using Microsoft.Quantum.Chemistry.Broombridge;
 
 namespace Microsoft.Quantum.Chemistry.Magic
 {
     /// <summary>
-    /// Jupyter Magic that loads and returns 
+    /// Jupyter Magic that loads and returns
     /// Broombridge electronic structure problem representation from a given .yaml file.
     /// </summary>
     public class BroombridgeMagic : MagicSymbol
@@ -23,7 +24,7 @@ namespace Microsoft.Quantum.Chemistry.Magic
         /// <summary>
         /// Loads the broombridge data from the given .yaml file and returns it.
         /// </summary>
-        public ExecutionResult Run(string input, IChannel channel)
+        public async Task<ExecutionResult> Run(string input, IChannel channel)
         {
             if (string.IsNullOrWhiteSpace(input))
             {
@@ -34,5 +35,5 @@ namespace Microsoft.Quantum.Chemistry.Magic
             var yamlData = Deserializers.DeserializeBroombridge(input).Raw;
             return yamlData.ToExecutionResult();
         }
-    }    
+    }
 }

--- a/Chemistry/src/Jupyter/ChemistryEncodeMagic.cs
+++ b/Chemistry/src/Jupyter/ChemistryEncodeMagic.cs
@@ -1,4 +1,5 @@
 ﻿
+using System.Threading.Tasks;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.Chemistry.Fermion;
 using Microsoft.Quantum.Chemistry.Paulis;
@@ -36,7 +37,7 @@ namespace Microsoft.Quantum.Chemistry.Magic
             public FermionWavefunction<int> Wavefunction { get; set; }
         }
 
-        public ExecutionResult Run(string input, IChannel channel)
+        public async Task<ExecutionResult> Run(string input, IChannel channel)
         {
             var args = JsonConvert.DeserializeObject<Arguments>(input);
 

--- a/Chemistry/src/Jupyter/FermionHamiltonianMagic.cs
+++ b/Chemistry/src/Jupyter/FermionHamiltonianMagic.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Quantum.Chemistry.Magic
         /// <summary>
         /// Simply calls AddRange on the hamiltonian to add each term from the list of fermionTerms
         /// </summary>
-        public ExecutionResult Run(string input, IChannel channel)
+        public async Task<ExecutionResult> Run(string input, IChannel channel)
         {
             if (string.IsNullOrWhiteSpace(input))
             {

--- a/Chemistry/src/Jupyter/FermionHamiltonianMagic.cs
+++ b/Chemistry/src/Jupyter/FermionHamiltonianMagic.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Linq;
 
 using Microsoft.Jupyter.Core;
@@ -59,7 +60,7 @@ namespace Microsoft.Quantum.Chemistry.Magic
         /// or from a ProblemDescription.
         /// If the fileName is specified, that will be used and the problemDescription will be ignored.
         /// </summary>
-        public ExecutionResult Run(string input, IChannel channel)
+        public async Task<ExecutionResult> Run(string input, IChannel channel)
         {
             if (string.IsNullOrWhiteSpace(input))
             {
@@ -79,7 +80,7 @@ namespace Microsoft.Quantum.Chemistry.Magic
             // This transformation requires us to pick a convention for converting a spin-orbital index to a single integer.
             // Let us pick one according to the formula `integer = 2 * orbitalIndex + spinIndex`.
             FermionHamiltonian fermionHamiltonian = orbitalIntegralHamiltonian.ToFermionHamiltonian(args.IndexConvention);
-            
+
             return fermionHamiltonian.ToExecutionResult();
         }
 
@@ -153,7 +154,7 @@ namespace Microsoft.Quantum.Chemistry.Magic
 
             var hamiltonian = args.Hamiltonian;
             hamiltonian.AddRange(args.FermionTerms.Select(t => (new HermitianFermionTerm(t.Item1.ToLadderSequence()), t.Item2.ToDoubleCoeff())));
-            
+
             return hamiltonian.ToExecutionResult();
         }
     }

--- a/Chemistry/src/Jupyter/Jupyter.csproj
+++ b/Chemistry/src/Jupyter/Jupyter.csproj
@@ -25,7 +25,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.2.29939" />
+    <PackageReference Include="Microsoft.Jupyter.Core" Version="1.3.52077" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/Chemistry/src/Jupyter/WavefunctionMagic.cs
+++ b/Chemistry/src/Jupyter/WavefunctionMagic.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.Chemistry.Broombridge;
@@ -48,7 +49,7 @@ namespace Microsoft.Quantum.Chemistry.Magic
             public IndexConvention IndexConvention { get; set; } = IndexConvention.UpDown;
 
             /// <summary>
-            /// The label of the wavefunctio within the ProblemDescription to use. 
+            /// The label of the wavefunctio within the ProblemDescription to use.
             /// If no label specified, it will return the Hartree-Fock state.
             /// </summary>
             [JsonProperty(PropertyName = "wavefunction_label")]
@@ -59,10 +60,10 @@ namespace Microsoft.Quantum.Chemistry.Magic
         /// Loads a InputState (WaveFunction) from the given Broombridge's ProblemDescription.
         /// The ProblemDescription can come from a .yaml broombridge file or can be passed down as parameter.
         /// If the wavefunctionLabel is specified, it will return the corresponding inputstate from the
-        /// ProblemDescription; if the wavefunctionLabel is not specified, then it returns 
+        /// ProblemDescription; if the wavefunctionLabel is not specified, then it returns
         /// the Hartree--Fock state.
         /// </summary>
-        public ExecutionResult Run(string input, IChannel channel)
+        public async Task<ExecutionResult> Run(string input, IChannel channel)
         {
             if (string.IsNullOrWhiteSpace(input))
             {
@@ -81,7 +82,7 @@ namespace Microsoft.Quantum.Chemistry.Magic
 
             return wavefunction.ToExecutionResult();
         }
-        
+
         /// <summary>
         /// Selects the ProblemDescription from the given arguments.
         /// If the fileName is specified, it will try to load the Broombridge data from the file

--- a/Chemistry/tests/JupyterTests/BroombridgeMagicTests.cs
+++ b/Chemistry/tests/JupyterTests/BroombridgeMagicTests.cs
@@ -16,37 +16,37 @@ namespace Microsoft.Quantum.Chemistry.Tests
     public class BroombridgeMagicTests
     {
         [Fact]
-        public void LoadNoFile()
+        public async void LoadNoFile()
         {
             var magic = new BroombridgeMagic();
             var channel = new MockChannel();
 
             Assert.Equal("%chemistry.broombridge", magic.Name);
-            var result = magic.Run("", channel);
+            var result = await magic.Run("", channel);
 
             Assert.Equal(ExecuteStatus.Error, result.Status);
         }
 
 
         [Fact]
-        public void LoadInvalidFile()
+        public async void LoadInvalidFile()
         {
             var filename = "foo_bar.yaml";
             var magic = new BroombridgeMagic();
             var channel = new MockChannel();
 
-            Assert.Throws<FileNotFoundException>(() => magic.Run(filename, channel));
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await magic.Run(filename, channel));
         }
 
 
         [Fact]
-        public void LoadBroombridgeFile()
+        public async void LoadBroombridgeFile()
         {
             var filename = "broombridge_v0.2.yaml";
             var magic = new BroombridgeMagic();
             var channel = new MockChannel();
 
-            var result = magic.Run(filename, channel);
+            var result = await magic.Run(filename, channel);
             var broombridge = (V0_2.Data)result.Output;
             Assert.Equal(ExecuteStatus.Ok, result.Status);
             Assert.Equal("0.2", broombridge.Format.Version);

--- a/Chemistry/tests/JupyterTests/ChemistryEncodeMagicTests.cs
+++ b/Chemistry/tests/JupyterTests/ChemistryEncodeMagicTests.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Jupyter.Core;
 using Microsoft.Quantum.Chemistry.Broombridge;
 using Microsoft.Quantum.Chemistry.Fermion;
@@ -22,7 +23,7 @@ namespace Microsoft.Quantum.Chemistry.Tests
 
 
         [Fact]
-        public void EncodeBroombridge()
+        public async Task EncodeBroombridge()
         {
             var (magic, channel) = Init();
             var fileName = "broombridge_v0.2.yaml";
@@ -41,7 +42,7 @@ namespace Microsoft.Quantum.Chemistry.Tests
                 WavefunctionLabel = "UCCSD |G>",
                 IndexConvention = IndexConvention.HalfUp
             });
-            var wavefunction = (FermionWavefunction<int>)wavefunctionMagic.Run(args, channel).Output;
+            var wavefunction = (FermionWavefunction<int>)((await wavefunctionMagic.Run(args, channel)).Output);
 
             args = JsonConvert.SerializeObject(new ChemistryEncodeMagic.Arguments
             {
@@ -49,7 +50,7 @@ namespace Microsoft.Quantum.Chemistry.Tests
                 Wavefunction = wavefunction
             });
 
-            var result = magic.Run(args, channel);
+            var result = await magic.Run(args, channel);
             Assert.Equal(ExecuteStatus.Ok, result.Status);
             var data = result.Output as JordanWignerEncodingData;
 


### PR DESCRIPTION
This PR parallels https://github.com/microsoft/QuantumKatas/pull/319 and updates the Microsoft.Quantum.Chemistry.Jupyter package to use Jupyter Core 1.3.