### PR TITLE
Disable .snupkg generation for Metapackage

### DIFF
--- a/Chemistry/src/Metapackage/Metapackage.csproj
+++ b/Chemistry/src/Metapackage/Metapackage.csproj
@@ -20,7 +20,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedAllSources>true</EmbedAllSources>
-    <IncludeSymbols>true</IncludeSymbols>
+    <IncludeSymbols>false</IncludeSymbols>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb;.xml</AllowedOutputExtensionsInPackageBuildOutputFolder>


### PR DESCRIPTION
The Metapackage project contains no code, so disable creating the .snupkg symbols package for that project.