### PR TITLE
Simulate ApplyAnd and ApplyLowDepthAnd classically

### DIFF
--- a/Standard/src/Canon/And.cs
+++ b/Standard/src/Canon/And.cs
@@ -10,11 +10,11 @@ using Microsoft.Quantum.Simulation.Simulators;
 
 namespace Microsoft.Quantum.Canon
 {
-    /// <summary>
-    /// Uses CCNOT implementation when executed using ToffoliSimulator.
-    /// </summary>
     public partial class ApplyAnd
     {
+        /// <summary>
+        /// Uses CCNOT implementation when executed using ToffoliSimulator.
+        /// </summary>
         public class Native : ApplyAnd
         {
             private ToffoliSimulator? simulator = null;
@@ -45,15 +45,15 @@ namespace Microsoft.Quantum.Canon
         }
     }
 
-    /// <summary>
-    /// Uses CCNOT implementation when executed using ToffoliSimulator.
-    /// </summary>
     public partial class ApplyLowDepthAnd
     {
+        /// <summary>
+        /// Uses CCNOT implementation when executed using ToffoliSimulator.
+        /// </summary>
         public class Native : ApplyLowDepthAnd
         {
-            private ToffoliSimulator simulator = null;
-            protected CCNOT CCNOT { get; set; } = null;
+            private ToffoliSimulator? simulator = null;
+            protected CCNOT? CCNOT { get; set; } = null;
 
             public Native(IOperationFactory m) : base(m)
             {

--- a/Standard/src/Canon/And.cs
+++ b/Standard/src/Canon/And.cs
@@ -1,5 +1,7 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+
+#nullable enable
 
 using System;
 using Microsoft.Quantum.Intrinsic;
@@ -15,8 +17,8 @@ namespace Microsoft.Quantum.Canon
     {
         public class Native : ApplyAnd
         {
-            private ToffoliSimulator simulator = null;
-            protected CCNOT CCNOT { get; set; } = null;
+            private ToffoliSimulator? simulator = null;
+            protected CCNOT? CCNOT { get; set; } = null;
 
             public Native(IOperationFactory m) : base(m)
             {

--- a/Standard/src/Canon/And.cs
+++ b/Standard/src/Canon/And.cs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Quantum.Intrinsic;
+using Microsoft.Quantum.Simulation.Core;
+using Microsoft.Quantum.Simulation.Simulators;
+
+namespace Microsoft.Quantum.Canon
+{
+    /// <summary>
+    /// Uses CCNOT implementation when executed using ToffoliSimulator.
+    /// </summary>
+    public partial class ApplyAnd
+    {
+        public class Native : ApplyAnd
+        {
+            private ToffoliSimulator simulator = null;
+            protected CCNOT CCNOT { get; set; } = null;
+
+            public Native(IOperationFactory m) : base(m)
+            {
+                simulator = m as ToffoliSimulator;
+            }
+
+            public override void Init()
+            {
+                base.Init();
+
+                if (simulator != null)
+                {
+                    CCNOT = Factory.Get<CCNOT>(typeof(CCNOT));
+                }
+            }
+
+            public override Func<(Qubit, Qubit, Qubit), QVoid> Body => CCNOT?.Body ?? base.Body;
+
+            public override Func<(Qubit, Qubit, Qubit), QVoid> AdjointBody => CCNOT?.AdjointBody ?? base.AdjointBody;
+
+            public override Func<(IQArray<Qubit>, (Qubit, Qubit, Qubit)), QVoid> ControlledBody => CCNOT?.ControlledBody ?? base.ControlledBody;
+
+            public override Func<(IQArray<Qubit>, (Qubit, Qubit, Qubit)), QVoid> ControlledAdjointBody => CCNOT?.ControlledAdjointBody ?? base.ControlledAdjointBody;
+        }
+    }
+
+    /// <summary>
+    /// Uses CCNOT implementation when executed using ToffoliSimulator.
+    /// </summary>
+    public partial class ApplyLowDepthAnd
+    {
+        public class Native : ApplyLowDepthAnd
+        {
+            private ToffoliSimulator simulator = null;
+            protected CCNOT CCNOT { get; set; } = null;
+
+            public Native(IOperationFactory m) : base(m)
+            {
+                simulator = m as ToffoliSimulator;
+            }
+
+            public override void Init()
+            {
+                base.Init();
+
+                if (simulator != null)
+                {
+                    CCNOT = Factory.Get<CCNOT>(typeof(CCNOT));
+                }
+            }
+
+            public override Func<(Qubit, Qubit, Qubit), QVoid> Body => CCNOT?.Body ?? base.Body;
+
+            public override Func<(Qubit, Qubit, Qubit), QVoid> AdjointBody => CCNOT?.AdjointBody ?? base.AdjointBody;
+
+            public override Func<(IQArray<Qubit>, (Qubit, Qubit, Qubit)), QVoid> ControlledBody => CCNOT?.ControlledBody ?? base.ControlledBody;
+
+            public override Func<(IQArray<Qubit>, (Qubit, Qubit, Qubit)), QVoid> ControlledAdjointBody => CCNOT?.ControlledAdjointBody ?? base.ControlledAdjointBody;
+        }
+    }
+}

--- a/Standard/tests/ANDTests.qs
+++ b/Standard/tests/ANDTests.qs
@@ -45,6 +45,7 @@ namespace Microsoft.Quantum.Tests {
     }
 
     @Test("QuantumSimulator")
+    @Test("ToffoliSimulator")
     operation ApplyAndTest() : Unit {
         for (p1 in [false, true]) {
             for (p2 in [false, true]) {
@@ -56,6 +57,7 @@ namespace Microsoft.Quantum.Tests {
     }
 
     @Test("QuantumSimulator")
+    @Test("ToffoliSimulator")
     operation ControlledApplyAndTest() : Unit {
         for (numControls in 3..5) {
             for (assignment in 0..2^numControls - 1) {


### PR DESCRIPTION
This PR overrides the behaviour of `ApplyAnd` and `ApplyLowDepthAnd` to use the `CCNOT` behaviour when used with `ToffoliSimulator`.