### PR TITLE
Deprecate Zip, Exclude

### DIFF
--- a/Chemistry/src/Runtime/JordanWigner/JordanWignerClusterOperatorEvolutionSet.qs
+++ b/Chemistry/src/Runtime/JordanWigner/JordanWignerClusterOperatorEvolutionSet.qs
@@ -10,7 +10,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Arrays;
 
     /// # Summary
-    /// Computes Z component of Jordan–Wigner string between
+    /// Computes Z component of Jordanï¿½Wigner string between
     /// fermion indices in a fermionic operator with an even
     /// number of creation / annihilation operators.
     ///
@@ -89,7 +89,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
         let ops = [[PauliX, PauliY], [PauliY, PauliX]];
         let signs = [+1.0, -1.0];
 
-        for ((op, sign) in Zip(ops, signs)) {
+        for ((op, sign) in Zipped(ops, signs)) {
             let pauliString = _ComputeJordanWignerPauliString(Length(qubits), idxFermions, op);
             Exp(pauliString, sign * angle, qubits);
         }
@@ -124,7 +124,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
         let ops = [[y,y,x,y],[x,x,x,y],[x,y,y,y],[y,x,y,y],[x,y,x,x],[y,x,x,x],[y,y,y,x],[x,x,y,x]];
         let (sortedIndices, signs, globalSign) = _JordanWignerClusterOperatorPQRSTermSigns([p,q,r,s]);
 
-        for ((op, sign) in Zip(ops, signs)) {
+        for ((op, sign) in Zipped(ops, signs)) {
             let pauliString = _ComputeJordanWignerPauliString(Length(qubits), sortedIndices, op);
             Exp(pauliString, globalSign * sign * angle, qubits);
         }

--- a/Chemistry/src/Runtime/JordanWigner/JordanWignerClusterOperatorEvolutionSet.qs
+++ b/Chemistry/src/Runtime/JordanWigner/JordanWignerClusterOperatorEvolutionSet.qs
@@ -10,7 +10,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Arrays;
 
     /// # Summary
-    /// Computes Z component of Jordan�Wigner string between
+    /// Computes Z component of Jordan–Wigner string between
     /// fermion indices in a fermionic operator with an even
     /// number of creation / annihilation operators.
     ///
@@ -271,5 +271,4 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
     }
     
 }
-
 

--- a/Chemistry/src/Runtime/JordanWigner/JordanWignerEvolutionSet.qs
+++ b/Chemistry/src/Runtime/JordanWigner/JordanWignerEvolutionSet.qs
@@ -8,7 +8,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Chemistry;
     open Microsoft.Quantum.Arrays;
 
-    // This evolution set runs off data optimized for a Jordan�Wigner encoding.
+    // This evolution set runs off data optimized for a Jordan–Wigner encoding.
     // This collects terms Z, ZZ, PQandPQQR, hpqrs separately.
     // This only apples the needed hpqrs XXXX XXYY terms.
     // Operations here are expressed in terms of Exp([...])
@@ -279,5 +279,4 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
     }
     
 }
-
 

--- a/Chemistry/src/Runtime/JordanWigner/JordanWignerEvolutionSet.qs
+++ b/Chemistry/src/Runtime/JordanWigner/JordanWignerEvolutionSet.qs
@@ -8,7 +8,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
     open Microsoft.Quantum.Chemistry;
     open Microsoft.Quantum.Arrays;
 
-    // This evolution set runs off data optimized for a Jordan–Wigner encoding.
+    // This evolution set runs off data optimized for a Jordanï¿½Wigner encoding.
     // This collects terms Z, ZZ, PQandPQQR, hpqrs separately.
     // This only apples the needed hpqrs XXXX XXYY terms.
     // Operations here are expressed in terms of Exp([...])
@@ -134,7 +134,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner {
                 
                 if (idxFermions[0] < qubitQidx and qubitQidx < idxFermions[3]) {
                     let termPR1 = GeneratorIndex((idxTermType, [1.0]), [idxFermions[0], idxFermions[3] - 1]);
-                    _ApplyJordanWignerPQTerm_(termPR1, angle, new Qubit[0], Exclude([qubitQidx], qubits));
+                    _ApplyJordanWignerPQTerm_(termPR1, angle, new Qubit[0], Excluding([qubitQidx], qubits));
                 }
                 else {
                     let termPR1 = GeneratorIndex((idxTermType, [1.0]), [0, idxFermions[3] - idxFermions[0]]);

--- a/Chemistry/src/Runtime/JordanWigner/JordanWignerVQE.qs
+++ b/Chemistry/src/Runtime/JordanWigner/JordanWignerVQE.qs
@@ -39,7 +39,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner.VQE {
     
         mutable jwTermEnergy = 0.;
 
-	for ((coeff, op) in Zip(coeffs, ops)) {
+	for ((coeff, op) in Zipped(coeffs, ops)) {
             // Only perform computation if the coefficient is significant enough
             if (AbsD(coeff) >= 1e-10) {
                 // Compute expectation value using the fast frequency estimator, add contribution to Jordan-Wigner term energy
@@ -95,7 +95,7 @@ namespace Microsoft.Quantum.Chemistry.JordanWigner.VQE {
                 mutable compactOp = compactOps[iOp];
 
                 mutable op = ConstantArray(nQubits, PauliI);
-                for ((idx, pauli) in Zip(indices, compactOp)) {
+                for ((idx, pauli) in Zipped(indices, compactOp)) {
                     set op w/= idx <- pauli;
                 }
                 for (i in indices[0]+1..indices[1]-1) {

--- a/MachineLearning/src/Private.qs
+++ b/MachineLearning/src/Private.qs
@@ -6,7 +6,7 @@ namespace Microsoft.Quantum.MachineLearning {
     open Microsoft.Quantum.Math;
 
     function _AllNearlyEqualD(v1 : Double[], v2 : Double[]) : Bool {
-        return Length(v1) == Length(v2) and All(NearlyEqualD, Zip(v1, v2));
+        return Length(v1) == Length(v2) and All(NearlyEqualD, Zipped(v1, v2));
     }
 
     function _TailMeasurement(nQubits : Int) : (Qubit[] => Result) {

--- a/MachineLearning/src/Structure.qs
+++ b/MachineLearning/src/Structure.qs
@@ -63,7 +63,7 @@ namespace Microsoft.Quantum.MachineLearning {
     }
 
     function _UncontrolledSpanSequence(idxsQubits : Int[]) : (Int, Int[])[] {
-        return ped(
+        return Zipped(
             idxsQubits,
             ConstantArray(Length(idxsQubits), new Int[0])
         );

--- a/MachineLearning/src/Structure.qs
+++ b/MachineLearning/src/Structure.qs
@@ -63,7 +63,7 @@ namespace Microsoft.Quantum.MachineLearning {
     }
 
     function _UncontrolledSpanSequence(idxsQubits : Int[]) : (Int, Int[])[] {
-        return Zip(
+        return ped(
             idxsQubits,
             ConstantArray(Length(idxsQubits), new Int[0])
         );

--- a/MachineLearning/src/Training.qs
+++ b/MachineLearning/src/Training.qs
@@ -160,9 +160,9 @@ namespace Microsoft.Quantum.MachineLearning {
             //     size of the step taken during the move. We can find this size
             //     as the squared norm of the gradient.
             SquaredNorm(batchGradient),
-            // To actually apply the step, we can use Mapped(PlusD, Zip(...))
+            // To actually apply the step, we can use Mapped(PlusD, Zipped(...))
             // to represent element-wise vector summation.
-            model w/ Parameters <- Mapped(PlusD, Zip(model::Parameters, batchGradient))
+            model w/ Parameters <- Mapped(PlusD, Zipped(model::Parameters, batchGradient))
         );
 
     }
@@ -239,7 +239,7 @@ namespace Microsoft.Quantum.MachineLearning {
                     features, options::NMeasurements
                 );
                 let updatedBias = _UpdatedBias(
-                    Zip(probabilities, actualLabels), model::Bias, options::Tolerance
+                    Zipped(probabilities, actualLabels), model::Bias, options::Tolerance
                 );
                 let updatedLabels = InferredLabels(
                     updatedBias, probabilities
@@ -330,7 +330,7 @@ namespace Microsoft.Quantum.MachineLearning {
         );
         // Find the best bias for the new classification parameters.
         let localBias = _UpdatedBias(
-            Zip(probabilities, Sampled(validationSchedule, labels)),
+            Zipped(probabilities, Sampled(validationSchedule, labels)),
             0.0,
             options::Tolerance
         );
@@ -359,7 +359,7 @@ namespace Microsoft.Quantum.MachineLearning {
         );
         mutable bestSoFar = model
             w/ Bias <- _UpdatedBias(
-                Zip(probabilities, actualLabels),
+                Zipped(probabilities, actualLabels),
                 model::Bias, options::Tolerance
             );
         let inferredLabels = InferredLabels(

--- a/MachineLearning/src/Validation.qs
+++ b/MachineLearning/src/Validation.qs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.MachineLearning {
     : Int[] {
         return Where(
             NotEqualI,
-            Zip(inferredLabels, actualLabels)
+            Zipped(inferredLabels, actualLabels)
         );
     }
 

--- a/MachineLearning/tests/StructureTests.qs
+++ b/MachineLearning/tests/StructureTests.qs
@@ -53,14 +53,14 @@ namespace Microsoft.Quantum.MachineLearning.Tests {
 
     function EqualCR(x : ML.ControlledRotation, y : ML.ControlledRotation) : Bool {
         return x::Axis == y::Axis and
-               All(EqualI, Zip(x::ControlIndices, y::ControlIndices)) and
+               All(EqualI, Zipped(x::ControlIndices, y::ControlIndices)) and
                x::TargetIndex == y::TargetIndex and
                x::ParameterIndex == y::ParameterIndex;
     }
 
     @Test("QuantumSimulator")
     function LocalRotationsLayerFact() : Unit {
-        Fact(All(EqualCR, Zip(
+        Fact(All(EqualCR, Zipped(
             ML.LocalRotationsLayer(3, PauliY),
             [
                 Default<ML.ControlledRotation>()
@@ -86,7 +86,7 @@ namespace Microsoft.Quantum.MachineLearning.Tests {
 
     @Test("QuantumSimulator")
     function PartialRotationsLayerFact() : Unit {
-        Fact(All(EqualCR, Zip(
+        Fact(All(EqualCR, Zipped(
             ML.PartialRotationsLayer([4, 5, 6], PauliY),
             [
                 Default<ML.ControlledRotation>()
@@ -112,7 +112,7 @@ namespace Microsoft.Quantum.MachineLearning.Tests {
 
     @Test("QuantumSimulator")
     function CyclicEntanglingLayerFact() : Unit {
-        Fact(All(EqualCR, Zip(
+        Fact(All(EqualCR, Zipped(
             ML.CyclicEntanglingLayer(3, PauliX, 2),
             [
                 Default<ML.ControlledRotation>()
@@ -160,7 +160,7 @@ namespace Microsoft.Quantum.MachineLearning.Tests {
                     w/ ParameterIndex <- 0
             ]
         ]);
-        Fact(All(EqualCR, Zip(
+        Fact(All(EqualCR, Zipped(
             combined,
             [
                 Default<ML.ControlledRotation>()

--- a/Numerics/src/FixedPoint/Multiplication.qs
+++ b/Numerics/src/FixedPoint/Multiplication.qs
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.Arithmetic {
                 MultiplySI(xsInt, ysInt, tmpResultInt);
                 (Controlled ApplyToEachCA)(controls,
                                            (CNOT,
-                                            Zip(tmpResult[n-px..2*n-px-1], zs)));
+                                            Zipped(tmpResult[n-px..2*n-px-1], zs)));
                 (Adjoint MultiplySI)(xsInt, ysInt, tmpResultInt);
             }
         }
@@ -77,7 +77,7 @@ namespace Microsoft.Quantum.Arithmetic {
                 SquareSI(xsInt, tmpResultInt);
                 (Controlled ApplyToEachCA)(controls,
                                            (CNOT,
-                                            Zip(tmpResult[n-px..2*n-px-1], ys)));
+                                            Zipped(tmpResult[n-px..2*n-px-1], ys)));
                 (Adjoint SquareSI)(xsInt, tmpResultInt);
             }
         }

--- a/Numerics/src/FixedPoint/Reciprocal.qs
+++ b/Numerics/src/FixedPoint/Reciprocal.qs
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.Arithmetic {
                     ([sign], SignedLittleEndian(LittleEndian(xs)));
                 ComputeReciprocalI(LittleEndian(xs), LittleEndian(tmpRes));
                 (Controlled ApplyToEachCA)(controls,
-                    (CNOT, Zip(tmpRes[p+pRes-1+n-Length(rs)..Min([n+p+pRes, 2*n-1])], rs)));
+                    (CNOT, Zipped(tmpRes[p+pRes-1+n-Length(rs)..Min([n+p+pRes, 2*n-1])], rs)));
                 (Controlled Invert2sSI)([sign], SignedLittleEndian(LittleEndian(rs)));
                 (Adjoint ComputeReciprocalI)(LittleEndian(xs), LittleEndian(tmpRes));
                 (Controlled Adjoint Invert2sSI)

--- a/Standard/src/AmplitudeAmplification/AmplitudeAmplification.qs
+++ b/Standard/src/AmplitudeAmplification/AmplitudeAmplification.qs
@@ -57,7 +57,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
         systemRegister : Qubit[]
     )
     : Unit is Adj + Ctl {
-        for ((startPhase, targetPhase) in Zip(phases!)) {
+        for ((startPhase, targetPhase) in Zipped(phases!)) {
             if (startPhase != 0.0) {
                 startStateReflection::ApplyReflection(
                     startPhase, auxiliaryRegister

--- a/Standard/src/Arithmetic/Arithmetic.qs
+++ b/Standard/src/Arithmetic/Arithmetic.qs
@@ -28,7 +28,7 @@ namespace Microsoft.Quantum.Arithmetic {
     : Unit is Adj + Ctl {
         ApplyToEachCA(
             CControlledCA(X),
-            Zip(IntAsBoolArray(value, Length(target!)), target!)
+            Zipped(IntAsBoolArray(value, Length(target!)), target!)
         );
     }
 

--- a/Standard/src/Arithmetic/Integer.qs
+++ b/Standard/src/Arithmetic/Integer.qs
@@ -182,7 +182,7 @@ namespace Microsoft.Quantum.Arithmetic {
         CCNOT(xs![nQubits - 2], ys![nQubits - 1], carry);
         ApplyToEachCA(X, Most(Rest(ys!)));   // X on ys[1..(nQubits-2)]
         CNOT(ancilla, ys![1]) ;
-        ApplyToEachCA(CNOT, Zip(Rest(Most(xs!)), Rest(Rest(ys!))));
+        ApplyToEachCA(CNOT, Zipped(Rest(Most(xs!)), Rest(Rest(ys!))));
     }
 
     /// # Summary
@@ -222,7 +222,7 @@ namespace Microsoft.Quantum.Arithmetic {
 
         using (auxiliary = Qubit()) {
             within {
-                ApplyToEachCA(CNOT, Zip(Rest(xs!), Rest(ys!)));
+                ApplyToEachCA(CNOT, Zipped(Rest(xs!), Rest(ys!)));
                 CNOT(xs![1], auxiliary);
                 CCNOT(xs![0], ys![0], auxiliary);
                 ApplyOuterCDKMAdder(xs, ys, auxiliary);
@@ -309,7 +309,7 @@ namespace Microsoft.Quantum.Arithmetic {
             "Input registers must have the same number of qubits."
         );
 
-        ApplyToEachCA(CNOT, Zip(Rest(xs!), Rest(ys!)));
+        ApplyToEachCA(CNOT, Zipped(Rest(xs!), Rest(ys!)));
         Adjoint ApplyCNOTChain(Rest(xs!));
     }
 
@@ -492,7 +492,7 @@ namespace Microsoft.Quantum.Arithmetic {
             else {
                 within {
                     ApplyToEachCA(X, ys!);
-                    ApplyToEachCA(CNOT, Zip(Rest(xs!), Rest(ys!)));
+                    ApplyToEachCA(CNOT, Zipped(Rest(xs!), Rest(ys!)));
                 } apply {
                     within {
                         (Adjoint ApplyCNOTChain) (Rest(xs!));

--- a/Standard/src/Arithmetic/Modular.qs
+++ b/Standard/src/Arithmetic/Modular.qs
@@ -245,7 +245,7 @@ namespace Microsoft.Quantum.Arithmetic {
             MultiplyAndAddByModularInteger(constMultiplier, modulus, multiplier, summandLE);
 
             // now the joint state is |x⟩|x⋅a(mod N)⟩
-            ApplyToEachCA(SWAP, Zip(summandLE!, multiplier!));
+            ApplyToEachCA(SWAP, Zipped(summandLE!, multiplier!));
 
             // now the joint state is |x⋅a(mod N)⟩|x⟩
             let inverseMod = InverseModI(constMultiplier, modulus);

--- a/Standard/src/Arithmetic/Reflections.qs
+++ b/Standard/src/Arithmetic/Reflections.qs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.Arithmetic {
             // of X instructions that flip all the zeros in our index.
             ApplyToEachCA(
                 CControlledCA(X),
-                Zip(Mapped(Not, IntAsBoolArray(index, Length(reg!))), reg!)
+                Zipped(Mapped(Not, IntAsBoolArray(index, Length(reg!))), reg!)
             );
         } apply {
             Controlled Z(Most(reg!), Tail(reg!));

--- a/Standard/src/Arrays/Arrays.qs
+++ b/Standard/src/Arrays/Arrays.qs
@@ -212,9 +212,9 @@ namespace Microsoft.Quantum.Arrays {
     /// ```qsharp
     /// let array = [10, 11, 12, 13, 14, 15];
     /// // The following line returns [10, 12, 15].
-    /// let subarray = Exclude([1, 3, 4], array);
+    /// let subarray = Excluding([1, 3, 4], array);
     /// ```
-    function Exclude<'T> (remove : Int[], array : 'T[]) : 'T[] {
+    function Excluding<'T>(remove : Int[], array : 'T[]) : 'T[] {
         let nSliced = Length(remove);
         let nElements = Length(array);
 

--- a/Standard/src/Arrays/Deprecated.qs
+++ b/Standard/src/Arrays/Deprecated.qs
@@ -1,8 +1,9 @@
-// Copyright (c) Microsoft Corporation.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arrays {
-    open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Arithmetic;
+    open Microsoft.Quantum.Logical;
 
     /// # Summary
     /// Given two arrays, returns a new array of pairs such that each pair
@@ -30,24 +31,16 @@ namespace Microsoft.Quantum.Arrays {
     /// ```qsharp
     /// let left = [1, 3, 71];
     /// let right = [false, true];
-    /// let pairs = Zipped(left, right); // [(1, false), (3, true)]
+    /// let pairs = Zip(left, right); // [(1, false), (3, true)]
     /// ```
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Arrays.Zipped3
-    /// - Microsoft.Quantum.Arrays.Zipped4
-    /// - Microsoft.Quantum.Arrays.Unzipped
-    function Zipped<'T, 'U>(left : 'T[], right : 'U[]) : ('T, 'U)[] {
-        let nElements = Length(left) < Length(right)
-                        ? Length(left)
-                        | Length(right);
-        mutable output = new ('T, 'U)[nElements];
-
-        for (idxElement in 0 .. nElements - 1) {
-            set output w/= idxElement <- (left[idxElement], right[idxElement]);
-        }
-
-        return output;
+    /// - Zip3
+    /// - Zip4
+    /// - Unzipped
+    @Deprecated("Microsoft.Quantum.Arrays.Zipped")
+    function Zip<'T, 'U> (left : 'T[], right : 'U[]) : ('T, 'U)[] {
+        return Zipped(left, right);
     }
 
     /// # Summary
@@ -76,19 +69,14 @@ namespace Microsoft.Quantum.Arrays {
     /// be as long as the shorter of the inputs.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Arrays.Zipped
-    /// - Microsoft.Quantum.Arrays.Zipped4
-    function Zipped3<'T1, 'T2, 'T3> (first : 'T1[], second : 'T2[], third : 'T3[]) : ('T1, 'T2, 'T3)[] {
-        let nElements = Min([Length(first), Length(second), Length(third)]);
-        mutable output = new ('T1, 'T2, 'T3)[nElements];
-
-        for (idxElement in 0 .. nElements - 1) {
-            set output w/= idxElement <- (first[idxElement], second[idxElement], third[idxElement]);
-        }
-
-        return output;
+    /// - Zip
+    /// - Zip4
+    @Deprecated("Microsoft.Quantum.Arrays.Zipped3")
+    function Zip3<'T1, 'T2, 'T3> (first : 'T1[], second : 'T2[], third : 'T3[]) : ('T1, 'T2, 'T3)[] {
+        return Zipped3(first, second, third);
     }
 
+    
     /// # Summary
     /// Given four arrays, returns a new array of 4-tuples such that each 4-tuple
     /// contains an element from each original array.
@@ -119,59 +107,43 @@ namespace Microsoft.Quantum.Arrays {
     /// be as long as the shorter of the inputs.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Arrays.Zipped
-    /// - Microsoft.Quantum.Arrays.Zipped3
-    function Zipped4<'T1, 'T2, 'T3, 'T4> (first : 'T1[], second : 'T2[], third : 'T3[], fourth : 'T4[]) : ('T1, 'T2, 'T3, 'T4)[] {
-        let nElements = Min([Length(first), Length(second), Length(third), Length(fourth)]);
-        mutable output = new ('T1, 'T2, 'T3, 'T4)[nElements];
-
-        for (idxElement in 0 .. nElements - 1) {
-            set output w/= idxElement <- (first[idxElement], second[idxElement], third[idxElement], fourth[idxElement]);
-        }
-
-        return output;
+    /// - Zip
+    /// - Zip3
+    @Deprecated("Microsoft.Quantum.Arrays.Zipped4")
+    function Zip4<'T1, 'T2, 'T3, 'T4> (first : 'T1[], second : 'T2[], third : 'T3[], fourth : 'T4[]) : ('T1, 'T2, 'T3, 'T4)[] {
+        return Zipped4(first, second, third, fourth);
     }
 
+    
+
     /// # Summary
-    /// Given an array of 2-tuples, returns a tuple of two arrays, each containing
-    /// the elements of the tuples of the input array.
+    /// Returns an array containing the elements of another array,
+    /// excluding elements at a given list of indices.
     ///
     /// # Type Parameters
     /// ## 'T
-    /// The type of the first element in each tuple
-    /// ## 'U
-    /// The type of the second element in each tuple
+    /// The type of the array elements.
     ///
     /// # Input
-    /// ## arr
-    /// An array containing 2-tuples
+    /// ## remove
+    /// An array of indices denoting which elements should be excluded
+    /// from the output.
+    /// ## array
+    /// Array of which the values in the output array are taken.
     ///
     /// # Output
-    /// Two arrays, the first one containing all first elements of the input
-    /// tuples, the second one containing all second elements of the input tuples.
+    /// An array `output` such that `output[0]` is the first element
+    /// of `array` whose index does not appear in `remove`,
+    /// such that `output[1]` is the second such element, and so
+    /// forth.
     ///
-    /// # Example
-    /// ```Q#
-    /// // split is same as ([6, 5, 5, 3, 2, 1], [true, false, false, false, true, false])
-    /// let split = Unzipped([(6, true), (5, false), (5, false), (3, false), (2, true), (1, false)]);
+    /// # Remarks
+    /// ## Example
+    /// ```qsharp
+    /// let array = [10, 11, 12, 13, 14, 15];
+    /// // The following line returns [10, 12, 15].
+    /// let subarray = Exclude([1, 3, 4], array);
     /// ```
-    ///
-    /// # Remark
-    /// This function is equivalent to `(Mapped(Fst<'T, 'U>, arr), Mapped(Snd<'T, 'U>, arr))`.
-    ///
-    /// # See Also
-    /// - Microsoft.Quantum.Arrays.Zipped
-    function Unzipped<'T, 'U>(arr : ('T, 'U)[]) : ('T[], 'U[]) {
-        let nElements = Length(arr);
-        mutable first = new 'T[nElements];
-        mutable second = new 'U[nElements];
-        for (idxElement in 0 .. nElements - 1) {
-            let (left, right) = arr[idxElement];
-            set first w/= idxElement <- left;
-            set second w/= idxElement <- right;
-        }
-        return (first, second);
-    }
+    // function Exclude<'T> (remove : Int[], array : 'T[]) : 'T[] {
+
 }
-
-

--- a/Standard/src/Arrays/Deprecated.qs
+++ b/Standard/src/Arrays/Deprecated.qs
@@ -144,6 +144,8 @@ namespace Microsoft.Quantum.Arrays {
     /// // The following line returns [10, 12, 15].
     /// let subarray = Exclude([1, 3, 4], array);
     /// ```
-    // function Exclude<'T> (remove : Int[], array : 'T[]) : 'T[] {
+    function Exclude<'T>(remove : Int[], array : 'T[]) : 'T[] {
+        return Excluding(remove, array);
+    }
 
 }

--- a/Standard/src/Arrays/EqualA.qs
+++ b/Standard/src/Arrays/EqualA.qs
@@ -51,7 +51,7 @@ namespace Microsoft.Quantum.Arrays {
         if (Length(array1) != Length(array2)) {
             return false;
         }
-        return All(equal, Zip(array1, array2));
+        return All(equal, Zipped(array1, array2));
     }
 
 }

--- a/Standard/src/Arrays/Sorted.qs
+++ b/Standard/src/Arrays/Sorted.qs
@@ -55,7 +55,7 @@ namespace Microsoft.Quantum.Arrays {
     function IsSorted<'T>(comparison : (('T, 'T) -> Bool), array : 'T[]) : Bool {
         return All(
             comparison,
-            Zip(Most(array), Rest(array))
+            Zipped(Most(array), Rest(array))
         );
     }
 

--- a/Standard/src/Canon/And.qs
+++ b/Standard/src/Canon/And.qs
@@ -167,7 +167,7 @@ namespace Microsoft.Quantum.Canon {
             if (i % 2 == 0) {
                 set j = 0;
             } else {
-                let e = Zip(current, RangeAsIntArray(0..N - 1));
+                let e = Zipped(current, RangeAsIntArray(0..N - 1));
                 set j = Snd(Head(Filtered(Fst<Bool, Int>, e))) + 1;
             }
 

--- a/Standard/src/Canon/Combinators/ApplyIf.qs
+++ b/Standard/src/Canon/Combinators/ApplyIf.qs
@@ -34,7 +34,7 @@ namespace Microsoft.Quantum.Canon {
     /// ```Q#
     /// let bitstring = [true, false, true];
     /// using (register = Qubit(3)) {
-    ///     ApplyToEach(ApplyIf(X, _, _), Zip(bitstring, register));
+    ///     ApplyToEach(ApplyIf(X, _, _), Zipped(bitstring, register));
     ///     // register should now be in the state |101⟩.
     ///     ...
     /// }
@@ -77,7 +77,7 @@ namespace Microsoft.Quantum.Canon {
     /// ```Q#
     /// let bitstring = [true, false, true];
     /// using (register = Qubit(3)) {
-    ///     ApplyToEach(ApplyIf(X, _, _), Zip(bitstring, register));
+    ///     ApplyToEach(ApplyIf(X, _, _), Zipped(bitstring, register));
     ///     // register should now be in the state |101⟩.
     ///     ...
     /// }
@@ -120,7 +120,7 @@ namespace Microsoft.Quantum.Canon {
     /// ```Q#
     /// let bitstring = [true, false, true];
     /// using (register = Qubit(3)) {
-    ///     ApplyToEach(ApplyIf(X, _, _), Zip(bitstring, register));
+    ///     ApplyToEach(ApplyIf(X, _, _), Zipped(bitstring, register));
     ///     // register should now be in the state |101⟩.
     ///     ...
     /// }
@@ -164,7 +164,7 @@ namespace Microsoft.Quantum.Canon {
     /// ```Q#
     /// let bitstring = [true, false, true];
     /// using (register = Qubit(3)) {
-    ///     ApplyToEach(ApplyIf(X, _, _), Zip(bitstring, register));
+    ///     ApplyToEach(ApplyIf(X, _, _), Zipped(bitstring, register));
     ///     // register should now be in the state |101⟩.
     ///     ...
     /// }

--- a/Standard/src/Canon/Combinators/ApplyRepeatedOver.qs
+++ b/Standard/src/Canon/Combinators/ApplyRepeatedOver.qs
@@ -35,7 +35,7 @@ namespace Microsoft.Quantum.Canon {
         if (Length(listOfOps) != Length(targets)) {
             fail "The number of ops and number of targets do not match!";
         }
-        for ((op, targetIndices) in Zip(listOfOps, targets)) {
+        for ((op, targetIndices) in Zipped(listOfOps, targets)) {
             if (Length(targetIndices) > Length(register)) {
                 fail "There are too many targets!";
             }
@@ -69,7 +69,7 @@ namespace Microsoft.Quantum.Canon {
         if (Length(listOfOps) != Length(targets)) {
             fail "The number of ops and number of targets do not match!";
         }
-        for ((op, targetIndices) in Zip(listOfOps, targets)) {
+        for ((op, targetIndices) in Zipped(listOfOps, targets)) {
             if (Length(targetIndices) > Length(register)) {
                 fail "There are too many targets!";
             }
@@ -103,7 +103,7 @@ namespace Microsoft.Quantum.Canon {
         if (Length(listOfOps) != Length(targets)) {
             fail "The number of ops and number of targets do not match!";
         }
-        for ((op, targetIndices) in Zip(listOfOps, targets)) {
+        for ((op, targetIndices) in Zipped(listOfOps, targets)) {
             if (Length(targetIndices) > Length(register)) {
                 fail "There are too many targets!";
             }
@@ -137,7 +137,7 @@ namespace Microsoft.Quantum.Canon {
         if (Length(listOfOps) != Length(targets)) {
             fail "The number of ops and number of targets do not match!";
         }
-        for ((op, targetIndices) in Zip(listOfOps, targets)) {
+        for ((op, targetIndices) in Zipped(listOfOps, targets)) {
             if (Length(targetIndices) > Length(register)) {
                 fail "There are too many targets!";
             }

--- a/Standard/src/Canon/Parity.qs
+++ b/Standard/src/Canon/Parity.qs
@@ -23,7 +23,7 @@ namespace Microsoft.Quantum.Canon {
     /// ## qubits
     /// Array of qubits whose parity is to be computed and stored.
     operation ApplyCNOTChain(qubits : Qubit[]) : Unit is Adj + Ctl {
-        ApplyToEachCA(CNOT, Zip(Most(qubits), Rest(qubits)));
+        ApplyToEachCA(CNOT, Zipped(Most(qubits), Rest(qubits)));
     }
 
     /// # Summary

--- a/Standard/src/Characterization/Distinguishability.qs
+++ b/Standard/src/Characterization/Distinguishability.qs
@@ -206,7 +206,7 @@ namespace Microsoft.Quantum.Characterization {
         } apply {
             preparation1(target1);
             preparation2(target2);
-            ApplyToEachCA(Controlled SWAP([control], _), Zip(target1, target2));
+            ApplyToEachCA(Controlled SWAP([control], _), Zipped(target1, target2));
         }
     }
 

--- a/Standard/src/Diagnostics/Facts.qs
+++ b/Standard/src/Diagnostics/Facts.qs
@@ -207,7 +207,7 @@ namespace Microsoft.Quantum.Diagnostics {
             FormattedFailure(actual, expected, message);
         }
 
-        Ignore(Mapped(EqualityFactB(_, _, message), Zip(actual, expected)));
+        Ignore(Mapped(EqualityFactB(_, _, message), Zipped(actual, expected)));
     }
 
     /// # Summary
@@ -229,7 +229,7 @@ namespace Microsoft.Quantum.Diagnostics {
             FormattedFailure(actual, expected, message);
         }
 
-        Ignore(Mapped(EqualityFactI(_, _, message), Zip(actual, expected)));
+        Ignore(Mapped(EqualityFactI(_, _, message), Zipped(actual, expected)));
     }
 
 }

--- a/Standard/src/Logical/Comparisons.qs
+++ b/Standard/src/Logical/Comparisons.qs
@@ -64,7 +64,7 @@ namespace Microsoft.Quantum.Logical {
     /// # Summary
     /// Used to implement `LexographicComparison`.
     internal function LessThanLexographic<'T>(comparison : (('T, 'T) -> Bool), left : 'T[], right : 'T[]) : Bool {
-        for ((l, r) in Zip(left, right)) {
+        for ((l, r) in Zipped(left, right)) {
             let lessThanOrEqual = comparison(l, r);
             let greaterThanOrEqual = comparison(r, l);
             let equal = lessThanOrEqual and greaterThanOrEqual;

--- a/Standard/src/Preparation/Reference.qs
+++ b/Standard/src/Preparation/Reference.qs
@@ -22,7 +22,7 @@ namespace Microsoft.Quantum.Preparation {
             fail $"Left and right registers must be the same length.";
         }
 
-        for ((leftQubit, rightQubit) in Zip(left, right)) {
+        for ((leftQubit, rightQubit) in Zipped(left, right)) {
             H(leftQubit);
             Controlled X([leftQubit], rightQubit);
         }

--- a/Standard/src/Synthesis/DecompositionBased.qs
+++ b/Standard/src/Synthesis/DecompositionBased.qs
@@ -279,7 +279,7 @@ namespace Microsoft.Quantum.Synthesis {
         let register = qubits!;
 
         for ((func, target) in TruthTablesFromPermutation(perm, variableOrder)) {
-            ApplyXControlledOnTruthTable(func, Exclude([target], register), register[target]);
+            ApplyXControlledOnTruthTable(func, Excluding([target], register), register[target]);
         }
     }
 }

--- a/Standard/src/Synthesis/Transposition.qs
+++ b/Standard/src/Synthesis/Transposition.qs
@@ -54,11 +54,11 @@ namespace Microsoft.Quantum.Synthesis {
 
             within {
                 for (target in Most(diff)) {
-                    (BitControlledX(bbits[...target - 1] + abits[target + 1...]))(Exclude([target], qs), qs[target]);
+                    (BitControlledX(bbits[...target - 1] + abits[target + 1...]))(Excluding([target], qs), qs[target]);
                 }
             } apply {
                 let target = Tail(diff);
-                (BitControlledX(bbits[...target - 1] + abits[target + 1...]))(Exclude([target], qs), qs[target]);
+                (BitControlledX(bbits[...target - 1] + abits[target + 1...]))(Excluding([target], qs), qs[target]);
             }
         }
     }

--- a/Standard/tests/ArrayTests.qs
+++ b/Standard/tests/ArrayTests.qs
@@ -125,10 +125,9 @@ namespace Microsoft.Quantum.Tests {
     }
 
 
-    function ExcludeTest () : Unit {
-
+    function ExcludingTest () : Unit {
         let array = [10, 11, 12, 13, 14, 15];
-        Ignore(Mapped(EqualityFactI(_, _, $"Exclude failed."), Zipped([10, 11, 13, 14], Exclude([2, 5], array))));
+        Ignore(Mapped(EqualityFactI(_, _, $"Excluding failed."), Zipped([10, 11, 13, 14], Excluding([2, 5], array))));
     }
 
 

--- a/Standard/tests/ArrayTests.qs
+++ b/Standard/tests/ArrayTests.qs
@@ -9,11 +9,11 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Math;
 
     @Test("QuantumSimulator")
-    function TestZip() : Unit {
+    function TestZipped() : Unit {
 
         let left = [1, 2, 101];
         let right = [PauliY, PauliI];
-        let zipped = Zip(left, right);
+        let zipped = Zipped(left, right);
         let (leftActual1, rightActual1) = zipped[0];
 
         if (leftActual1 != 1 or rightActual1 != PauliY) {
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.Tests {
         let first = [6, 5, 5, 3, 2, 1];
         let second = [true, false, false, false, true, false];
 
-        let (first2, second2) = Unzipped(Zip(first, second));
+        let (first2, second2) = Unzipped(Zipped(first, second));
         AllEqualityFactI(first2, first, "Unexpected array of integers");
         AllEqualityFactB(second2, second, "Unexpected array of Booleans");
     }
@@ -52,7 +52,7 @@ namespace Microsoft.Quantum.Tests {
     }
 
     internal function AllEqualI(expected : Int[], actual : Int[]) : Bool {
-        return All(EqualI, Zip(expected, actual));
+        return All(EqualI, Zipped(expected, actual));
     }
 
     @Test("QuantumSimulator")
@@ -60,13 +60,13 @@ namespace Microsoft.Quantum.Tests {
         let data = [10, 11, 12, 13, 14, 15];
 
         // 2 × 3 case.
-        Fact(All(AllEqualI, Zip(
+        Fact(All(AllEqualI, Zipped(
             [[10, 11], [12, 13], [14, 15]],
             Chunks(2, data)
         )), "Wrong chunks in 2x3 case.");
 
         // Case with some leftovers.
-        Fact(All(AllEqualI, Zip(
+        Fact(All(AllEqualI, Zipped(
             [[10, 11, 12, 13], [14, 15]],
             Chunks(4, data)
         )), "Wrong chunks in case with leftover elements.");
@@ -98,7 +98,7 @@ namespace Microsoft.Quantum.Tests {
         Fact(All(IsEven, subarrayEven), $"the even elements of [1..10] were not correctly sliced.");
         Fact(not Any(IsEven, subarrayOdd), $"the odd elements of [1..10] were not correctly sliced.");
         let array1 = [10, 11, 12, 13];
-        Ignore(Mapped(EqualityFactI(_, _, $"Subarray failed: subpermutation case."), Zip([12, 11], Subarray([2, 1], array1))));
+        Ignore(Mapped(EqualityFactI(_, _, $"Subarray failed: subpermutation case."), Zipped([12, 11], Subarray([2, 1], array1))));
     }
 
 
@@ -121,14 +121,14 @@ namespace Microsoft.Quantum.Tests {
     function ReverseTest () : Unit {
 
         let array = [1, 2, 3];
-        Ignore(Mapped(EqualityFactI(_, _, $"Reversed failed."), Zip([3, 2, 1], Reversed(array))));
+        Ignore(Mapped(EqualityFactI(_, _, $"Reversed failed."), Zipped([3, 2, 1], Reversed(array))));
     }
 
 
     function ExcludeTest () : Unit {
 
         let array = [10, 11, 12, 13, 14, 15];
-        Ignore(Mapped(EqualityFactI(_, _, $"Exclude failed."), Zip([10, 11, 13, 14], Exclude([2, 5], array))));
+        Ignore(Mapped(EqualityFactI(_, _, $"Exclude failed."), Zipped([10, 11, 13, 14], Exclude([2, 5], array))));
     }
 
 
@@ -139,7 +139,7 @@ namespace Microsoft.Quantum.Tests {
         for (idxTest in IndexRange(arrayTestCase)) {
             let (nElementsTotal, defaultElement, inputArray, outputArray) = arrayTestCase[idxTest];
             let paddedArray = Padded(nElementsTotal, defaultElement, inputArray);
-            Ignore(Mapped(EqualityFactI(_, _, $"Padded failed."), Zip(outputArray, paddedArray)));
+            Ignore(Mapped(EqualityFactI(_, _, $"Padded failed."), Zipped(outputArray, paddedArray)));
         }
     }
 
@@ -148,7 +148,7 @@ namespace Microsoft.Quantum.Tests {
         let expected = [(0, 37), (1, 12)];
         let actual = Enumerated(example);
 
-        for ((actualElement, expectedElement) in Zip(actual, expected)) {
+        for ((actualElement, expectedElement) in Zipped(actual, expected)) {
             EqualityFactI(Fst(actualElement), Fst(expectedElement), "Indices did not match.");
             EqualityFactI(Snd(actualElement), Snd(expectedElement), "Elements did not match.");
         }
@@ -159,9 +159,9 @@ namespace Microsoft.Quantum.Tests {
         let expected = [[0, 1, 2, 3], [23, 24, 25, 26, 27, 28, 29], [-5, -4, -3, -2]];
         let actual = Mapped(SequenceI, example);
 
-        for ((exp, act) in Zip(expected, actual)) {
+        for ((exp, act) in Zipped(expected, actual)) {
             EqualityFactI(Length(exp), Length(act), "Lengths of arrays did not match.");
-            for ((i, j) in Zip(exp, act)) {
+            for ((i, j) in Zipped(exp, act)) {
                 EqualityFactI(i, j, "Elements did not match.");
             }
         }
@@ -172,9 +172,9 @@ namespace Microsoft.Quantum.Tests {
         let expected = [[0L, 1L, 2L, 3L], [23L, 24L, 25L, 26L, 27L, 28L, 29L], [-5L, -4L, -3L, -2L]];
         let actual = Mapped(SequenceL, example);
 
-        for ((exp, act) in Zip(expected, actual)) {
+        for ((exp, act) in Zipped(expected, actual)) {
             EqualityFactI(Length(exp), Length(act), "Lengths of arrays did not match.");
-            for ((i, j) in Zip(exp, act)) {
+            for ((i, j) in Zipped(exp, act)) {
                 EqualityFactL(i, j, "Elements did not match.");
             }
         }
@@ -185,9 +185,9 @@ namespace Microsoft.Quantum.Tests {
         let expected = [[0, 1, 2, 3], [0, 1, 2, 3, 4, 5], [0]];
         let actual = Mapped(SequenceI(0, _), example);
 
-        for ((exp, act) in Zip(expected, actual)) {
+        for ((exp, act) in Zipped(expected, actual)) {
             EqualityFactI(Length(exp), Length(act), "Lengths of arrays did not match.");
-            for ((i, j) in Zip(exp, act)) {
+            for ((i, j) in Zipped(exp, act)) {
                 EqualityFactI(i, j, "Elements did not match.");
             }
         }
@@ -207,7 +207,7 @@ namespace Microsoft.Quantum.Tests {
         let actual = _SwapOrderToPermuteArray(newOrder);
 
         EqualityFactI(Length(expected), Length(actual), "Number of swaps does not match");
-        for ((exp, act) in Zip(expected, actual)) {
+        for ((exp, act) in Zipped(expected, actual)) {
             let (leftExp, rightExp) = exp;
             let (leftAct, rightAct) = act;
 
@@ -224,7 +224,7 @@ namespace Microsoft.Quantum.Tests {
         let newArray = Swapped(leftIndex, rightIndex, example);
 
         EqualityFactI(Length(expected), Length(newArray), "Swapped array is a different size than original");
-        for ((exp, act) in Zip(expected, newArray)) {
+        for ((exp, act) in Zipped(expected, newArray)) {
             EqualityFactI(exp, act, "Elements did not match");
         }
     }
@@ -235,8 +235,8 @@ namespace Microsoft.Quantum.Tests {
 
         let actual = TupleArrayAsNestedArray(example);
         EqualityFactI(Length(expected), Length(actual), "Arrays are of different sizes");
-        for ((exp, act) in Zip(expected, actual)) {
-            for ((elementExp, elementAct) in Zip(exp, act)) {
+        for ((exp, act) in Zipped(expected, actual)) {
+            for ((elementExp, elementAct) in Zipped(exp, act)) {
                 EqualityFactI(elementExp, elementAct, "Elements did not match");
             }
         }
@@ -270,7 +270,7 @@ namespace Microsoft.Quantum.Tests {
 
     @Test("QuantumSimulator")
     operation TestTransposed() : Unit {
-        for ((actual, expected) in Zip(Transposed([[1, 2, 3], [4, 5, 6]]), [[1, 4], [2, 5], [3, 6]])) {
+        for ((actual, expected) in Zipped(Transposed([[1, 2, 3], [4, 5, 6]]), [[1, 4], [2, 5], [3, 6]])) {
             AllEqualityFactI(actual, expected, "Transposed failed");
         }
     }
@@ -300,7 +300,7 @@ namespace Microsoft.Quantum.Tests {
         let fibonacci = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34];
         let catalan = [1, 1, 2, 5, 14, 42, 132, 429, 1430, 4862];
         let famousOdd = Mapped(ElementsAt<Int>(0..2..9, _), [lucas, prime, fibonacci, catalan]);
-        for ((actual, expected) in Zip(famousOdd, [[2, 3, 7, 18, 47], [2, 5, 11, 17, 23], [0, 1, 3, 8, 21], [1, 2, 14, 132, 1430]])) {
+        for ((actual, expected) in Zipped(famousOdd, [[2, 3, 7, 18, 47], [2, 5, 11, 17, 23], [0, 1, 3, 8, 21], [1, 2, 14, 132, 1430]])) {
             AllEqualityFactI(actual, expected, "ElementsAt failed");
         }
     }

--- a/Standard/tests/ArrayTests.qs
+++ b/Standard/tests/ArrayTests.qs
@@ -76,13 +76,15 @@ namespace Microsoft.Quantum.Tests {
         return x * x;
     }
 
-
-    function ConstantArrayTest () : Unit {
-
+    @Test("QuantumSimulator")
+    function ConstantArrayOfDoublesIsCorrect() : Unit {
         let dblArray = ConstantArray(71, 2.17);
         EqualityFactI(Length(dblArray), 71, $"ConstantArray(Int, Double) had the wrong length.");
         let ignore = Mapped(NearEqualityFactD(_, 2.17), dblArray);
+    }
 
+    @Test("QuantumSimulator")
+    function ConstantArrayOfFunctionsIsCorrect() : Unit {
         // Stress test by making an array of Int -> Int.
         let fnArray = ConstantArray(7, Squared);
         EqualityFactI(Length(fnArray), 7, $"ConstantArray(Int, Int -> Int) had the wrong length.");
@@ -91,7 +93,6 @@ namespace Microsoft.Quantum.Tests {
 
 
     function SubarrayTest () : Unit {
-
         let array0 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let subarrayOdd = Subarray([1, 3, 5, 7, 9], array0);
         let subarrayEven = Subarray([0, 2, 4, 6, 8, 10], array0);
@@ -101,17 +102,15 @@ namespace Microsoft.Quantum.Tests {
         Ignore(Mapped(EqualityFactI(_, _, $"Subarray failed: subpermutation case."), Zipped([12, 11], Subarray([2, 1], array1))));
     }
 
-
-    function FilterTest () : Unit {
-
+    @Test("QuantumSimulator")
+    function FilteredIsEvenHasNoOdds() : Unit {
         let array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let evenArray = Filtered(IsEven, array);
-        EqualityFactB(All(IsEven, evenArray), true, $"the even elements of [1..10] were not correctly filtered.");
+        Fact(All(IsEven, evenArray), $"the even elements of [1..10] were not correctly filtered.");
     }
 
     @Test("QuantumSimulator")
-    function TestCount() : Unit {
-
+    function CountOfIsEvenIsCorrect() : Unit {
         let array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let countEvens = Count(IsEven, array);
         EqualityFactI(countEvens, 5, $"the even elements of [1..10] were not correctly counted.");
@@ -361,5 +360,3 @@ namespace Microsoft.Quantum.Tests {
         SquareArrayFact([[1, 2], [3, 4, 5]], "Array is not a square");
     }
 }
-
-

--- a/Standard/tests/CombinatorTests.qs
+++ b/Standard/tests/CombinatorTests.qs
@@ -134,14 +134,14 @@ namespace Microsoft.Quantum.Tests {
 
     operation CControlledActual (op : (Qubit => Unit), target : Qubit[]) : Unit {
 
-        ApplyToEach(CControlled(op), Zip([true, false, true], target));
+        ApplyToEach(CControlled(op), Zipped([true, false, true], target));
     }
 
 
     operation CControlledActualC (op : (Qubit => Unit is Ctl), target : Qubit[]) : Unit {
 
         body (...) {
-            ApplyToEachC(CControlledC(op), Zip([true, false, true], target));
+            ApplyToEachC(CControlledC(op), Zipped([true, false, true], target));
         }
 
         controlled distribute;
@@ -151,7 +151,7 @@ namespace Microsoft.Quantum.Tests {
     operation CControlledActualA (op : (Qubit => Unit is Adj), target : Qubit[]) : Unit {
 
         body (...) {
-            ApplyToEachA(CControlledA(op), Zip([true, false, true], target));
+            ApplyToEachA(CControlledA(op), Zipped([true, false, true], target));
         }
 
         adjoint invert;
@@ -161,7 +161,7 @@ namespace Microsoft.Quantum.Tests {
     operation CControlledActualCA (op : (Qubit => Unit is Adj + Ctl), target : Qubit[]) : Unit {
 
         body (...) {
-            ApplyToEachCA(CControlledCA(op), Zip([true, false, true], target));
+            ApplyToEachCA(CControlledCA(op), Zipped([true, false, true], target));
         }
 
         adjoint invert;

--- a/Standard/tests/QubitizationTests.qs
+++ b/Standard/tests/QubitizationTests.qs
@@ -145,7 +145,7 @@ namespace Microsoft.Quantum.Tests {
         for (idxTest in IndexRange(testCases)) {
             let (expected, range) = testCases[idxTest];
             let output = RangeAsIntArray(range);
-            Ignore(Mapped(EqualityFactI(_, _, "Padded failed."), Zip(output, expected)));
+            Ignore(Mapped(EqualityFactI(_, _, "Padded failed."), Zipped(output, expected)));
         }
     }
 


### PR DESCRIPTION
This PR takes the action described in e72b1e9 and deprecates `Zip` for `Zipped, and `Exclude` for `Excluding`. As per that discussion, we should also consider how to help users discover new names.