### PR TITLE
Update C# callable implementations to use new naming conventions

### DIFF
--- a/Build/props/tests.props
+++ b/Build/props/tests.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.12.20081417-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.12.200824007-vnext" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/Build/props/tests.props
+++ b/Build/props/tests.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.12.200824007-vnext" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.12.20082515-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/Chemistry/src/Runtime/Runtime.csproj
+++ b/Chemistry/src/Runtime/Runtime.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.200824007-vnext" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20082515-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chemistry/src/Runtime/Runtime.csproj
+++ b/Chemistry/src/Runtime/Runtime.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082035-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20082035-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.200824007-vnext" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chemistry/tests/ChemistryTests/QSharpTests.csproj
+++ b/Chemistry/tests/ChemistryTests/QSharpTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
 
   <Import Project="..\..\..\Build\props\tests.props" />
 

--- a/Chemistry/tests/ChemistryTests/QSharpTests.csproj
+++ b/Chemistry/tests/ChemistryTests/QSharpTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082035-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
 
   <Import Project="..\..\..\Build\props\tests.props" />
 

--- a/Chemistry/tests/SystemTests/SystemTests.csproj
+++ b/Chemistry/tests/SystemTests/SystemTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
 
   <Import Project="..\..\..\Build\props\tests.props" />
 

--- a/Chemistry/tests/SystemTests/SystemTests.csproj
+++ b/Chemistry/tests/SystemTests/SystemTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082035-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
 
   <Import Project="..\..\..\Build\props\tests.props" />
 

--- a/MachineLearning/src/MachineLearning.csproj
+++ b/MachineLearning/src/MachineLearning.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082035-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.MachineLearning</AssemblyName>

--- a/MachineLearning/src/MachineLearning.csproj
+++ b/MachineLearning/src/MachineLearning.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.MachineLearning</AssemblyName>

--- a/MachineLearning/tests/MachineLearningTests.csproj
+++ b/MachineLearning/tests/MachineLearningTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082035-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/MachineLearning/tests/MachineLearningTests.csproj
+++ b/MachineLearning/tests/MachineLearningTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Numerics/src/Numerics.csproj
+++ b/Numerics/src/Numerics.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.200824007-vnext" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20082515-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Numerics/src/Numerics.csproj
+++ b/Numerics/src/Numerics.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082035-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20082035-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.200824007-vnext" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Numerics/tests/NumericsTests.csproj
+++ b/Numerics/tests/NumericsTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082035-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Numerics/tests/NumericsTests.csproj
+++ b/Numerics/tests/NumericsTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Standard/src/Canon/And.cs
+++ b/Standard/src/Canon/And.cs
@@ -25,23 +25,23 @@ namespace Microsoft.Quantum.Canon
                 simulator = m as ToffoliSimulator;
             }
 
-            public override void Init()
+            public override void __Init__()
             {
-                base.Init();
+                base.__Init__();
 
                 if (simulator != null)
                 {
-                    CCNOT = Factory.Get<CCNOT>(typeof(CCNOT));
+                    CCNOT = __Factory__.Get<CCNOT>(typeof(CCNOT));
                 }
             }
 
-            public override Func<(Qubit, Qubit, Qubit), QVoid> Body => CCNOT?.Body ?? base.Body;
+            public override Func<(Qubit, Qubit, Qubit), QVoid> __Body__ => CCNOT?.__Body__ ?? base.__Body__;
 
-            public override Func<(Qubit, Qubit, Qubit), QVoid> AdjointBody => CCNOT?.AdjointBody ?? base.AdjointBody;
+            public override Func<(Qubit, Qubit, Qubit), QVoid> __AdjointBody__ => CCNOT?.__AdjointBody__ ?? base.__AdjointBody__;
 
-            public override Func<(IQArray<Qubit>, (Qubit, Qubit, Qubit)), QVoid> ControlledBody => CCNOT?.ControlledBody ?? base.ControlledBody;
+            public override Func<(IQArray<Qubit>, (Qubit, Qubit, Qubit)), QVoid> __ControlledBody__ => CCNOT?.__ControlledBody__ ?? base.__ControlledBody__;
 
-            public override Func<(IQArray<Qubit>, (Qubit, Qubit, Qubit)), QVoid> ControlledAdjointBody => CCNOT?.ControlledAdjointBody ?? base.ControlledAdjointBody;
+            public override Func<(IQArray<Qubit>, (Qubit, Qubit, Qubit)), QVoid> __ControlledAdjointBody__ => CCNOT?.__ControlledAdjointBody__ ?? base.__ControlledAdjointBody__;
         }
     }
 
@@ -60,23 +60,23 @@ namespace Microsoft.Quantum.Canon
                 simulator = m as ToffoliSimulator;
             }
 
-            public override void Init()
+            public override void __Init__()
             {
-                base.Init();
+                base.__Init__();
 
                 if (simulator != null)
                 {
-                    CCNOT = Factory.Get<CCNOT>(typeof(CCNOT));
+                    CCNOT = __Factory__.Get<CCNOT>(typeof(CCNOT));
                 }
             }
 
-            public override Func<(Qubit, Qubit, Qubit), QVoid> Body => CCNOT?.Body ?? base.Body;
+            public override Func<(Qubit, Qubit, Qubit), QVoid> __Body__ => CCNOT?.__Body__ ?? base.__Body__;
 
-            public override Func<(Qubit, Qubit, Qubit), QVoid> AdjointBody => CCNOT?.AdjointBody ?? base.AdjointBody;
+            public override Func<(Qubit, Qubit, Qubit), QVoid> __AdjointBody__ => CCNOT?.__AdjointBody__ ?? base.__AdjointBody__;
 
-            public override Func<(IQArray<Qubit>, (Qubit, Qubit, Qubit)), QVoid> ControlledBody => CCNOT?.ControlledBody ?? base.ControlledBody;
+            public override Func<(IQArray<Qubit>, (Qubit, Qubit, Qubit)), QVoid> __ControlledBody__ => CCNOT?.__ControlledBody__ ?? base.__ControlledBody__;
 
-            public override Func<(IQArray<Qubit>, (Qubit, Qubit, Qubit)), QVoid> ControlledAdjointBody => CCNOT?.ControlledAdjointBody ?? base.ControlledAdjointBody;
+            public override Func<(IQArray<Qubit>, (Qubit, Qubit, Qubit)), QVoid> __ControlledAdjointBody__ => CCNOT?.__ControlledAdjointBody__ ?? base.__ControlledAdjointBody__;
         }
     }
 }

--- a/Standard/src/Characterization/EstimateFrequency.cs
+++ b/Standard/src/Characterization/EstimateFrequency.cs
@@ -43,26 +43,26 @@ namespace Microsoft.Quantum.Characterization
                 this.Simulator = m as QuantumSimulator;
             }
 
-            public override void Init()
+            public override void __Init__()
             {
-                base.Init();
+                base.__Init__();
 
-                this.Allocate = this.Factory.Get<Allocate>(typeof(Microsoft.Quantum.Intrinsic.Allocate));
-                this.Release = this.Factory.Get<Release>(typeof(Microsoft.Quantum.Intrinsic.Release));
-                this.ResetAll = this.Factory.Get<ResetAll>(typeof(Microsoft.Quantum.Intrinsic.ResetAll));
+                this.Allocate = this.__Factory__.Get<Allocate>(typeof(Microsoft.Quantum.Intrinsic.Allocate));
+                this.Release = this.__Factory__.Get<Release>(typeof(Microsoft.Quantum.Intrinsic.Release));
+                this.ResetAll = this.__Factory__.Get<ResetAll>(typeof(Microsoft.Quantum.Intrinsic.ResetAll));
             }
 
             /// <summary>
             /// Overrides the body to do the emulation when possible. If emulation is not possible, then
             /// it just invokes the default Q# implementation.
             /// </summary>
-            public override Func<(IAdjointable, ICallable, long, long), double> Body => (_args) =>
+            public override Func<(IAdjointable, ICallable, long, long), double> __Body__ => (_args) =>
             {
                 var (preparation, measure, count, samples) = _args;
 
                 if (!CanEmulate(preparation, measure))
                 {
-                    return base.Body(_args);
+                    return base.__Body__(_args);
                 }
 
                 // Find the basis used for measurement from the captured Paulis:

--- a/Standard/src/Diagnostics/Emulation/AllowOperationCalls.cs
+++ b/Standard/src/Diagnostics/Emulation/AllowOperationCalls.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Quantum.Diagnostics
                 Simulator = m as SimulatorBase;
             }
 
-            public override Func<(long, IUnitary, string), QVoid> Body => _args =>
+            public override Func<(long, IUnitary, string), QVoid> __Body__ => _args =>
             {
                 if (Simulator == null) return QVoid.Instance;
 
@@ -97,7 +97,7 @@ namespace Microsoft.Quantum.Diagnostics
                 return QVoid.Instance;
             };
 
-            public override Func<(long, IUnitary, string), QVoid> AdjointBody => _args =>
+            public override Func<(long, IUnitary, string), QVoid> __AdjointBody__ => _args =>
             {
                 if (Simulator == null) return QVoid.Instance;
 

--- a/Standard/src/Diagnostics/Emulation/AllowQubitAllocations.cs
+++ b/Standard/src/Diagnostics/Emulation/AllowQubitAllocations.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.Diagnostics
                 Simulator = m as SimulatorBase;
             }
 
-            public override Func<(long, string), QVoid> Body => _args =>
+            public override Func<(long, string), QVoid> __Body__ => _args =>
             {
                 if (Simulator == null) return QVoid.Instance;
 
@@ -68,7 +68,7 @@ namespace Microsoft.Quantum.Diagnostics
                 return QVoid.Instance;
             };
 
-            public override Func<(long, string), QVoid> AdjointBody => _args =>
+            public override Func<(long, string), QVoid> __AdjointBody__ => _args =>
             {
                 if (Simulator == null) return QVoid.Instance;
 

--- a/Standard/src/Diagnostics/Emulation/Internal.cs
+++ b/Standard/src/Diagnostics/Emulation/Internal.cs
@@ -73,14 +73,14 @@ namespace Microsoft.Quantum.Diagnostics
                 return QVoid.Instance;
             }
 
-            public override Func<(IQArray<Qubit>, IQArray<Qubit>), QVoid> Body => __in__ =>
+            public override Func<(IQArray<Qubit>, IQArray<Qubit>), QVoid> __Body__ => __in__ =>
             {
                 var (reference, target) = __in__;
                 return Simulator switch
                 {
                     QuantumSimulator sim => this.DumpUnitaryFromChoiState(sim, reference, target),
                     // TODO: Add other simulators here as appropriate.
-                    _ => base.Body(__in__)
+                    _ => base.__Body__(__in__)
                 };
             };
 

--- a/Standard/src/Standard.csproj
+++ b/Standard/src/Standard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.200824007-vnext" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20082515-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>

--- a/Standard/src/Standard.csproj
+++ b/Standard/src/Standard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082035-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20082035-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.200824007-vnext" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>

--- a/Standard/tests/Arrays/MapTests.cs
+++ b/Standard/tests/Arrays/MapTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Quantum.Tests
             var op = new Microsoft.Quantum.Arrays.ForEach<Qubit, Result>(new QuantumSimulator());
             var baseOp = new Microsoft.Quantum.Intrinsic.M(new QuantumSimulator());
             IQArray<Qubit> targets = new QArray<Qubit>(new Qubit[] { });
-            var args = op.__dataIn((baseOp, targets));
+            var args = op.__DataIn__((baseOp, targets));
             var expected = new RuntimeMetadata()
             {
                 Label = "ForEach",

--- a/Standard/tests/Canon/ApplyToEachTests.cs
+++ b/Standard/tests/Canon/ApplyToEachTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Quantum.Tests
             var op = new Microsoft.Quantum.Canon.ApplyToEach<Qubit>(new QuantumSimulator());
             var baseOp = new Microsoft.Quantum.Intrinsic.I(new QuantumSimulator());
             IQArray<Qubit> targets = new QArray<Qubit>(new Qubit[] { });
-            var args = op.__dataIn((baseOp, targets));
+            var args = op.__DataIn__((baseOp, targets));
             var expected = new RuntimeMetadata()
             {
                 Label = "ApplyToEach",
@@ -39,7 +39,7 @@ namespace Microsoft.Quantum.Tests
             var op = new Microsoft.Quantum.Canon.ApplyToEachC<Qubit>(new QuantumSimulator());
             var baseOp = new Microsoft.Quantum.Intrinsic.I(new QuantumSimulator());
             IQArray<Qubit> targets = new QArray<Qubit>(new Qubit[] { });
-            var args = op.__dataIn((baseOp, targets));
+            var args = op.__DataIn__((baseOp, targets));
             var expected = new RuntimeMetadata()
             {
                 Label = "ApplyToEachC",
@@ -56,7 +56,7 @@ namespace Microsoft.Quantum.Tests
             var op = new Microsoft.Quantum.Canon.ApplyToEachA<Qubit>(new QuantumSimulator());
             var baseOp = new Microsoft.Quantum.Intrinsic.I(new QuantumSimulator());
             IQArray<Qubit> targets = new QArray<Qubit>(new Qubit[] { });
-            var args = op.__dataIn((baseOp, targets));
+            var args = op.__DataIn__((baseOp, targets));
             var expected = new RuntimeMetadata()
             {
                 Label = "ApplyToEachA",
@@ -73,7 +73,7 @@ namespace Microsoft.Quantum.Tests
             var op = new Microsoft.Quantum.Canon.ApplyToEachCA<Qubit>(new QuantumSimulator());
             var baseOp = new Microsoft.Quantum.Intrinsic.I(new QuantumSimulator());
             IQArray<Qubit> targets = new QArray<Qubit>(new Qubit[] { });
-            var args = op.__dataIn((baseOp, targets));
+            var args = op.__DataIn__((baseOp, targets));
             var expected = new RuntimeMetadata()
             {
                 Label = "ApplyToEachCA",

--- a/Standard/tests/Canon/CommonGatesTests.cs
+++ b/Standard/tests/Canon/CommonGatesTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.Tests
             var control = new MockQubit(1);
             var target = new MockQubit(0);
             var op = new Microsoft.Quantum.Canon.CX(new QuantumSimulator());
-            var args = op.__dataIn((control, target));
+            var args = op.__DataIn__((control, target));
             var expected = new RuntimeMetadata()
             {
                 Label = "X",
@@ -47,7 +47,7 @@ namespace Microsoft.Quantum.Tests
             var control = new MockQubit(1);
             var target = new MockQubit(0);
             var op = new Microsoft.Quantum.Canon.CY(new QuantumSimulator());
-            var args = op.__dataIn((control, target));
+            var args = op.__DataIn__((control, target));
             var expected = new RuntimeMetadata()
             {
                 Label = "Y",
@@ -70,7 +70,7 @@ namespace Microsoft.Quantum.Tests
             var control = new MockQubit(1);
             var target = new MockQubit(0);
             var op = new Microsoft.Quantum.Canon.CZ(new QuantumSimulator());
-            var args = op.__dataIn((control, target));
+            var args = op.__DataIn__((control, target));
             var expected = new RuntimeMetadata()
             {
                 Label = "Z",

--- a/Standard/tests/Standard.Tests.csproj
+++ b/Standard/tests/Standard.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082035-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Standard/tests/Standard.Tests.csproj
+++ b/Standard/tests/Standard.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.200824007-vnext">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Visualization/src/Visualization.csproj
+++ b/Visualization/src/Visualization.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20082035-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.200824007-vnext" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.12.20082035-beta" />
+    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.12.200824007-vnext" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>
 

--- a/Visualization/src/Visualization.csproj
+++ b/Visualization/src/Visualization.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.200824007-vnext" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20082515-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.12.200824007-vnext" />
+    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.12.20082515-beta" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>
 


### PR DESCRIPTION
This updates the QuantumLibraries repo for the breaking changes to the Q# runtime that will be made by microsoft/qsharp-runtime#349:

* Wrap C# callable member names in underscores (e.g., `Body` -> `__Body__`, `Factory` -> `__Factory__`).

This shouldn't be merged until microsoft/qsharp-runtime#349 is merged.