### PR TITLE
Add PrivateAssets="All" to IQ# package reference

### DIFF
--- a/Visualization/src/Visualization.csproj
+++ b/Visualization/src/Visualization.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20082515-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.12.20082515-beta" />
+    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.12.20082515-beta" PrivateAssets="All" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>
 


### PR DESCRIPTION
This change improves the performance of loading the `Microsoft.Quantum.Standard.Visualization` package inside IQ# by telling NuGet to skip resolution of the IQ#-specific dependency.

This resolves https://github.com/microsoft/iqsharp/issues/338.