### PR TITLE
Fix #261.

### DIFF
--- a/Chemistry/src/DataModel/Extensions.cs
+++ b/Chemistry/src/DataModel/Extensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Quantum.Chemistry
 
         #region Extension methods
         /// <summary>
-        /// Computes the L_p norm of coefficicients of all terms in a Hamiltonian.
+        /// Computes the L_p norm of coefficients of all terms in a Hamiltonian.
         /// </summary>
         /// <param name="power">Selects type of norm.</param>
         /// <returns>L_p norm of Hamiltonian coefficients.</returns>

--- a/MachineLearning/src/Classification.qs
+++ b/MachineLearning/src/Classification.qs
@@ -80,7 +80,10 @@ namespace Microsoft.Quantum.MachineLearning {
         nMeasurements : Int
     )
     : Double[] {
-        let effectiveTolerance = tolerance / IntAsDouble(Length(model::Structure));
+        let effectiveTolerance =
+            IsEmpty(model::Structure)
+            ? tolerance
+            | tolerance / IntAsDouble(Length(model::Structure));
         return ForEach(
             EstimateClassificationProbability(
                 effectiveTolerance, model, _, nMeasurements


### PR DESCRIPTION
This PR uses an `effectiveTolerance` equal to `tolerance` during QML training on an empty model (that is, just measuring the output of an `InputEncoder`).