### PR TITLE
Update docs for PyPI package descriptions

### DIFF
--- a/Python/qsharp-chemistry/README.md
+++ b/Python/qsharp-chemistry/README.md
@@ -6,6 +6,8 @@ For details on how to get started with Python and Q#, please see the [Getting St
 
 For details about the Quantum Chemistry Library, please see the [Introduction to the Quantum Chemistry Library article](https://docs.microsoft.com/quantum/user-guide/libraries/chemistry/) in our online documentation.
 
+You can also try our [Quantum Computing Fundamentals](https://aka.ms/learnqc) learning path to get familiar with the basic concepts of quantum computing, build quantum programs, and identify the kind of problems that can be solved.
+
 ## Installing with Anaconda ##
 
 If you use Anaconda or Miniconda, installing the `qsharp` package will automatically include all dependencies:
@@ -36,3 +38,7 @@ python setup.py bdist_wheel
 
 By default, this will create a `qsharp-chemistry` wheel in `dist/` with the version number set to 0.0.0.1.
 To provide a more useful version number, set the `PYTHON_VERSION` environment variable before running `setup.py`.
+
+## Support and Q&A
+
+If you have questions about the Quantum Development Kit and the Q# language, or if you encounter issues while using any of the components of the kit, you can reach out to the quantum team and the community of users in [Stack Overflow](https://stackoverflow.com/questions/tagged/q%23) and in [Quantum Computing Stack Exchange](https://quantumcomputing.stackexchange.com/questions/tagged/q%23) tagging your questions with **q#**.

--- a/Python/qsharp/README.md
+++ b/Python/qsharp/README.md
@@ -4,6 +4,8 @@ The `qsharp` package for Python provides interoperability with the Quantum Devel
 
 For details on how to get started with Python and Q#, please see the [Getting Started with Python guide](https://docs.microsoft.com/quantum/install-guide/python).
 
+You can also try our [Quantum Computing Fundamentals](https://aka.ms/learnqc) learning path to get familiar with the basic concepts of quantum computing, build quantum programs, and identify the kind of problems that can be solved.
+
 ## Installing with Anaconda ##
 
 If you use Anaconda or Miniconda, installing the `qsharp` package will automatically include all dependencies:
@@ -22,7 +24,7 @@ cd Python/qsharp
 python setup.py install
 ```
 
-## Building the `qsharp-chemistry` Package ##
+## Building the `qsharp` Package ##
 
 The Python interoperability feature uses a standard `setuptools`-based packaging strategy.
 To build a platform-independent wheel, run the setup script with `bdist_wheel` instead:
@@ -34,3 +36,7 @@ python setup.py bdist_wheel
 
 By default, this will create a `qsharp` wheel in `dist/` with the version number set to 0.0.0.1.
 To provide a more useful version number, set the `PYTHON_VERSION` environment variable before running `setup.py`.
+
+## Support and Q&A
+
+If you have questions about the Quantum Development Kit and the Q# language, or if you encounter issues while using any of the components of the kit, you can reach out to the quantum team and the community of users in [Stack Overflow](https://stackoverflow.com/questions/tagged/q%23) and in [Quantum Computing Stack Exchange](https://quantumcomputing.stackexchange.com/questions/tagged/q%23) tagging your questions with **q#**.


### PR DESCRIPTION
Following the example of microsoft/qsharp-compiler#671, this PR adds links to support and learning paths for the metadata for the `qsharp` and `qsharp-chemistry` PyPI packages.