### PR TITLE
Tweak tests to decrease their duration

### DIFF
--- a/Standard/tests/ANDTests.qs
+++ b/Standard/tests/ANDTests.qs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-namespace Microsoft.Quantum.Tests {
+namespace Microsoft.Quantum.ANDTests {
     open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Convert;

--- a/Standard/tests/ArithmeticTests.qs
+++ b/Standard/tests/ArithmeticTests.qs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-namespace Microsoft.Quantum.Tests {
+namespace Microsoft.Quantum.ArithmeticTests {
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Math;
@@ -41,13 +41,14 @@ namespace Microsoft.Quantum.Tests {
     /// # Summary
     /// Exhaustively tests Microsoft.Quantum.Artihmetic.IncrementByInteger
     /// on 4 qubits
+    @Test("QuantumSimulator")
     operation IncrementByIntegerTest () : Unit {
         
         let numberOfQubits = 4;
         
-        for (summand1 in 0 .. 2 ^ numberOfQubits - 1) {
+        for (summand1 in [0, 3, 9, 2 ^ numberOfQubits - 1]) {
             
-            for (summand2 in -2 ^ numberOfQubits .. 2 ^ numberOfQubits) {
+            for (summand2 in [-2 ^ numberOfQubits, -1, 0, 15, 32, 2 ^ numberOfQubits]) {
                 IncrementByIntegerTestHelper(summand1, summand2, numberOfQubits);
             }
         }
@@ -82,16 +83,18 @@ namespace Microsoft.Quantum.Tests {
     
     
     /// # Summary
-    /// Exhaustively tests Microsoft.Quantum.Arithmetic.IncrementByModularInteger
+    /// Tests Microsoft.Quantum.Arithmetic.IncrementByModularInteger
     /// on 4 qubits with modulus 13
+    @Test("QuantumSimulator")
     operation IncrementByModularIntegerTest () : Unit {
         
         let numberOfQubits = 4;
         let modulus = 13;
+        let scenarios = [0, 6, modulus - 2, modulus - 1];
         
-        for (summand1 in 0 .. modulus - 1) {
+        for (summand1 in scenarios) {
             
-            for (summand2 in 0 .. modulus - 1) {
+            for (summand2 in scenarios) {
                 IncrementByModularIntegerHelper(summand1, summand2, modulus, numberOfQubits);
             }
         }
@@ -116,18 +119,20 @@ namespace Microsoft.Quantum.Tests {
     
     
     /// # Summary
-    /// Exhaustively tests Microsoft.Quantum.Canon.ModularAddProductLE
+    /// Tests Microsoft.Quantum.Canon.ModularAddProductLE
     /// on 4 qubits with modulus 13
+    @Test("QuantumSimulator")
     operation MultiplyAndAddByModularIntegerTest () : Unit {
         
         let numberOfQubits = 4;
         let modulus = 13;
+        let scenarios = [0, 6, modulus - 2, modulus - 1];
         
-        for (summand in 0 .. modulus - 1) {
+        for (summand in scenarios) {
             
-            for (multiplier1 in 0 .. modulus - 1) {
+            for (multiplier1 in scenarios) {
                 
-                for (multiplier2 in 0 .. modulus - 1) {
+                for (multiplier2 in scenarios) {
                     MultiplyAndAddByModularIntegerTestHelper(summand, multiplier1, multiplier2, modulus, numberOfQubits);
                 }
             }
@@ -152,16 +157,18 @@ namespace Microsoft.Quantum.Tests {
     
     
     /// # Summary
-    /// Exhaustively tests Microsoft.Quantum.Canon.ModularMultiplyByConstantLE
+    /// Tests Microsoft.Quantum.Canon.ModularMultiplyByConstantLE
     /// on 4 qubits with modulus 13
+    @Test("QuantumSimulator")
     operation MultiplyByModularIntegerTest () : Unit {
         
         let numberOfQubits = 4;
         let modulus = 13;
+        let scenarios = [0, 6, modulus - 2, modulus - 1];
         
-        for (multiplier1 in 0 .. modulus - 1) {
+        for (multiplier1 in scenarios) {
             
-            for (multiplier2 in 0 .. modulus - 1) {
+            for (multiplier2 in scenarios) {
                 MultiplyByModularIntegerTestHelper(multiplier1, multiplier2, modulus, numberOfQubits);
             }
         }

--- a/Standard/tests/IntegerTests.qs
+++ b/Standard/tests/IntegerTests.qs
@@ -85,7 +85,7 @@ namespace Microsoft.Quantum.Arithmetic {
 
     @Test("ToffoliSimulator")
     operation RippleCarryAdderDExhaustiveTestReversible () : Unit {
-        for (numberOfQubits in 3..6) {
+        for (numberOfQubits in [3, 6]) {
             IntegerAdderExhaustiveTestHelper (RippleCarryAdderD, numberOfQubits);
         }
     }
@@ -108,7 +108,7 @@ namespace Microsoft.Quantum.Arithmetic {
 
     @Test("ToffoliSimulator")
     operation RippleCarryAdderCDKMExhaustiveTestReversible () : Unit {
-        for (numberOfQubits in 3..6) {
+        for (numberOfQubits in [3, 6]) {
             IntegerAdderExhaustiveTestHelper (RippleCarryAdderCDKM, numberOfQubits);
         }
     }
@@ -121,7 +121,7 @@ namespace Microsoft.Quantum.Arithmetic {
 
     @Test("ToffoliSimulator")
     operation RippleCarryAdderTTKExhaustiveTestReversible () : Unit {
-        for (numberOfQubits in 1..6){
+        for (numberOfQubits in [4, 6]){
             IntegerAdderExhaustiveTestHelper (RippleCarryAdderTTK, numberOfQubits);
         }
     }
@@ -195,7 +195,7 @@ namespace Microsoft.Quantum.Arithmetic {
 
     @Test("ToffoliSimulator")
     operation RippleCarryAdderNoCarryTTKExhaustiveTestReversible () : Unit {
-        for (numberOfQubits in 1..6) {
+        for (numberOfQubits in [1, 3, 6]) {
             IntegerAdderNoCarryExhaustiveTestHelper (RippleCarryAdderNoCarryTTK, numberOfQubits);
         }
     }

--- a/Standard/tests/QcvvTests.cs
+++ b/Standard/tests/QcvvTests.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Quantum.Tests
             {
                 var count = 0;
                 sim.OnLog += (_) => count++;
+                sim.DisableLogToConsole();
 
                 EstimateFrequencyEmulationTest.Run(sim).Wait();
                 Assert.Equal(expected, count);

--- a/Standard/tests/QeccTests.qs
+++ b/Standard/tests/QeccTests.qs
@@ -364,7 +364,7 @@ namespace Microsoft.Quantum.Tests {
     /// since corrections would make the output magic state
     /// less accurate, compared to post-selection on zero syndrome.
     operation KDTest () : Unit {
-        
+
         using (rm = Qubit[15]) {
             ApplyToEach(Ry(PI() / 4.0, _), rm);
             let acc = KnillDistill(rm);
@@ -377,7 +377,7 @@ namespace Microsoft.Quantum.Tests {
             AssertQubit(Zero, rm[0]);
             
             // Cases where a single magic state is wrong
-            for (idx in 0 .. 14) {
+            for (idx in [0, 8, 14]) {
                 ResetAll(rm);
                 ApplyToEach(Ry(PI() / 4.0, _), rm);
                 Y(rm[idx]);
@@ -390,20 +390,18 @@ namespace Microsoft.Quantum.Tests {
             }
             
             // Cases where two magic states are wrong
-            for (idxFirst in 0 .. 13) {
+            for ((idxFirst, idxSecond) in [(0,1), (0, 3), (0,14), (4, 13), (13, 14)]) {
                 
-                for (idxSecond in idxFirst + 1 .. 14) {
-                    ResetAll(rm);
-                    ApplyToEach(Ry(PI() / 4.0, _), rm);
-                    Y(rm[idxFirst]);
-                    Y(rm[idxSecond]);
-                    let acc1 = KnillDistill(rm);
+                ResetAll(rm);
+                ApplyToEach(Ry(PI() / 4.0, _), rm);
+                Y(rm[idxFirst]);
+                Y(rm[idxSecond]);
+                let acc1 = KnillDistill(rm);
                     
-                    // Check that the rough magic states were
-                    // successfully reset to |0〉.
-                    ApplyToEach(AssertQubit(Zero, _), Rest(rm));
-                    EqualityFactB(false, acc1, $"Distillation missed a pair error");
-                }
+                // Check that the rough magic states were
+                // successfully reset to |0〉.
+                ApplyToEach(AssertQubit(Zero, _), Rest(rm));
+                EqualityFactB(false, acc1, $"Distillation missed a pair error");
             }
             
             ResetAll(rm);


### PR DESCRIPTION
Running all the standard tests could take 15+ mins, this changes tweaks some of the tests to instead of doing exhaustive validations, simply take some representative cases.