### PR TITLE
Less-than comparison with a constant

### DIFF
--- a/Standard/src/Arithmetic/Arithmetic.qs
+++ b/Standard/src/Arithmetic/Arithmetic.qs
@@ -33,6 +33,31 @@ namespace Microsoft.Quantum.Arithmetic {
     }
 
     /// # Summary
+    /// Applies a bitwise-XOR operation between a classical integer and a
+    /// big integer represented by a register of qubits.
+    ///
+    /// # Description
+    /// Applies `X` operations to qubits in a little-endian register based on
+    /// 1 bits in a big integer.
+    ///
+    /// Let us denote `value` by a and let y be an unsigned integer encoded in `target`,
+    /// then `InPlaceXorLE` performs an operation given by the following map:
+    /// $\ket{y}\rightarrow \ket{y\oplus a}$ , where $\oplus$ is the bitwise exclusive OR operator.
+    ///
+    /// # Input
+    /// ## value
+    /// A big integer which is assumed to be non-negative.
+    /// ## target
+    /// A quantum register which is used to store `value` in little-endian encoding.
+    operation ApplyXorInPlaceL(value : BigInt, target : LittleEndian)
+    : Unit is Adj + Ctl {
+        ApplyToEachCA(
+            CControlledCA(X),
+            Zip(BigIntAsBoolArray(value), target!)
+        );
+    }
+
+    /// # Summary
     /// Applies the three-qubit majority operation in-place on a register of
     /// qubits.
     ///

--- a/Standard/src/Arithmetic/Comparators.qs
+++ b/Standard/src/Arithmetic/Comparators.qs
@@ -73,6 +73,7 @@ namespace Microsoft.Quantum.Arithmetic {
         } else {
             let l = TrailingZeroes(c);
             using ((tmpConstants, tmpAnd) = (Qubit[bitwidth - l], Qubit[bitwidth - 2 - l])) {
+                let tmpCarry = x![l..l] + tmpAnd;
                 within {
                     ApplyXorInPlaceL(c >>> l, LittleEndian(tmpConstants));
                     ApplyXorInPlaceL(c, x);
@@ -80,18 +81,18 @@ namespace Microsoft.Quantum.Arithmetic {
                         if (i == 0) {
                             CNOT(x![i + l], tmpConstants[i + 1]);
                         } else {
-                            ApplyAnd(tmpConstants[i], x![i + l], tmpAnd[i - 1]);
+                            ApplyAnd(tmpConstants[i], x![i + l], tmpCarry[i]);
                             if (i == 1) {
-                                CNOT(x![i + l - 1], tmpAnd[i - 1]);
+                                CNOT(x![i + l - 1], tmpCarry[i]);
                             } else {
-                                CNOT(tmpAnd[i - 2], tmpAnd[i - 1]);
+                                CNOT(tmpCarry[i - 1], tmpCarry[i]);
                             }
-                            CNOT(tmpAnd[i - 1], tmpConstants[i + 1]);
+                            CNOT(tmpCarry[i], tmpConstants[i + 1]);
                         }
                     }
                 } apply {
                     ApplyAnd(Tail(tmpConstants), Tail(x!), output);
-                    CNOT(Length(tmpAnd) == 0 ? x![l] | Tail(tmpAnd), output);
+                    CNOT(Tail(tmpCarry), output);
                 }
             }
         }

--- a/Standard/src/Arithmetic/Comparators.qs
+++ b/Standard/src/Arithmetic/Comparators.qs
@@ -72,17 +72,17 @@ namespace Microsoft.Quantum.Arithmetic {
             X(output);
         } else {
             let l = TrailingZeroes(c);
-            using ((tmpConstants, tmpAnd) = (Qubit[bitwidth - l], Qubit[bitwidth - 2 - l])) {
+            using ((tmpConstants, tmpAnd) = (Qubit[bitwidth - 1 - l], Qubit[bitwidth - 2 - l])) {
                 let tmpCarry = x![l..l] + tmpAnd;
                 within {
-                    ApplyXorInPlaceL(c >>> l, LittleEndian(tmpConstants));
+                    ApplyXorInPlaceL(c >>> l + 1, LittleEndian(tmpConstants));
                     ApplyXorInPlaceL(c, x);
                     for (i in 0..bitwidth - l - 2) {
                         if (i > 0) {
-                            ApplyAnd(tmpConstants[i], x![i + l], tmpCarry[i]);
+                            ApplyAnd(tmpConstants[i - 1], x![i + l], tmpCarry[i]);
                             CNOT(tmpCarry[i - 1], tmpCarry[i]);
                         }
-                        CNOT(tmpCarry[i], tmpConstants[i + 1]);
+                        CNOT(tmpCarry[i], tmpConstants[i]);
                     }
                 } apply {
                     ApplyAnd(Tail(tmpConstants), Tail(x!), output);

--- a/Standard/src/Arithmetic/Comparators.qs
+++ b/Standard/src/Arithmetic/Comparators.qs
@@ -7,6 +7,7 @@ namespace Microsoft.Quantum.Arithmetic {
     open Microsoft.Quantum.Convert;
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Logical;
 
     /// # Summary
     /// This operation tests if an integer represented by a register of qubits
@@ -72,11 +73,11 @@ namespace Microsoft.Quantum.Arithmetic {
             X(output);
         } else {
             let bits = BigIntAsBoolArray(c);
-            let l = TrailingZeroes(c);
+            let l = IndexOf(EqualB(true, _), bits);
             using (tmpAnd = Qubit[bitwidth - 2 - l]) {
                 let tmpCarry = x![l..l] + tmpAnd;
                 within {
-                    ApplyXorInPlaceL(c, x);
+                    ApplyPauliFromBitString(PauliX, true, bits, x!);
                     for (i in 1..bitwidth - l - 2) {
                         within {
                             ApplyIfA(X, bits[i + l], tmpCarry[i - 1]);
@@ -95,16 +96,6 @@ namespace Microsoft.Quantum.Arithmetic {
                 }
             }
         }
-    }
-
-    internal function TrailingZeroes(number : BigInt) : Int {
-        mutable zeroes = 0;
-        mutable copy = number;
-        while (copy % 2L == 0L) {
-            set zeroes += 1;
-            set copy /= 2L;
-        }
-        return zeroes;
     }
 
 }

--- a/Standard/src/Arithmetic/Comparators.qs
+++ b/Standard/src/Arithmetic/Comparators.qs
@@ -72,7 +72,7 @@ namespace Microsoft.Quantum.Arithmetic {
             X(output);
         } else {
             let l = TrailingZeroes(c);
-            using ((tmpConstants, tmpAnd) = (Qubit[bitwidth - l], Qubit[bitwidth - 1 - l])) {
+            using ((tmpConstants, tmpAnd) = (Qubit[bitwidth - l], Qubit[bitwidth - 2 - l])) {
                 within {
                     ApplyXorInPlaceL(c >>> l, LittleEndian(tmpConstants));
                     ApplyXorInPlaceL(c, x);
@@ -80,18 +80,18 @@ namespace Microsoft.Quantum.Arithmetic {
                         if (i == 0) {
                             CNOT(x![i + l], tmpConstants[i + 1]);
                         } else {
-                            ApplyAnd(tmpConstants[i], x![i + l], tmpAnd[i]);
+                            ApplyAnd(tmpConstants[i], x![i + l], tmpAnd[i - 1]);
                             if (i == 1) {
-                                CNOT(x![i + l - 1], tmpAnd[i]);
+                                CNOT(x![i + l - 1], tmpAnd[i - 1]);
                             } else {
-                                CNOT(tmpAnd[i - 1], tmpAnd[i]);
+                                CNOT(tmpAnd[i - 2], tmpAnd[i - 1]);
                             }
-                            CNOT(tmpAnd[i], tmpConstants[i + 1]);
+                            CNOT(tmpAnd[i - 1], tmpConstants[i + 1]);
                         }
                     }
                 } apply {
                     ApplyAnd(Tail(tmpConstants), Tail(x!), output);
-                    CNOT(Length(tmpAnd) == 1 ? x![l] | Tail(tmpAnd), output);
+                    CNOT(Length(tmpAnd) == 0 ? x![l] | Tail(tmpAnd), output);
                 }
             }
         }

--- a/Standard/src/Arithmetic/Comparators.qs
+++ b/Standard/src/Arithmetic/Comparators.qs
@@ -78,16 +78,20 @@ namespace Microsoft.Quantum.Arithmetic {
                     ApplyXorInPlaceL(c, x);
                     for (i in 0..bitwidth - l - 2) {
                         if (i == 0) {
-                            CNOT(x![i + l], tmpAnd[i]);
+                            CNOT(x![i + l], tmpConstants[i + 1]);
                         } else {
                             ApplyAnd(tmpConstants[i], x![i + l], tmpAnd[i]);
-                            CNOT(tmpAnd[i - 1], tmpAnd[i]);
+                            if (i == 1) {
+                                CNOT(x![i + l - 1], tmpAnd[i]);
+                            } else {
+                                CNOT(tmpAnd[i - 1], tmpAnd[i]);
+                            }
+                            CNOT(tmpAnd[i], tmpConstants[i + 1]);
                         }
-                        CNOT(tmpAnd[i], tmpConstants[i + 1]);
                     }
                 } apply {
                     ApplyAnd(Tail(tmpConstants), Tail(x!), output);
-                    CNOT(Tail(tmpAnd), output);
+                    CNOT(Length(tmpAnd) == 1 ? x![l] | Tail(tmpAnd), output);
                 }
             }
         }

--- a/Standard/src/Arithmetic/Comparators.qs
+++ b/Standard/src/Arithmetic/Comparators.qs
@@ -78,17 +78,11 @@ namespace Microsoft.Quantum.Arithmetic {
                     ApplyXorInPlaceL(c >>> l, LittleEndian(tmpConstants));
                     ApplyXorInPlaceL(c, x);
                     for (i in 0..bitwidth - l - 2) {
-                        if (i == 0) {
-                            CNOT(x![i + l], tmpConstants[i + 1]);
-                        } else {
+                        if (i > 0) {
                             ApplyAnd(tmpConstants[i], x![i + l], tmpCarry[i]);
-                            if (i == 1) {
-                                CNOT(x![i + l - 1], tmpCarry[i]);
-                            } else {
-                                CNOT(tmpCarry[i - 1], tmpCarry[i]);
-                            }
-                            CNOT(tmpCarry[i], tmpConstants[i + 1]);
+                            CNOT(tmpCarry[i - 1], tmpCarry[i]);
                         }
+                        CNOT(tmpCarry[i], tmpConstants[i + 1]);
                     }
                 } apply {
                     ApplyAnd(Tail(tmpConstants), Tail(x!), output);

--- a/Standard/src/Arithmetic/Comparators.qs
+++ b/Standard/src/Arithmetic/Comparators.qs
@@ -77,8 +77,10 @@ namespace Microsoft.Quantum.Arithmetic {
                     ApplyXorInPlaceL(c >>> l, LittleEndian(tmpConstants));
                     ApplyXorInPlaceL(c, x);
                     for (i in 0..bitwidth - l - 2) {
-                        ApplyAnd(tmpConstants[i], x![i + l], tmpAnd[i]);
-                        if (i > 0) {
+                        if (i == 0) {
+                            CNOT(x![i + l], tmpAnd[i]);
+                        } else {
+                            ApplyAnd(tmpConstants[i], x![i + l], tmpAnd[i]);
                             CNOT(tmpAnd[i - 1], tmpAnd[i]);
                         }
                         CNOT(tmpAnd[i], tmpConstants[i + 1]);

--- a/Standard/src/Arithmetic/Comparators.qs
+++ b/Standard/src/Arithmetic/Comparators.qs
@@ -77,15 +77,13 @@ namespace Microsoft.Quantum.Arithmetic {
                 let tmpCarry = x![l..l] + tmpAnd;
                 within {
                     ApplyXorInPlaceL(c, x);
-                    for (i in 0..bitwidth - l - 2) {
-                        if (i > 0) {
-                            within {
-                                ApplyIfA(X, bits[i + l], tmpCarry[i - 1]);
-                            } apply {
-                                ApplyAnd(tmpCarry[i - 1], x![i + l], tmpCarry[i]);
-                            }
-                            CNOT(tmpCarry[i - 1], tmpCarry[i]);
+                    for (i in 1..bitwidth - l - 2) {
+                        within {
+                            ApplyIfA(X, bits[i + l], tmpCarry[i - 1]);
+                        } apply {
+                            ApplyAnd(tmpCarry[i - 1], x![i + l], tmpCarry[i]);
                         }
+                        CNOT(tmpCarry[i - 1], tmpCarry[i]);
                     }
                 } apply {
                     within {

--- a/Standard/src/Arithmetic/Comparators.qs
+++ b/Standard/src/Arithmetic/Comparators.qs
@@ -59,43 +59,95 @@ namespace Microsoft.Quantum.Arithmetic {
         }
     }
 
+    /// # Summary
+    /// This operation tests if an integer represented by a register of qubits is
+    /// less than a big integer provided as a constant.
+    ///
+    /// # Description
+    /// Given two integers `x` and `c`, `x` stored in a qubit register, and `c` being
+    /// a big integer constant, this operation checks if they satisfy `x < c`.  If true,
+    /// the output qubit is changed to state $\ket 1$.  The output qubit is assumed to
+    /// be in state $\ket 0$ when the operation is being called.
+    ///
+    /// # Input
+    /// ## c
+    /// Non-negative constant number to compared to
+    /// ## x
+    /// Number in qubit register to compare
+    /// ## output
+    /// Qubit that stores the result of comparison (must be initialized to $\ket 0$)
+    ///
+    /// # Remark
+    /// This operation applies several optimizations in addition to the construction
+    /// described in the original work.  Special cases are applied if `c` is $0$,
+    /// `c` is $2^n$, or `c` is $2^{n-1}$, where $n$ is the number of bits in `x`.
+    /// Qubits and AND gates are saved for each trailing `0` in the bit representation of
+    /// `c`.  Further, one AND gate is saved for the least significant bit in `c`, which
+    /// is 1, after the trailing `0`s have been removed.  Further, all qubits associated
+    /// to constant inputs in the construction of the original work are propagated and
+    /// not allocated in this implementation.
+    ///
+    /// # References
+    /// - Qubitization of Arbitrary Basis Quantum Chemistry Leveraging Sparsity and Low Rank Factorization
+    ///   Dominic W. Berry, Craig Gidney, Mario Motta, Jarrod R. McClean, Ryan Babbush
+    ///   Quantum 3, 208 (2019)
+    ///   https://arxiv.org/abs/1902.02134v4
     operation LessThanConstantUsingRippleCarry(c : BigInt, x : LittleEndian, output : Qubit)
     : Unit {
-        let bitwidth = Length(x!);
-        AssertAllZero([output]);
+        body (...) {
+            let bitwidth = Length(x!);
+            AssertAllZero([output]);
+            Fact(c >= 0L, "Constant input `c` must not be negative");
 
-        if (c == 0L) {
-            // do nothing; output stays 0
-        } elif (c >= (1L <<< bitwidth)) {
-            X(output);
-        } elif (c == (1L <<< (bitwidth - 1))) {
-            CNOT(Tail(x!), output);
-            X(output);
-        } else {
-            let bits = BigIntAsBoolArray(c);
-            let l = IndexOf(EqualB(true, _), bits);
-            using (tmpAnd = Qubit[bitwidth - 2 - l]) {
-                let tmpCarry = x![l..l] + tmpAnd;
-                within {
-                    ApplyPauliFromBitString(PauliX, true, bits, x!);
-                    for (i in 1..bitwidth - l - 2) {
-                        within {
-                            ApplyIfA(X, bits[i + l], tmpCarry[i - 1]);
-                        } apply {
-                            ApplyAnd(tmpCarry[i - 1], x![i + l], tmpCarry[i]);
-                        }
-                        CNOT(tmpCarry[i - 1], tmpCarry[i]);
-                    }
-                } apply {
+            if (c == 0L) {
+                // do nothing; output stays 0
+            } elif (c >= (1L <<< bitwidth)) {
+                X(output);
+            } elif (c == (1L <<< (bitwidth - 1))) {
+                CNOT(Tail(x!), output);
+                X(output);
+            } else {
+                let bits = BigIntAsBoolArray(c);
+                let l = IndexOf(EqualB(true, _), bits);
+                using (tmpAnd = Qubit[bitwidth - 2 - l]) {
+                    let tmpCarry = x![l..l] + tmpAnd;
                     within {
-                        ApplyIfA(X, bits[bitwidth - 1], Tail(tmpCarry));
+                        ApplyPauliFromBitString(PauliX, true, bits, x!);
+                        for (i in 1..bitwidth - l - 2) {
+                            within {
+                                ApplyIfA(X, bits[i + l], tmpCarry[i - 1]);
+                            } apply {
+                                ApplyAnd(tmpCarry[i - 1], x![i + l], tmpCarry[i]);
+                            }
+                            CNOT(tmpCarry[i - 1], tmpCarry[i]);
+                        }
                     } apply {
-                        ApplyAnd(Tail(tmpCarry), Tail(x!), output);
+                        within {
+                            ApplyIfA(X, bits[bitwidth - 1], Tail(tmpCarry));
+                        } apply {
+                            ApplyAnd(Tail(tmpCarry), Tail(x!), output);
+                        }
+                        CNOT(Tail(tmpCarry), output);
                     }
-                    CNOT(Tail(tmpCarry), output);
                 }
             }
         }
+        adjoint self;
+
+        controlled (controls, ...) {
+            using (q = Qubit()) {
+                within {
+                    LessThanConstantUsingRippleCarry(c, x, q);
+                } apply {
+                    if (Length(controls) == 1) {
+                        ApplyAnd(Head(controls), q, output);
+                    } else {
+                        Controlled X(controls + [q], output);
+                    }
+                }
+            }
+        }
+        adjoint controlled self;
     }
 
 }

--- a/Standard/tests/ArithmeticTests.qs
+++ b/Standard/tests/ArithmeticTests.qs
@@ -2,10 +2,13 @@
 // Licensed under the MIT License.
 namespace Microsoft.Quantum.ArithmeticTests {
     open Microsoft.Quantum.Arithmetic;
+    open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Convert;
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Measurement;
     
     
     operation InPlaceXorTestHelper (testValue : Int, numberOfQubits : Int) : Unit {
@@ -173,7 +176,28 @@ namespace Microsoft.Quantum.ArithmeticTests {
             }
         }
     }
-    
+
+    @Test("ToffoliSimulator")
+    operation TestLessThanConstantUsingRippleCarry() : Unit {
+        TestLessThanConstantUsingRippleCarryForBitWidth(3);
+        TestLessThanConstantUsingRippleCarryForBitWidth(4);
+    }
+
+    internal operation TestLessThanConstantUsingRippleCarryForBitWidth(bitwidth : Int) : Unit {
+        using ((input, output) = (Qubit[bitwidth], Qubit())) {
+            let inputReg = LittleEndian(input);
+            for (qinput in 0..2^bitwidth - 1) {
+                for (cinput in 0..2^bitwidth - 1) {
+                    within {
+                        ApplyXorInPlace(qinput, inputReg);
+                    } apply {
+                        LessThanConstantUsingRippleCarry(IntAsBigInt(cinput), inputReg, output);
+                        EqualityFactB(IsResultOne(MResetZ(output)), qinput < cinput, $"Unexpected result for cinput = {cinput} and qinput = {qinput}");
+                    }
+                }
+            }
+        }
+    }
 }
 
 


### PR DESCRIPTION
This operation implements an optimised version of Fig. 17 in [arXiv:1902.02134](https://arxiv.org/abs/1902.02134v4). Constant input bits are propagated into the circuits, and no qubits are allocated for them. Further optimisations are applied for trailing 0s in the bit representation of the constant. The circuit uses AND gates instead of Toffoli gates to further reduce costs.

API review is necessary for consistent naming of arithmetic operations (e.g., compare to `CompareUsingRippleCarry` which performs greater-than comparison.)