### PR TITLE
Fix documentation warnings

### DIFF
--- a/Build/props/tests.props
+++ b/Build/props/tests.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.12.201016171-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.12.20102008-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/Build/props/tests.props
+++ b/Build/props/tests.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.12.20082515-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.12.201016171-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
@@ -14,4 +14,3 @@
   </ItemGroup>
 
 </Project>
-

--- a/Chemistry/src/Runtime/Runtime.csproj
+++ b/Chemistry/src/Runtime/Runtime.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20082515-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.201016171-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chemistry/src/Runtime/Runtime.csproj
+++ b/Chemistry/src/Runtime/Runtime.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20102008-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.201016171-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20102008-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chemistry/tests/ChemistryTests/QSharpTests.csproj
+++ b/Chemistry/tests/ChemistryTests/QSharpTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
 
   <Import Project="..\..\..\Build\props\tests.props" />
 
@@ -12,4 +12,3 @@
   </ItemGroup>
 
 </Project>
-

--- a/Chemistry/tests/ChemistryTests/QSharpTests.csproj
+++ b/Chemistry/tests/ChemistryTests/QSharpTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20102008-beta">
 
   <Import Project="..\..\..\Build\props\tests.props" />
 

--- a/Chemistry/tests/SystemTests/SystemTests.csproj
+++ b/Chemistry/tests/SystemTests/SystemTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20102008-beta">
 
   <Import Project="..\..\..\Build\props\tests.props" />
 

--- a/Chemistry/tests/SystemTests/SystemTests.csproj
+++ b/Chemistry/tests/SystemTests/SystemTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
 
   <Import Project="..\..\..\Build\props\tests.props" />
 
@@ -39,4 +39,3 @@
   </ItemGroup>
 
 </Project>
-

--- a/MachineLearning/src/MachineLearning.csproj
+++ b/MachineLearning/src/MachineLearning.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20102008-beta">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.MachineLearning</AssemblyName>

--- a/MachineLearning/src/MachineLearning.csproj
+++ b/MachineLearning/src/MachineLearning.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.MachineLearning</AssemblyName>

--- a/MachineLearning/tests/MachineLearningTests.csproj
+++ b/MachineLearning/tests/MachineLearningTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/MachineLearning/tests/MachineLearningTests.csproj
+++ b/MachineLearning/tests/MachineLearningTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20102008-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Numerics/src/Numerics.csproj
+++ b/Numerics/src/Numerics.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20102008-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.201016171-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20102008-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Numerics/src/Numerics.csproj
+++ b/Numerics/src/Numerics.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20082515-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.201016171-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Numerics/tests/NumericsTests.csproj
+++ b/Numerics/tests/NumericsTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Numerics/tests/NumericsTests.csproj
+++ b/Numerics/tests/NumericsTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20102008-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Standard/src/AmplitudeAmplification/AmplitudeAmplification.qs
+++ b/Standard/src/AmplitudeAmplification/AmplitudeAmplification.qs
@@ -185,8 +185,6 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     /// Reflection operator about start state
     /// ## targetStateReflection
     /// Reflection operator about target state
-    /// ## startQubits
-    /// Qubit register
     ///
     /// # Output
     /// An operation that implements amplitude amplification by partial reflections.
@@ -223,8 +221,6 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     /// Unitary oracle $A$ that prepares start state
     /// ## idxFlagQubit
     /// Index to flag qubit
-    /// ## qubits
-    /// Start state register
     ///
     /// # Output
     /// An operation that implements amplitude amplification by oracles that are
@@ -259,12 +255,10 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     /// # Input
     /// ## nIterations
     /// Number of iterations $n$ of amplitude amplification
-    /// ## statePrepOracle
+    /// ## stateOracle
     /// Unitary oracle $A$ that prepares start state
     /// ## idxFlagQubit
     /// Index to flag qubit
-    /// ## qubits
-    /// Start state register
     ///
     /// # Output
     /// An operation that implements the standard amplitude amplification quantum algorithm

--- a/Standard/src/Arithmetic/ApplyDual.qs
+++ b/Standard/src/Arithmetic/ApplyDual.qs
@@ -37,7 +37,7 @@ namespace Microsoft.Quantum.Arithmetic {
     }
 
     /// # See Also
-    /// - ApplyPhaseLEOperationOnLE
+    /// - Microsoft.Quantum.Canon.ApplyPhaseLEOperationOnLE
     operation ApplyPhaseLEOperationOnLEA (op : (PhaseLittleEndian => Unit is Adj), target : LittleEndian) : Unit
     {
         body (...)
@@ -53,7 +53,7 @@ namespace Microsoft.Quantum.Arithmetic {
 
 
     /// # See Also
-    /// - @"microsoft.quantum.canon.applyphaseleoperationonle"
+    /// - Microsoft.Quantum.Canon.ApplyPhaseLEOperationOnLE
     operation ApplyPhaseLEOperationOnLEC (op : (PhaseLittleEndian => Unit is Ctl), target : LittleEndian) : Unit
     {
         body (...)
@@ -75,7 +75,7 @@ namespace Microsoft.Quantum.Arithmetic {
 
 
     /// # See Also
-    /// - @"microsoft.quantum.canon.applyphaseleoperationonle"
+    /// - Microsoft.Quantum.Canon.ApplyPhaseLEOperationOnLE
     operation ApplyPhaseLEOperationOnLECA (op : (PhaseLittleEndian => Unit is Adj + Ctl), target : LittleEndian) : Unit
     {
         body (...)

--- a/Standard/src/Arithmetic/ApplyReversed.qs
+++ b/Standard/src/Arithmetic/ApplyReversed.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -20,9 +20,9 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A big-endian register to be transformed.
     ///
     /// # See Also
-    /// - ApplyReversedOpLEA
-    /// - ApplyReversedOpLEC
-    /// - ApplyReversedOpLECA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLEA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLEC
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLECA
     operation ApplyReversedOpLE(op : (LittleEndian => Unit), register : BigEndian) : Unit {
         ApplyWithInputTransformation(BigEndianAsLittleEndian, op, register);
     }
@@ -38,10 +38,10 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A new operation that accepts its input as a big-endian register.
     ///
     /// # See Also
-    /// - ApplyReversedOpLE
-    /// - ReversedOpLEA
-    /// - ReversedOpLEC
-    /// - ReversedOpLECA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLE
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpLEA
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpLEC
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpLECA
     function ReversedOpLE(op : (LittleEndian => Unit)) : (BigEndian => Unit) {
         return ApplyReversedOpLE(op, _);
     }
@@ -57,9 +57,9 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A big-endian register to be transformed.
     ///
     /// # See Also
-    /// - ApplyReversedOpLE
-    /// - ApplyReversedOpLEC
-    /// - ApplyReversedOpLECA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLE
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLEC
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLECA
     operation ApplyReversedOpLEA (op : (LittleEndian => Unit is Adj), register : BigEndian) : Unit {
         body (...) {
             ApplyWithInputTransformationA(BigEndianAsLittleEndian, op, register);
@@ -81,10 +81,10 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A new operation that accepts its input as a big-endian register.
     ///
     /// # See Also
-    /// - ApplyReversedOpLEA
-    /// - ReversedOpLE
-    /// - ReversedOpLEC
-    /// - ReversedOpLECA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLEA
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpLE
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpLEC
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpLECA
     function ReversedOpLEA(op : (LittleEndian => Unit is Adj)) : (BigEndian => Unit is Adj) {
         return ApplyReversedOpLEA(op, _);
     }
@@ -100,9 +100,9 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A big-endian register to be transformed.
     ///
     /// # See Also
-    /// - ApplyReversedOpLE
-    /// - ApplyReversedOpLEA
-    /// - ApplyReversedOpLECA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLE
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLEA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLECA
     operation ApplyReversedOpLEC(op : (LittleEndian => Unit is Ctl), register : BigEndian) : Unit {
         body (...) {
             ApplyWithInputTransformationC(BigEndianAsLittleEndian, op, register);
@@ -123,10 +123,10 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A new operation that accepts its input as a big-endian register.
     ///
     /// # See Also
-    /// - ApplyReversedOpLEC
-    /// - ReversedOpLE
-    /// - ReversedOpLEA
-    /// - ReversedOpLECA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLEC
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpLE
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpLEA
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpLECA
     function ReversedOpLEC(op : (LittleEndian => Unit is Ctl)) : (BigEndian => Unit is Ctl) {
         return ApplyReversedOpLEC(op, _);
     }
@@ -142,9 +142,9 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A big-endian register to be transformed.
     ///
     /// # See Also
-    /// - ApplyReversedOpLE
-    /// - ApplyReversedOpLEA
-    /// - ApplyReversedOpLEC
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLE
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLEA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLEC
     operation ApplyReversedOpLECA(op : (LittleEndian => Unit is Ctl + Adj), register : BigEndian) : Unit {
         body (...) {
             ApplyWithInputTransformationCA(BigEndianAsLittleEndian, op, register);
@@ -167,10 +167,10 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A new operation that accepts its input as a big-endian register.
     ///
     /// # See Also
-    /// - ApplyReversedOpLECA
-    /// - ReversedOpLE
-    /// - ReversedOpLEA
-    /// - ReversedOpLEC
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpLECA
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpLE
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpLEA
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpLEC
     function ReversedOpLECA(op : (LittleEndian => Unit is Adj + Ctl)) : (BigEndian => Unit is Adj + Ctl) {
         return ApplyReversedOpLECA(op, _);
     }
@@ -186,9 +186,9 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A little-endian register to be transformed.
     ///
     /// # See Also
-    /// - ApplyReversedOpBEA
-    /// - ApplyReversedOpBEC
-    /// - ApplyReversedOpBECA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBEA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBEC
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBECA
     operation ApplyReversedOpBE(op : (BigEndian => Unit), register : LittleEndian) : Unit {
         ApplyWithInputTransformation(LittleEndianAsBigEndian, op, register);
     }
@@ -205,10 +205,10 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A new operation that accepts its input as a little-endian register.
     ///
     /// # See Also
-    /// - ApplyReversedOpBE
-    /// - ReversedOpBEA
-    /// - ReversedOpBEC
-    /// - ReversedOpBECA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBE
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpBEA
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpBEC
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpBECA
     function ReversedOpBE(op : (BigEndian => Unit)) : (LittleEndian => Unit) {
         return ApplyReversedOpBE(op, _);
     }
@@ -224,9 +224,9 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A little-endian register to be transformed.
     ///
     /// # See Also
-    /// - ApplyReversedOpBE
-    /// - ApplyReversedOpBEC
-    /// - ApplyReversedOpBECA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBE
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBEC
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBECA
     operation ApplyReversedOpBEA (op : (BigEndian => Unit is Adj), register : LittleEndian) : Unit {
         body (...) {
             ApplyWithInputTransformationA(LittleEndianAsBigEndian, op, register);
@@ -247,10 +247,10 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A new operation that accepts its input as a little-endian register.
     ///
     /// # See Also
-    /// - ApplyReversedOpBEA
-    /// - ReversedOpBE
-    /// - ReversedOpBEC
-    /// - ReversedOpBECA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBEA
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpBE
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpBEC
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpBECA
     function ReversedOpBEA(op : (BigEndian => Unit is Adj)) : (LittleEndian => Unit is Adj) {
         return ApplyReversedOpBEA(op, _);
     }
@@ -266,9 +266,9 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A little-endian register to be transformed.
     ///
     /// # See Also
-    /// - ApplyReversedOpBE
-    /// - ApplyReversedOpBEA
-    /// - ApplyReversedOpBECA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBE
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBEA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBECA
     operation ApplyReversedOpBEC(op : (BigEndian => Unit is Ctl), register : LittleEndian) : Unit {
         body (...) {
             ApplyWithInputTransformationC(LittleEndianAsBigEndian, op, register);
@@ -289,10 +289,10 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A new operation that accepts its input as a little-endian register.
     ///
     /// # See Also
-    /// - ApplyReversedOpBEC
-    /// - ReversedOpBE
-    /// - ReversedOpBEA
-    /// - ReversedOpBECA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBEC
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpBE
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpBEA
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpBECA
     function ReversedOpBEC(op : (BigEndian => Unit is Ctl)) : (LittleEndian => Unit is Ctl) {
         return ApplyReversedOpBEC(op, _);
     }
@@ -308,9 +308,9 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A little-endian register to be transformed.
     ///
     /// # See Also
-    /// - ApplyReversedOpBE
-    /// - ApplyReversedOpBEA
-    /// - ApplyReversedOpBEC
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBE
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBEA
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBEC
     operation ApplyReversedOpBECA(op : (BigEndian => Unit is Ctl + Adj), register : LittleEndian) : Unit {
         body (...) {
             ApplyWithInputTransformationCA(LittleEndianAsBigEndian, op, register);
@@ -333,10 +333,10 @@ namespace Microsoft.Quantum.Arithmetic {
     /// A new operation that accepts its input as a little-endian register.
     ///
     /// # See Also
-    /// - ApplyReversedOpBECA
-    /// - ReversedOpBE
-    /// - ReversedOpBEA
-    /// - ReversedOpBEC
+    /// - Microsoft.Quantum.Arithmetic.ApplyReversedOpBECA
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpBE
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpBEA
+    /// - Microsoft.Quantum.Arithmetic.ReversedOpBEC
     function ReversedOpBECA(op : (BigEndian => Unit is Adj + Ctl)) : (LittleEndian => Unit is Adj + Ctl) {
         return ApplyReversedOpBECA(op, _);
     }

--- a/Standard/src/Arithmetic/Arithmetic.qs
+++ b/Standard/src/Arithmetic/Arithmetic.qs
@@ -71,7 +71,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// in computational basis.
     ///
     /// # See Also
-    /// - LittleEndian
+    /// - Microsoft.Quantum.Arithmetic.LittleEndian
     operation CopyMostSignificantBit (from : LittleEndian, target : Qubit) : Unit {
         body (...) {
             let mostSingificantQubit = Tail(from!);

--- a/Standard/src/Arithmetic/Comparators.qs
+++ b/Standard/src/Arithmetic/Comparators.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arithmetic {
@@ -48,7 +48,7 @@ namespace Microsoft.Quantum.Arithmetic {
                 ApplyToEachCA(X, x! + [auxiliary]);
 
                 ApplyMajorityInPlace(x![0], [y![0], auxiliary]);
-                ApplyToEachCA(MAJ, Zip3(Most(x!), Rest(y!), Rest(x!)));
+                ApplyToEachCA(MAJ, Zipped3(Most(x!), Rest(y!), Rest(x!)));
             } apply {
                 X(output);
                 CNOT(Tail(x!), output);

--- a/Standard/src/Arithmetic/Increment.qs
+++ b/Standard/src/Arithmetic/Increment.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arithmetic {
@@ -24,8 +24,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// The integer by which the `target` is incremented by.
     ///
     /// # See Also
-    /// - IncrementByIntegerBE
-    /// - IncrementByIntegerLE
+    /// - Microsoft.Quantum.Arithmetic.IncrementByInteger
     ///
     /// # References
     /// - [ *Thomas G. Draper*,

--- a/Standard/src/Arithmetic/Modular.qs
+++ b/Standard/src/Arithmetic/Modular.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arithmetic {
@@ -130,7 +130,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// for a given modulus $N$, constant multiplier $a$, and summand $y$.
     ///
     /// # Input
-    /// ## constantMultiplier
+    /// ## constMultiplier
     /// An integer $a$ to be added to each basis state label.
     /// ## modulus
     /// The modulus $N$ which addition and multiplication is taken with respect to.
@@ -163,7 +163,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// integers in QFT basis.
     ///
     /// # Input
-    /// ## constantMultiplier
+    /// ## constMultiplier
     /// An integer $a$ to be added to each basis state label.
     /// ## modulus
     /// The modulus $N$ which addition and multiplication is taken with respect to.

--- a/Standard/src/Arithmetic/Types.qs
+++ b/Standard/src/Arithmetic/Types.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arithmetic {
@@ -31,8 +31,8 @@ namespace Microsoft.Quantum.Arithmetic {
     /// We abbreviate `PhaseLittleEndian` as `PhaseLE` in the documentation.
     ///
     /// # See Also
-    /// - QFT
-    /// - QFTLE
+    /// - Microsoft.Quantum.Canon.QFT
+    /// - Microsoft.Quantum.Canon.QFTLE
     newtype PhaseLittleEndian = Qubit[];
 
 }

--- a/Standard/src/Arrays/Arrays.qs
+++ b/Standard/src/Arrays/Arrays.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arrays {
@@ -373,7 +373,7 @@ namespace Microsoft.Quantum.Arrays {
     /// that `array` can be interpreted as a permutation on `n` elements.
     ///
     /// # Input
-    /// ## array
+    /// ## permuation
     /// An array that may or may not represent a permutation.
     ///
     /// # Ouput

--- a/Standard/src/Arrays/EqualA.qs
+++ b/Standard/src/Arrays/EqualA.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Arrays {
@@ -19,7 +19,7 @@ namespace Microsoft.Quantum.Arrays {
     /// The type of each array's elements.
     ///
     /// # Input
-    /// ## predicate
+    /// ## equal
     /// A function from tuple `('T, 'T)` to `Bool` that is used to check whether two elements of arrays are equal.
     /// ## array1
     /// The first array to be compared.

--- a/Standard/src/Arrays/Map.qs
+++ b/Standard/src/Arrays/Map.qs
@@ -76,7 +76,7 @@ namespace Microsoft.Quantum.Arrays {
     /// ```
     ///
     /// # See Also
-    /// - Mapped
+    /// - Microsoft.Quantum.Arrays.Mapped
     function MappedByIndex<'T, 'U> (mapper : ((Int, 'T) -> 'U), array : 'T[]) : 'U[] {
         mutable resultArray = new 'U[Length(array)];
 

--- a/Standard/src/Canon/Combinators/ApplyRepeatedOver.qs
+++ b/Standard/src/Canon/Combinators/ApplyRepeatedOver.qs
@@ -22,7 +22,7 @@ namespace Microsoft.Quantum.Canon {
     /// ## register
     /// Qubit register to be acted upon.
     ///
-    /// ## Example
+    /// # Example
     /// // The following applies Exp([PauliX, PauliY], 0.5) to qubits 0, 1
     /// // then X to qubit 2
     /// let ops = [Exp([PauliX, PauliY], 0.5, _), ApplyToFirstQubit(X, _)];
@@ -56,7 +56,7 @@ namespace Microsoft.Quantum.Canon {
     /// ## register
     /// Qubit register to be acted upon.
     ///
-    /// ## Example
+    /// # Example
     /// // The following applies Exp([PauliX, PauliY], 0.5) to qubits 0, 1
     /// // then X to qubit 2
     /// let ops = [Exp([PauliX, PauliY], 0.5, _), ApplyToFirstQubitA(X, _)];
@@ -90,7 +90,7 @@ namespace Microsoft.Quantum.Canon {
     /// ## register
     /// Qubit register to be acted upon.
     ///
-    /// ## Example
+    /// # Example
     /// // The following applies Exp([PauliX, PauliY], 0.5) to qubits 0, 1
     /// // then X to qubit 2
     /// let ops = [Exp([PauliX, PauliY], 0.5, _), ApplyToFirstQubitC(X, _)];
@@ -124,7 +124,7 @@ namespace Microsoft.Quantum.Canon {
     /// ## register
     /// Qubit register to be acted upon.
     ///
-    /// ## Example
+    /// # Example
     /// // The following applies Exp([PauliX, PauliY], 0.5) to qubits 0, 1
     /// // then X to qubit 2
     /// let ops = [Exp([PauliX, PauliY], 0.5, _), ApplyToFirstQubitCA(X, _)];

--- a/Standard/src/Canon/Combinators/ApplyToArray.qs
+++ b/Standard/src/Canon/Combinators/ApplyToArray.qs
@@ -14,7 +14,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which the first will be applied to `op`.
     ///
     /// # Type Parameters
@@ -46,7 +46,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which the first will be applied to `op`.
     ///
     /// # Type Parameters
@@ -71,7 +71,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which the first will be applied to `op`.
     ///
     /// # Type Parameters
@@ -96,7 +96,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which the first will be applied to `op`.
     ///
     /// # Type Parameters
@@ -121,7 +121,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which all but the first will be applied to `op`.
     ///
     /// # Type Parameters
@@ -153,7 +153,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which all but the first will be applied to `op`.
     ///
     /// # Type Parameters
@@ -178,7 +178,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which all but the first will be applied to `op`.
     ///
     /// # Type Parameters
@@ -203,7 +203,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which all but the first will be applied to `op`.
     ///
     /// # Type Parameters
@@ -228,7 +228,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which the last will be applied to `op`.
     ///
     /// # Type Parameters
@@ -260,7 +260,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which the last will be applied to `op`.
     ///
     /// # Type Parameters
@@ -285,7 +285,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which the last will be applied to `op`.
     ///
     /// # Type Parameters
@@ -310,7 +310,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which the last will be applied to `op`.
     ///
     /// # Type Parameters
@@ -335,7 +335,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which all but the last will be applied to `op`.
     ///
     /// # Type Parameters
@@ -367,7 +367,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which all but the last will be applied to `op`.
     ///
     /// # Type Parameters
@@ -392,7 +392,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which all but the last will be applied to `op`.
     ///
     /// # Type Parameters
@@ -417,7 +417,7 @@ namespace Microsoft.Quantum.Canon {
     /// # Input
     /// ## op
     /// An operation to be applied.
-    /// ## target
+    /// ## targets
     /// An array of targets, of which all but the last will be applied to `op`.
     ///
     /// # Type Parameters

--- a/Standard/src/Canon/Combinators/ApplyToElement.qs
+++ b/Standard/src/Canon/Combinators/ApplyToElement.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
@@ -15,7 +15,7 @@ namespace Microsoft.Quantum.Canon {
     /// An operation to be applied.
     /// ## index
     /// An index into the array of targets.
-    /// ## target
+    /// ## targets
     /// An array of possible targets for `op`.
     ///
     /// # Type Parameters
@@ -42,7 +42,7 @@ namespace Microsoft.Quantum.Canon {
     /// An operation to be applied.
     /// ## index
     /// An index into the array of targets.
-    /// ## target
+    /// ## targets
     /// An array of possible targets for `op`.
     ///
     /// # Type Parameters
@@ -69,7 +69,7 @@ namespace Microsoft.Quantum.Canon {
     /// An operation to be applied.
     /// ## index
     /// An index into the array of targets.
-    /// ## target
+    /// ## targets
     /// An array of possible targets for `op`.
     ///
     /// # Type Parameters
@@ -96,7 +96,7 @@ namespace Microsoft.Quantum.Canon {
     /// An operation to be applied.
     /// ## index
     /// An index into the array of targets.
-    /// ## target
+    /// ## targets
     /// An array of possible targets for `op`.
     ///
     /// # Type Parameters

--- a/Standard/src/Canon/Combinators/ApplyToFirst.qs
+++ b/Standard/src/Canon/Combinators/ApplyToFirst.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon
@@ -17,9 +17,9 @@ namespace Microsoft.Quantum.Canon
     /// Qubit array to the first qubit of which the operation is applied
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytofirstqubita"
-    /// - @"microsoft.quantum.canon.applytofirstqubitc"
-    /// - @"microsoft.quantum.canon.applytofirstqubitca"
+    /// - Microsoft.Quantum.Canon.ApplyToFirstQubitA
+    /// - Microsoft.Quantum.Canon.ApplyToFirstQubitC
+    /// - Microsoft.Quantum.Canon.ApplyToFirstQubitCA
     operation ApplyToFirstQubit (op : (Qubit => Unit), register : Qubit[]) : Unit
     {
         if (Length(register) == 0)
@@ -41,7 +41,7 @@ namespace Microsoft.Quantum.Canon
     /// Qubit array to the first qubit of which the operation is applied
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytofirstqubit"
+    /// - Microsoft.Quantum.Canon.ApplyToFirstQubit
     operation ApplyToFirstQubitA (op : (Qubit => Unit is Adj), register : Qubit[]) : Unit
     {
         body (...)
@@ -68,7 +68,7 @@ namespace Microsoft.Quantum.Canon
     /// Qubit array to the first qubit of which the operation is applied
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytofirstqubit"
+    /// - Microsoft.Quantum.Canon.ApplyToFirstQubit
     operation ApplyToFirstQubitC (op : (Qubit => Unit is Ctl), register : Qubit[]) : Unit
     {
         body (...)
@@ -95,7 +95,7 @@ namespace Microsoft.Quantum.Canon
     /// Qubit array to the first qubit of which the operation is applied
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytofirstqubit"
+    /// - Microsoft.Quantum.Canon.ApplyToFirstQubit
     operation ApplyToFirstQubitCA (op : (Qubit => Unit is Adj + Ctl), register : Qubit[]) : Unit
     {
         body (...)
@@ -130,9 +130,9 @@ namespace Microsoft.Quantum.Canon
     /// ```
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytofirsttwoqubitsa"
-    /// - @"microsoft.quantum.canon.applytofirsttwoqubitsc"
-    /// - @"microsoft.quantum.canon.applytofirsttwoqubitsca"
+    /// - Microsoft.Quantum.Canon.ApplyToFirstTwoQubitsA
+    /// - Microsoft.Quantum.Canon.ApplyToFirstTwoQubitsC
+    /// - Microsoft.Quantum.Canon.ApplyToFirstTwoQubitsCA
     operation ApplyToFirstTwoQubits (op : ((Qubit, Qubit) => Unit), register : Qubit[]) : Unit
     {
         if (Length(register) < 2)
@@ -161,7 +161,7 @@ namespace Microsoft.Quantum.Canon
     /// ```
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytofirsttwoqubits"
+    /// - Microsoft.Quantum.Canon.ApplyToFirstTwoQubits
     operation ApplyToFirstTwoQubitsA (op : ((Qubit, Qubit) => Unit is Adj), register : Qubit[]) : Unit
     {
         body (...)
@@ -195,7 +195,7 @@ namespace Microsoft.Quantum.Canon
     /// ```
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytofirsttwoqubits"
+    /// - Microsoft.Quantum.Canon.ApplyToFirstTwoQubits
     operation ApplyToFirstTwoQubitsC (op : ((Qubit, Qubit) => Unit is Ctl), register : Qubit[]) : Unit
     {
         body (...)
@@ -229,7 +229,7 @@ namespace Microsoft.Quantum.Canon
     /// ```
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytofirsttwoqubits"
+    /// - Microsoft.Quantum.Canon.ApplyToFirstTwoQubits
     operation ApplyToFirstTwoQubitsCA (op : ((Qubit, Qubit) => Unit is Adj + Ctl), register : Qubit[]) : Unit
     {
         body (...)

--- a/Standard/src/Canon/Combinators/ApplyToPartition.qs
+++ b/Standard/src/Canon/Combinators/ApplyToPartition.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
@@ -18,10 +18,10 @@ namespace Microsoft.Quantum.Canon {
     /// given two operation.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytopartitiona"
-    /// - @"microsoft.quantum.canon.applytopartitionc"
-    /// - @"microsoft.quantum.canon.applytopartitionca"
-    operation ApplyToPartition (op : ((Qubit[], Qubit[]) => Unit), numberOfQubitsToFirstArgument : Int, target : Qubit[]) : Unit
+    /// - Microsoft.Quantum.Canon.ApplyToPartitionA
+    /// - Microsoft.Quantum.Canon.ApplyToPartitionC
+    /// - Microsoft.Quantum.Canon.ApplyToPartitionCA
+    operation ApplyToPartition(op : ((Qubit[], Qubit[]) => Unit), numberOfQubitsToFirstArgument : Int, target : Qubit[]) : Unit
     {
         EqualityFactB(numberOfQubitsToFirstArgument >= 0, true, $"numberOfQubitsToFirstArgument must be non-negative");
         EqualityFactB(Length(target) >= numberOfQubitsToFirstArgument, true, $"Length(target) must greater or equal to numberOfQubitsToFirstArgument");
@@ -44,7 +44,7 @@ namespace Microsoft.Quantum.Canon {
     /// given two operation.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytopartition"
+    /// - Microsoft.Quantum.Canon.ApplyToPartition
     operation ApplyToPartitionA (op : ((Qubit[], Qubit[]) => Unit is Adj), numberOfQubitsToFirstArgument : Int, target : Qubit[]) : Unit
     {
         body (...)
@@ -73,7 +73,7 @@ namespace Microsoft.Quantum.Canon {
     /// given two operation.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytopartition"
+    /// - Microsoft.Quantum.Canon.ApplyToPartition
     operation ApplyToPartitionC (op : ((Qubit[], Qubit[]) => Unit is Ctl), numberOfQubitsToFirstArgument : Int, target : Qubit[]) : Unit
     {
         body (...)
@@ -102,7 +102,7 @@ namespace Microsoft.Quantum.Canon {
     /// given two operation.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytopartition"
+    /// - Microsoft.Quantum.Canon.ApplyToPartition
     operation ApplyToPartitionCA (op : ((Qubit[], Qubit[]) => Unit is Ctl + Adj), numberOfQubitsToFirstArgument : Int, target : Qubit[]) : Unit
     {
         body (...)

--- a/Standard/src/Canon/Combinators/Curry.qs
+++ b/Standard/src/Canon/Combinators/Curry.qs
@@ -68,9 +68,9 @@ namespace Microsoft.Quantum.Canon {
     /// ## 'U
     /// The type of the second input to a curried operation.
     /// # See Also
-    /// - @"microsoft.quantum.canon.uncurryopc"
-    /// - @"microsoft.quantum.canon.uncurryopa"
-    /// - @"microsoft.quantum.canon.uncurryopca"
+    /// - Microsoft.Quantum.Canon.UncurriedOpC
+    /// - Microsoft.Quantum.Canon.UncurriedOpA
+    /// - Microsoft.Quantum.Canon.UncurriedOpCA
     function UncurriedOp<'T, 'U> (curriedOp : ('T -> ('U => Unit))) : (('T, 'U) => Unit) {
         return ApplyCurriedOp(curriedOp, _, _);
     }
@@ -104,7 +104,7 @@ namespace Microsoft.Quantum.Canon {
     /// The type of the second argument of a curried function.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.uncurryop"
+    /// - Microsoft.Quantum.Canon.UncurriedOp
     function UncurriedOpC<'T, 'U> (curriedOp : ('T -> ('U => Unit is Ctl)))
     : (('T, 'U) => Unit is Ctl) {
         return ApplyCurriedOpC(curriedOp, _, _);
@@ -139,7 +139,7 @@ namespace Microsoft.Quantum.Canon {
     /// The type of the second argument of a curried function.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.uncurryop"
+    /// - Microsoft.Quantum.Canon.UncurriedOp
     function UncurriedOpA<'T, 'U> (curriedOp : ('T -> ('U => Unit is Adj))) : (('T, 'U) => Unit is Adj) {
         return ApplyCurriedOpA(curriedOp, _, _);
     }
@@ -173,7 +173,7 @@ namespace Microsoft.Quantum.Canon {
     /// The type of the second argument of a curried function.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.uncurryop"
+    /// - Microsoft.Quantum.Canon.UncurriedOp
     function UncurriedOpCA<'T, 'U> (curriedOp : ('T -> ('U => Unit is Ctl + Adj))) : (('T, 'U) => Unit is Ctl + Adj) {
         return ApplyCurriedOpCA(curriedOp, _, _);
     }

--- a/Standard/src/Canon/Combinators/Delay.qs
+++ b/Standard/src/Canon/Combinators/Delay.qs
@@ -1,8 +1,7 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-namespace Microsoft.Quantum.Canon
-{
+namespace Microsoft.Quantum.Canon {
 
     /// # Summary
     /// Applies a given operation with a delay.
@@ -34,7 +33,7 @@ namespace Microsoft.Quantum.Canon
     /// - Microsoft.Quantum.Canon.DelayA
     /// - Microsoft.Quantum.Canon.DelayCA
     /// - Microsoft.Quantum.Canon.Delayed
-    operation Delay<'T, 'U> ( op : ('T => 'U), arg : 'T, aux : Unit) : 'U {
+    operation Delay<'T, 'U> (op : ('T => 'U), arg : 'T, aux : Unit) : 'U {
         return op(arg);
     }
 
@@ -157,7 +156,7 @@ namespace Microsoft.Quantum.Canon
     /// # See Also
     /// - Microsoft.Quantum.Canon.DelayedC
     /// - Microsoft.Quantum.Canon.DelayedA
-    /// - Microsoft.Quantum.Canon.DelayedCA    
+    /// - Microsoft.Quantum.Canon.DelayedCA
     /// - Microsoft.Quantum.Canon.Delay
     function Delayed<'T, 'U> ( op : ('T => 'U), arg : 'T) : (Unit => 'U) {
         return Delay(op, arg, _);

--- a/Standard/src/Canon/Combinators/OperationPow.qs
+++ b/Standard/src/Canon/Combinators/OperationPow.qs
@@ -55,9 +55,9 @@ namespace Microsoft.Quantum.Canon {
     /// The type of the operation to be powered.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.operationpowc"
-    /// - @"microsoft.quantum.canon.operationpowa"
-    /// - @"microsoft.quantum.canon.operationpowca"
+    /// - Microsoft.Quantum.Canon.OperationPowC
+    /// - Microsoft.Quantum.Canon.OperationPowA
+    /// - Microsoft.Quantum.Canon.OperationPowCA
     function OperationPow<'T> (op : ('T => Unit), power : Int) : ('T => Unit) {
         return ApplyOperationRepeatedly(op, power, _);
     }
@@ -84,7 +84,7 @@ namespace Microsoft.Quantum.Canon {
     /// The type of the operation to be powered.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.operationpow"
+    /// - Microsoft.Quantum.Canon.OperationPow
     function OperationPowC<'T> (op : ('T => Unit is Ctl), power : Int) : ('T => Unit is Ctl) {
         return ApplyOperationRepeatedlyC(op, power, _);
     }
@@ -111,7 +111,7 @@ namespace Microsoft.Quantum.Canon {
     /// The type of the operation to be powered.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.operationpow"
+    /// - Microsoft.Quantum.Canon.OperationPow
     function OperationPowA<'T> (op : ('T => Unit is Adj), power : Int) : ('T => Unit is Adj) {
         return ApplyOperationRepeatedlyA(op, power, _);
     }
@@ -138,7 +138,7 @@ namespace Microsoft.Quantum.Canon {
     /// The type of the operation to be powered.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.operationpow"
+    /// - Microsoft.Quantum.Canon.OperationPow
     function OperationPowCA<'T> (op : ('T => Unit is Ctl + Adj), power : Int) : ('T => Unit is Ctl + Adj) {
         return ApplyOperationRepeatedlyCA(op, power, _);
     }

--- a/Standard/src/Canon/Combinators/RestrictedToSubregister.qs
+++ b/Standard/src/Canon/Combinators/RestrictedToSubregister.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
@@ -26,9 +26,9 @@ namespace Microsoft.Quantum.Canon {
     /// ```
     ///
     /// # See Also
-    /// - ApplyToSubregisterA
-    /// - ApplyToSubregisterC
-    /// - ApplyToSubregisterCA
+    /// - Microsoft.Quantum.Canon.ApplyToSubregisterA
+    /// - Microsoft.Quantum.Canon.ApplyToSubregisterC
+    /// - Microsoft.Quantum.Canon.ApplyToSubregisterCA
     operation ApplyToSubregister (op : (Qubit[] => Unit), idxs : Int[], target : Qubit[]) : Unit {
         let subregister = Subarray(idxs, target);
         op(subregister);
@@ -49,7 +49,7 @@ namespace Microsoft.Quantum.Canon {
     /// Register on which the operation acts.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytosubregister"
+    /// - Microsoft.Quantum.Canon.ApplyToSubregister
     operation ApplyToSubregisterA (op : (Qubit[] => Unit is Adj), idxs : Int[], target : Qubit[]) : Unit
     {
         body (...)
@@ -78,7 +78,7 @@ namespace Microsoft.Quantum.Canon {
     /// Register on which the operation acts.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytosubregister"
+    /// - Microsoft.Quantum.Canon.ApplyToSubregister
     operation ApplyToSubregisterC (op : (Qubit[] => Unit is Ctl), idxs : Int[], target : Qubit[]) : Unit
     {
         body (...)
@@ -108,7 +108,7 @@ namespace Microsoft.Quantum.Canon {
     /// Register on which the operation acts.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.applytosubregister"
+    /// - Microsoft.Quantum.Canon.ApplyToSubregister
     operation ApplyToSubregisterCA (op : (Qubit[] => Unit is Ctl + Adj), idxs : Int[], target : Qubit[]) : Unit
     {
         body (...)
@@ -143,8 +143,6 @@ namespace Microsoft.Quantum.Canon {
     /// Operation to be restricted to a subregister.
     /// ## idxs
     /// Array of indices, indicating to which qubits the operation will be restricted.
-    /// ## target
-    /// Register on which the operation acts.
     ///
     /// # See Also
     /// - Microsoft.Quantum.Canon.RestrictedToSubregisterA
@@ -164,11 +162,9 @@ namespace Microsoft.Quantum.Canon {
     /// Operation to be restricted to a subregister.
     /// ## idxs
     /// Array of indices, indicating to which qubits the operation will be restricted.
-    /// ## target
-    /// Register on which the operation acts.
     ///
     /// # See Also
-    /// - RestrictedToSubregister
+    /// - Microsoft.Quantum.Canon.RestrictedToSubregister
     function RestrictedToSubregisterA (op : (Qubit[] => Unit is Adj), idxs : Int[]) : (Qubit[] => Unit is Adj)
     {
         return ApplyToSubregisterA(op, idxs, _);
@@ -184,8 +180,6 @@ namespace Microsoft.Quantum.Canon {
     /// Operation to be restricted to a subregister.
     /// ## idxs
     /// Array of indices, indicating to which qubits the operation will be restricted.
-    /// ## target
-    /// Register on which the operation acts.
     ///
     /// # See Also
     /// - Microsoft.Quantum.Canon.RestrictedToSubregister
@@ -204,8 +198,6 @@ namespace Microsoft.Quantum.Canon {
     /// Operation to be restricted to a subregister.
     /// ## idxs
     /// Array of indices, indicating to which qubits the operation will be restricted.
-    /// ## target
-    /// Register on which the operation acts.
     ///
     /// # See Also
     /// - Microsoft.Quantum.Canon.RestrictedToSubregister

--- a/Standard/src/Canon/Combinators/Transformed.qs
+++ b/Standard/src/Canon/Combinators/Transformed.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
@@ -21,10 +21,10 @@ namespace Microsoft.Quantum.Canon {
     /// An input to the function.
     ///
     /// # See Also
-    /// - ApplyWithInputTransformationA
-    /// - ApplyWithInputTransformationC
-    /// - ApplyWithInputTransformationCA
-    /// - TransformedOperation
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformationA
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformationC
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformationCA
+    /// - Microsoft.Quantum.Canon.TransformedOperation
     ///
     /// # Example
     /// The following call uses
@@ -55,11 +55,11 @@ namespace Microsoft.Quantum.Canon {
     /// resulting output to `op`.
     ///
     /// # See Also
-    /// - TransformedOperationA
-    /// - TransformedOperationC
-    /// - TransformedOperationCA
-    /// - ApplyWithInputTransformation
-    /// - Compose
+    /// - Microsoft.Quantum.Canon.TransformedOperationA
+    /// - Microsoft.Quantum.Canon.TransformedOperationC
+    /// - Microsoft.Quantum.Canon.TransformedOperationCA
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformation
+    /// - Microsoft.Quantum.Canon.Composed
     ///
     /// # Example
     /// The following call uses
@@ -96,10 +96,10 @@ namespace Microsoft.Quantum.Canon {
     /// An input to the function.
     ///
     /// # See Also
-    /// - ApplyWithInputTransformation
-    /// - ApplyWithInputTransformationC
-    /// - ApplyWithInputTransformationCA
-    /// - TransformedOperation
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformation
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformationC
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformationCA
+    /// - Microsoft.Quantum.Canon.TransformedOperation
     ///
     /// # Example
     /// The following call uses
@@ -131,11 +131,11 @@ namespace Microsoft.Quantum.Canon {
     /// resulting output to `op`.
     ///
     /// # See Also
-    /// - TransformedOperation
-    /// - TransformedOperationC
-    /// - TransformedOperationCA
-    /// - ApplyWithInputTransformation
-    /// - Compose
+    /// - Microsoft.Quantum.Canon.TransformedOperation
+    /// - Microsoft.Quantum.Canon.TransformedOperationC
+    /// - Microsoft.Quantum.Canon.TransformedOperationCA
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformation
+    /// - Microsoft.Quantum.Canon.Composed
     ///
     /// # Example
     /// The following call uses
@@ -173,10 +173,10 @@ namespace Microsoft.Quantum.Canon {
     /// An input to the function.
     ///
     /// # See Also
-    /// - ApplyWithInputTransformation
-    /// - ApplyWithInputTransformationA
-    /// - ApplyWithInputTransformationCA
-    /// - TransformedOperation
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformation
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformationA
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformationCA
+    /// - Microsoft.Quantum.Canon.TransformedOperation
     ///
     /// # Example
     /// The following call uses
@@ -208,11 +208,11 @@ namespace Microsoft.Quantum.Canon {
     /// resulting output to `op`.
     ///
     /// # See Also
-    /// - TransformedOperation
-    /// - TransformedOperationA
-    /// - TransformedOperationCA
-    /// - ApplyWithInputTransformation
-    /// - Compose
+    /// - Microsoft.Quantum.Canon.TransformedOperation
+    /// - Microsoft.Quantum.Canon.TransformedOperationA
+    /// - Microsoft.Quantum.Canon.TransformedOperationCA
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformation
+    /// - Microsoft.Quantum.Canon.Composed
     ///
     /// # Example
     /// The following call uses
@@ -249,10 +249,10 @@ namespace Microsoft.Quantum.Canon {
     /// An input to the function.
     ///
     /// # See Also
-    /// - ApplyWithInputTransformation
-    /// - ApplyWithInputTransformationA
-    /// - ApplyWithInputTransformationC
-    /// - TransformedOperation
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformation
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformationA
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformationC
+    /// - Microsoft.Quantum.Canon.TransformedOperation
     ///
     /// # Example
     /// The following call uses
@@ -286,11 +286,11 @@ namespace Microsoft.Quantum.Canon {
     /// resulting output to `op`.
     ///
     /// # See Also
-    /// - TransformedOperation
-    /// - TransformedOperationA
-    /// - TransformedOperationCA
-    /// - ApplyWithInputTransformation
-    /// - Compose
+    /// - Microsoft.Quantum.Canon.TransformedOperation
+    /// - Microsoft.Quantum.Canon.TransformedOperationA
+    /// - Microsoft.Quantum.Canon.TransformedOperationCA
+    /// - Microsoft.Quantum.Canon.ApplyWithInputTransformation
+    /// - Microsoft.Quantum.Canon.Composed
     ///
     /// # Example
     /// The following call uses

--- a/Standard/src/Canon/Combinators/With.qs
+++ b/Standard/src/Canon/Combinators/With.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
@@ -33,14 +33,15 @@ namespace Microsoft.Quantum.Canon {
     /// controllable.
     ///
     /// # See Also
-    /// - ApplyWithA
-    /// - ApplyWithC
-    /// - ApplyWithCA
+    /// - Microsoft.Quantum.Canon.ApplyWithA
+    /// - Microsoft.Quantum.Canon.ApplyWithC
+    /// - Microsoft.Quantum.Canon.ApplyWithCA
     operation ApplyWith<'T>(outerOperation : ('T => Unit is Adj), innerOperation : ('T => Unit), target : 'T) : Unit {
         outerOperation(target);
         innerOperation(target);
         Adjoint outerOperation(target);
     }
+
     /// # Summary
     /// Given outer and inner operations, returns a new operation that
     /// conjugates the inner operation by the outer operation.
@@ -68,10 +69,10 @@ namespace Microsoft.Quantum.Canon {
     /// controllable.
     ///
     /// # See Also
-    /// - ConjugatedByA
-    /// - ConjugatedByC
-    /// - ConjugatedByCA
-    /// - ApplyWith
+    /// - Microsoft.Quantum.Canon.ConjugatedByA
+    /// - Microsoft.Quantum.Canon.ConjugatedByC
+    /// - Microsoft.Quantum.Canon.ConjugatedByCA
+    /// - Microsoft.Quantum.Canon.ApplyWith
     function ConjugatedBy<'T>(outerOperation : ('T => Unit is Adj), innerOperation : ('T => Unit)) : ('T => Unit) {
         return ApplyWith(outerOperation, innerOperation, _);
     }
@@ -105,9 +106,9 @@ namespace Microsoft.Quantum.Canon {
     /// controllable.
     ///
     /// # See Also
-    /// - ApplyWith
-    /// - ApplyWithC
-    /// - ApplyWithCA
+    /// - Microsoft.Quantum.Canon.ApplyWith
+    /// - Microsoft.Quantum.Canon.ApplyWithC
+    /// - Microsoft.Quantum.Canon.ApplyWithCA
     operation ApplyWithA<'T>(outerOperation : ('T => Unit is Adj), innerOperation : ('T => Unit is Adj), target : 'T) : Unit {
         body (...) {
             outerOperation(target);
@@ -145,10 +146,10 @@ namespace Microsoft.Quantum.Canon {
     /// controllable.
     ///
     /// # See Also
-    /// - ConjugatedByA
-    /// - ConjugatedByC
-    /// - ConjugatedByCA
-    /// - ApplyWith
+    /// - Microsoft.Quantum.Canon.ConjugatedByA
+    /// - Microsoft.Quantum.Canon.ConjugatedByC
+    /// - Microsoft.Quantum.Canon.ConjugatedByCA
+    /// - Microsoft.Quantum.Canon.ApplyWith
     function ConjugatedByA<'T>(outerOperation : ('T => Unit is Adj), innerOperation : ('T => Unit is Adj)) : ('T => Unit is Adj) {
         return ApplyWithA(outerOperation, innerOperation, _);
     }
@@ -182,9 +183,9 @@ namespace Microsoft.Quantum.Canon {
     /// controllable.
     ///
     /// # See Also
-    /// - ApplyWith
-    /// - ApplyWithA
-    /// - ApplyWithCA
+    /// - Microsoft.Quantum.Canon.ApplyWith
+    /// - Microsoft.Quantum.Canon.ApplyWithA
+    /// - Microsoft.Quantum.Canon.ApplyWithCA
     operation ApplyWithC<'T>(outerOperation : ('T => Unit is Adj), innerOperation : ('T => Unit is Ctl), target : 'T) : Unit {
         body (...) {
             outerOperation(target);
@@ -226,10 +227,10 @@ namespace Microsoft.Quantum.Canon {
     /// controllable.
     ///
     /// # See Also
-    /// - ConjugatedBy
-    /// - ConjugatedByA
-    /// - ConjugatedByCA
-    /// - ApplyWith
+    /// - Microsoft.Quantum.Canon.ConjugatedBy
+    /// - Microsoft.Quantum.Canon.ConjugatedByA
+    /// - Microsoft.Quantum.Canon.ConjugatedByCA
+    /// - Microsoft.Quantum.Canon.ApplyWith
     function ConjugatedByC<'T>(outerOperation : ('T => Unit is Adj), innerOperation : ('T => Unit is Ctl)) : ('T => Unit is Ctl) {
         return ApplyWithC(outerOperation, innerOperation, _);
     }
@@ -264,9 +265,9 @@ namespace Microsoft.Quantum.Canon {
     /// controllable.
     ///
     /// # See Also
-    /// - ApplyWith
-    /// - ApplyWithA
-    /// - ApplyWithC
+    /// - Microsoft.Quantum.Canon.ApplyWith
+    /// - Microsoft.Quantum.Canon.ApplyWithA
+    /// - Microsoft.Quantum.Canon.ApplyWithC
     operation ApplyWithCA<'T>(outerOperation : ('T => Unit is Adj), innerOperation : ('T => Unit is Adj + Ctl), target : 'T) : Unit {
         body (...) {
             outerOperation(target);
@@ -313,10 +314,10 @@ namespace Microsoft.Quantum.Canon {
     /// controllable.
     ///
     /// # See Also
-    /// - ConjugatedByA
-    /// - ConjugatedByC
-    /// - ConjugatedByCA
-    /// - ApplyWith
+    /// - Microsoft.Quantum.Canon.ConjugatedByA
+    /// - Microsoft.Quantum.Canon.ConjugatedByC
+    /// - Microsoft.Quantum.Canon.ConjugatedByCA
+    /// - Microsoft.Quantum.Canon.ApplyWith
     function ConjugatedByCA<'T>(outerOperation : ('T => Unit is Adj), innerOperation : ('T => Unit is Adj + Ctl)) : ('T => Unit is Adj + Ctl) {
         return ApplyWithCA(outerOperation, innerOperation, _);
     }

--- a/Standard/src/Canon/CommonGates.qs
+++ b/Standard/src/Canon/CommonGates.qs
@@ -146,7 +146,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.qft"
+    /// - Microsoft.Quantum.Canon.QFT
     operation QFTLE(qs : LittleEndian) : Unit {
         body (...) {
             ApplyQuantumFourierTransform(qs);
@@ -223,6 +223,7 @@ namespace Microsoft.Quantum.Canon {
     /// Qubit to which the gate should be applied.
     ///
     /// # See Also
+    /// - Microsoft.Quantum.Intrinsic.H
     operation HY (target : Qubit) : Unit {
         body (...) {
             H(target);

--- a/Standard/src/Canon/Enumeration/Trotter.qs
+++ b/Standard/src/Canon/Enumeration/Trotter.qs
@@ -14,9 +14,9 @@ namespace Microsoft.Quantum.Canon {
     /// `Qubit[]` or `Qubit`.
     ///
     /// # Input
-    /// ### nSteps
+    /// ## nSteps
     /// The number of operations to be decomposed into time steps.
-    /// ### op
+    /// ## op
     /// An operation which accepts an index input (type `Int`) and a time
     /// input (type `Double`) and a quantum register (type `'T`) for decomposition.
     /// ## stepSize
@@ -51,9 +51,9 @@ namespace Microsoft.Quantum.Canon {
     /// `Qubit[]` or `Qubit`.
     ///
     /// # Input
-    /// ### nSteps
+    /// ## nSteps
     /// The number of operations to be decomposed into time steps.
-    /// ### op
+    /// ## op
     /// An operation which accepts an index input (type `Int`) and a time
     /// input (type `Double`) and a quantum register (type `'T`) for decomposition.
     /// ## stepSize
@@ -97,11 +97,11 @@ namespace Microsoft.Quantum.Canon {
     /// `Qubit[]` or `Qubit`.
     ///
     /// # Input
-    /// ### Order
+    /// ## order
     /// Order of Trotter-Suzuki integrator.
-    /// ### nSteps
+    /// ## nSteps
     /// The number of operations to be decomposed into time steps.
-    /// ### op
+    /// ## op
     /// An operation which accepts an index input (type `Int`) and a time
     /// input (type `Double`) and a quantum register (type `'T`) for decomposition.
     /// ## stepSize

--- a/Standard/src/Canon/Parity.qs
+++ b/Standard/src/Canon/Parity.qs
@@ -51,7 +51,7 @@ namespace Microsoft.Quantum.Canon {
             "Target register must have one more qubit."
         );
 
-        ApplyToEachCA(CCNOT, Zip3(register, Most(targets), Rest(targets)));
+        ApplyToEachCA(CCNOT, Zipped3(register, Most(targets), Rest(targets)));
     }
 
 

--- a/Standard/src/Canon/QFT.qs
+++ b/Standard/src/Canon/QFT.qs
@@ -85,7 +85,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     ///
     /// # See Also
-    /// - ApplyQuantumFourierTransformBE
+    /// - Microsoft.Quantum.Canon.ApplyQuantumFourierTransformBE
     operation ApplyQuantumFourierTransform(qs : LittleEndian) : Unit is Adj + Ctl {
         ApplyReversedOpBECA(ApplyQuantumFourierTransformBE, qs);
     }

--- a/Standard/src/Canon/Utils/Multiplexer.qs
+++ b/Standard/src/Canon/Utils/Multiplexer.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Canon {
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.Canon {
     /// fewer than $2^n$ are specified.
     ///
     /// # See Also
-    /// - ApproximatelyMultiplexPauli
+    /// - Microsoft.Quantum.Canon.ApproximatelyMultiplexPauli
     operation MultiplexPauli(coefficients : Double[], pauli : Pauli, control : LittleEndian, target : Qubit)
     : Unit is Adj + Ctl {
         ApproximatelyMultiplexPauli(0.0, coefficients, pauli, control, target);
@@ -89,7 +89,7 @@ namespace Microsoft.Quantum.Canon {
     /// fewer than $2^n$ are specified.
     ///
     /// # See Also
-    /// - MultiplexPauli
+    /// - Microsoft.Quantum.Canon.MultiplexPauli
     operation ApproximatelyMultiplexPauli(tolerance : Double, coefficients : Double[], pauli : Pauli, control : LittleEndian, target : Qubit)
     : Unit is Adj + Ctl {
         if (pauli == PauliZ) {
@@ -145,7 +145,7 @@ namespace Microsoft.Quantum.Canon {
     ///   https://arxiv.org/abs/quant-ph/0406176
     ///
     /// # See Also
-    /// - ApproximatelyMultiplexZ
+    /// - Microsoft.Quantum.Canon.ApproximatelyMultiplexZ
     operation MultiplexZ(coefficients : Double[], control : LittleEndian, target : Qubit)
     : Unit is Adj + Ctl {
         ApproximatelyMultiplexZ(0.0, coefficients, control, target);
@@ -212,7 +212,7 @@ namespace Microsoft.Quantum.Canon {
     ///   https://arxiv.org/abs/quant-ph/0406176
     ///
     /// # See Also
-    /// - MultiplexZ
+    /// - Microsoft.Quantum.Canon.MultiplexZ
     operation ApproximatelyMultiplexZ(tolerance : Double, coefficients : Double[], control : LittleEndian, target : Qubit) : Unit is Adj + Ctl {
         body (...) {
             // pad coefficients length at tail to a power of 2.
@@ -271,8 +271,7 @@ namespace Microsoft.Quantum.Canon {
     /// ## coefficients
     /// Array of up to $2^n$ coefficients $\theta_j$. The $j$th coefficient
     /// indexes the number state $\ket{j}$ encoded in little-endian format.
-    ///
-    /// ## control
+    /// ## qubits
     /// $n$-qubit control register that encodes number states $\ket{j}$ in
     /// little-endian format.
     ///
@@ -286,7 +285,7 @@ namespace Microsoft.Quantum.Canon {
     ///   https://arxiv.org/abs/quant-ph/0406176
     ///
     /// # See Also
-    /// - ApproximatelyApplyDiagonalUnitary
+    /// - Microsoft.Quantum.Canon.ApproximatelyApplyDiagonalUnitary
     operation ApplyDiagonalUnitary(coefficients : Double[], qubits : LittleEndian) : Unit is Adj + Ctl {
         ApproximatelyApplyDiagonalUnitary(0.0, coefficients, qubits);
     }
@@ -315,7 +314,7 @@ namespace Microsoft.Quantum.Canon {
     /// Array of up to $2^n$ coefficients $\theta_j$. The $j$th coefficient
     /// indexes the number state $\ket{j}$ encoded in little-endian format.
     ///
-    /// ## control
+    /// ## qubits
     /// $n$-qubit control register that encodes number states $\ket{j}$ in
     /// little-endian format.
     ///
@@ -329,7 +328,7 @@ namespace Microsoft.Quantum.Canon {
     ///   https://arxiv.org/abs/quant-ph/0406176
     ///
     /// # See Also
-    /// - ApplyDiagonalUnitary
+    /// - Microsoft.Quantum.Canon.ApplyDiagonalUnitary
     operation ApproximatelyApplyDiagonalUnitary(tolerance : Double, coefficients : Double[], qubits : LittleEndian)
     : Unit is Adj + Ctl {
         if (IsEmpty(qubits!)) {

--- a/Standard/src/Convert/Convert.qs
+++ b/Standard/src/Convert/Convert.qs
@@ -185,8 +185,6 @@ namespace Microsoft.Quantum.Convert {
     /// apply Pauli if bit is this value.
     /// ## bits
     /// Boolean array.
-    /// ## qubits
-    /// Quantum register to which a Pauli operator is to be applied.
     ///
     /// # Remarks
     /// The Boolean array and the quantum register must be of equal length.

--- a/Standard/src/ErrorCorrection/5QubitCode.qs
+++ b/Standard/src/ErrorCorrection/5QubitCode.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.ErrorCorrection {
@@ -18,8 +18,7 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// # Remarks
     /// The particular encoder chosen was taken from the paper V. Kliuchnikov and D. Maslov, "Optimization of Clifford Circuits,"
     /// Phys. Rev. Phys. Rev. A 88, 052307 (2013); https://arxiv.org/abs/1305.0810, Figure 4b) and requires a total of 11 gates.
-    operation FiveQubitCodeEncoderImpl (data : Qubit[], scratch : Qubit[]) : Unit
-    {
+    operation FiveQubitCodeEncoderImpl (data : Qubit[], scratch : Qubit[]) : Unit {
         body (...) {
             Controlled X(data, scratch[1]);
             H(data[0]);
@@ -61,9 +60,8 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// ordering in the table lookup recovery is given by converting the bitvectors to integers (using little endian).
     ///
     /// # See Also
-    /// - RecoveryFn
-    function FiveQubitCodeRecoveryFn () : RecoveryFn
-    {
+    /// - Microsoft.Quantum.ErrorCorrection.RecoveryFn
+    function FiveQubitCodeRecoveryFn () : RecoveryFn {
         return TableLookupRecovery(
             [
                 [PauliI, PauliI, PauliI, PauliI, PauliI],
@@ -102,7 +100,7 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// encoded state.
     ///
     /// # See Also
-    /// - LogicalRegister
+    /// - Microsoft.Quantum.ErrorCorrection.LogicalRegister
     operation EncodeIntoFiveQubitCode(physRegister : Qubit[], auxQubits : Qubit[]) : LogicalRegister {
         FiveQubitCodeEncoderImpl(physRegister, auxQubits);
         let logicalRegister = LogicalRegister(physRegister + auxQubits);
@@ -121,8 +119,8 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// first parameter, together with auxiliary qubits in the second parameter.
     ///
     /// # See Also
-    /// - FiveQubitCodeEncoder
-    /// - LogicalRegister
+    /// - Microsoft.Quantum.ErrorCorrection.FiveQubitCodeEncoder
+    /// - Microsoft.Quantum.ErrorCorrection.LogicalRegister
     operation DecodeFromFiveQubitCode(logicalRegister : LogicalRegister) : (Qubit[], Qubit[]) {
         let physRegister = [(logicalRegister!)[0]];
         let auxQubits = (logicalRegister!)[1 .. 4];

--- a/Standard/src/ErrorCorrection/7QubitCode.qs
+++ b/Standard/src/ErrorCorrection/7QubitCode.qs
@@ -52,8 +52,8 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// to be applied is the 3-bit encoding of the X, respectively, Z syndrome when considered an integer.
     ///
     /// # See Also
-    /// - SteaneCodeRecoveryX
-    /// - SteaneCodeRecoveryFns
+    /// - Microsoft.Quantum.ErrorCorrection.SteaneCodeRecoveryX
+    /// - Microsoft.Quantum.ErrorCorrection.SteaneCodeRecoveryFns
     ///
     /// # References
     /// - D. Gottesman, "Stabilizer Codes and Quantum Error Correction," Ph.D. Thesis, Caltech, 1997;
@@ -69,8 +69,8 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// Decoder for the Z-part of the stabilizer group of the ⟦7, 1, 3⟧ Steane quantum code.
     ///
     /// # See Also
-    /// - SteaneCodeRecoveryX
-    /// - SteaneCodeRecoveryFns
+    /// - Microsoft.Quantum.ErrorCorrection.SteaneCodeRecoveryX
+    /// - Microsoft.Quantum.ErrorCorrection.SteaneCodeRecoveryFns
     function SteaneCodeRecoveryZ (syndrome : Syndrome) : Pauli[] {
         let idxQubit = ResultArrayAsInt(syndrome!);
         return idxQubit == 0
@@ -88,8 +88,8 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// corrects the detected error.
     ///
     /// # See Also
-    /// - SteaneCodeRecoveryX
-    /// - SteaneCodeRecoveryZ
+    /// - Microsoft.Quantum.ErrorCorrection.SteaneCodeRecoveryX
+    /// - Microsoft.Quantum.ErrorCorrection.SteaneCodeRecoveryZ
     function SteaneCodeRecoveryFns () : (RecoveryFn, RecoveryFn)
     {
         return (RecoveryFn(SteaneCodeRecoveryX), RecoveryFn(SteaneCodeRecoveryZ));
@@ -111,8 +111,8 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// A quantum register holding the state after the Steane encoder has been applied
     ///
     /// # See Also
-    /// - LogicalRegister
-    /// - SteaneCodeDecoder
+    /// - Microsoft.Quantum.ErrorCorrection.LogicalRegister
+    /// - Microsoft.Quantum.ErrorCorrection.SteaneCodeDecoder
     operation EncodeIntoSteaneCode(physRegister : Qubit[], auxQubits : Qubit[]) : LogicalRegister
     {
         SteaneCodeEncoderImpl(physRegister, auxQubits);
@@ -139,9 +139,9 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// to be applied is the 3-bit encoding of the X, respectively, Z syndrome when considered an integer.
     ///
     /// # See Also
-    /// - SteaneCodeEncoder
-    /// - SteaneCodeDecoder
-    /// - LogicalRegister
+    /// - Microsoft.Quantum.ErrorCorrection.SteaneCodeEncoder
+    /// - Microsoft.Quantum.ErrorCorrection.SteaneCodeDecoder
+    /// - Microsoft.Quantum.ErrorCorrection.LogicalRegister
     ///
     /// # References
     /// - D. Gottesman, "Stabilizer Codes and Quantum Error Correction," Ph.D. Thesis, Caltech, 1997;

--- a/Standard/src/ErrorCorrection/BitFlipCode.qs
+++ b/Standard/src/ErrorCorrection/BitFlipCode.qs
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// logical register.
     ///
     /// # See Also
-    /// - LogicalRegister
+    /// - Microsoft.Quantum.ErrorCorrection.LogicalRegister
     operation EncodeIntoBitFlipCode(physRegister : Qubit[], auxQubits : Qubit[])
     : LogicalRegister {
         ApplyBitFlipEncoder(false, physRegister, auxQubits);
@@ -64,8 +64,8 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// qubits used to represent the syndrome.
     ///
     /// # See Also
-    /// - LogicalRegister
-    /// - EncodeIntoBitFlipCode
+    /// - Microsoft.Quantum.ErrorCorrection.LogicalRegister
+    /// - Microsoft.Quantum.ErrorCorrection.EncodeIntoBitFlipCode
     operation DecodeFromBitFlipCode(logicalRegister : LogicalRegister)
     : (Qubit[], Qubit[]) {
         let physRegister = [(logicalRegister!)[0]];
@@ -99,7 +99,7 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// detected error.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.RecoveryFn
+    /// - Microsoft.Quantum.ErrorCorrection.RecoveryFn
     function BitFlipRecoveryFn () : RecoveryFn {
         return TableLookupRecovery([
             [PauliI, PauliI, PauliI],

--- a/Standard/src/ErrorCorrection/Types.qs
+++ b/Standard/src/ErrorCorrection/Types.qs
@@ -63,8 +63,8 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// ```
     ///
     /// # See Also
-    /// - LogicalRegister
-    /// - Syndrome
+    /// - Microsoft.Quantum.ErrorCorrection.LogicalRegister
+    /// - Microsoft.Quantum.ErrorCorrection.Syndrome
     newtype SyndromeMeasOp = (LogicalRegister => Syndrome);
 
     /// # Summary

--- a/Standard/src/ErrorCorrection/Utils.qs
+++ b/Standard/src/ErrorCorrection/Utils.qs
@@ -46,9 +46,9 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// An array of qubits where the stabilizer code is defined.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.QECC
-    /// - Microsoft.Quantum.Canon.RecoveryFn
-    /// - Microsoft.Quantum.Canon.LogicalRegister
+    /// - Microsoft.Quantum.ErrorCorrection.QECC
+    /// - Microsoft.Quantum.ErrorCorrection.RecoveryFn
+    /// - Microsoft.Quantum.ErrorCorrection.LogicalRegister
     operation Recover (code : QECC, fn : RecoveryFn, logicalRegister : LogicalRegister) : Unit
     {
         let (encode, decode, syndMeas) = code!;
@@ -77,9 +77,9 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// An array of qubits where the stabilizer code is defined.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.CSS
-    /// - Microsoft.Quantum.Canon.RecoveryFn
-    /// - Microsoft.Quantum.Canon.LogicalRegister
+    /// - Microsoft.Quantum.ErrorCorrection.CSS
+    /// - Microsoft.Quantum.ErrorCorrection.RecoveryFn
+    /// - Microsoft.Quantum.ErrorCorrection.LogicalRegister
     operation RecoverCSS (code : CSS, fnX : RecoveryFn, fnZ : RecoveryFn, logicalRegister : LogicalRegister) : Unit
     {
         let (encode, decode, syndMeasX, syndMeasZ) = code!;

--- a/Standard/src/Math/Complex.qs
+++ b/Standard/src/Math/Complex.qs
@@ -256,16 +256,16 @@ namespace Microsoft.Quantum.Math {
     /// Returns a number raised to a given power.
     ///
     /// # Input
-    /// ## base
+    /// ## a
     /// The number $a$ that is to be raised.
     /// ## power
     /// The power $b$ to which $a$ should be raised.
     ///
     /// # Output
     /// The power $a^b$
-    function PowC(base_ : Complex, power : Complex) : Complex {
+    function PowC(a : Complex, power : Complex) : Complex {
         return ComplexPolarAsComplex(
-            PowCAsCP(base_, power)
+            PowCAsCP(a, power)
         );
     }
 
@@ -273,7 +273,7 @@ namespace Microsoft.Quantum.Math {
     /// Returns a number raised to a given power.
     ///
     /// # Input
-    /// ## base
+    /// ## a
     /// The number $a$ that is to be raised.
     /// ## power
     /// The power $b$ to which $a$ should be raised.

--- a/Standard/src/Math/Complex.qs
+++ b/Standard/src/Math/Complex.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Math {
@@ -10,9 +10,9 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Named Items
     /// ## Magnitude
-    /// `Double` is absolute value $r \ge 0$.
+    /// The absolute value $r \ge 0$ of $c$.
     /// ## Argument
-    /// `Double` is the phase $t \in \mathbb R$.
+    /// The phase $t \in \mathbb R$ of $c$.
     newtype ComplexPolar = (Magnitude: Double, Argument: Double);
 
     /// # Summary
@@ -25,7 +25,7 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Output
     /// Squared absolute value $|c|^2 = x^2 + y^2$.
-    function AbsSquaredComplex (input : Complex) : Double {
+    function AbsSquaredComplex(input : Complex) : Double {
         let (real, imaginary) = input!;
         return real * real + imaginary * imaginary;
     }
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Output
     /// Absolute value $|c| = \sqrt{x^2 + y^2}$.
-    function AbsComplex (input : Complex) : Double {
+    function AbsComplex(input : Complex) : Double {
         return Sqrt(AbsSquaredComplex(input));
     }
 
@@ -54,7 +54,7 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Output
     /// Phase $\text{Arg}[c] = \text{ArcTan}(y,x) \in (-\pi,\pi]$.
-    function ArgComplex (input : Complex) : Double {
+    function ArgComplex(input : Complex) : Double {
         let (real, imaginary) = input!;
         return ArcTan2(imaginary, real);
     }
@@ -69,7 +69,7 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Output
     /// Squared absolute value $|c|^2 = r^2$.
-    function AbsSquaredComplexPolar (input : ComplexPolar) : Double {
+    function AbsSquaredComplexPolar(input : ComplexPolar) : Double {
         let (abs, arg) = input!;
         return abs * abs;
     }
@@ -85,7 +85,7 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Output
     /// Absolute value $|c| = r$.
-    function AbsComplexPolar (input : ComplexPolar) : Double {
+    function AbsComplexPolar(input : ComplexPolar) : Double {
         return input::Magnitude;
     }
 

--- a/Standard/src/Math/Functions.qs
+++ b/Standard/src/Math/Functions.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Math {
@@ -51,16 +51,13 @@ namespace Microsoft.Quantum.Math {
     ///
     /// # Output
     /// The smallest element of `values`.
-    function Min (value : Int[]) : Int
-    {
-        mutable min = value[0];
-        let nTerms = Length(value);
+    function Min (values : Int[]) : Int {
+        mutable min = values[0];
+        let nTerms = Length(values);
 
-        for (idx in 0 .. nTerms - 1)
-        {
-            if (value[idx] < min)
-            {
-                set min = value[idx];
+        for (idx in 0 .. nTerms - 1) {
+            if (values[idx] < min) {
+                set min = values[idx];
             }
         }
 
@@ -642,7 +639,7 @@ namespace Microsoft.Quantum.Math {
     /// The array $x$ normalized by the $p$-norm $\|x\|_p$.
     ///
     /// # See Also
-    /// - PNorm
+    /// - Microsoft.Quantum.Math.PNorm
     function PNormalized(p : Double, array : Double[]) : Double[] {
         let nElements = Length(array);
         let norm = PNorm(p, array);

--- a/Standard/src/Oracles/Convert.qs
+++ b/Standard/src/Oracles/Convert.qs
@@ -26,8 +26,8 @@ namespace Microsoft.Quantum.Oracles {
     /// An oracle $O=UA$ of type `ObliviousOracle`.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.DeterministicStateOracle
-    /// - Microsoft.Quantum.Canon.ObliviousOracle
+    /// - Microsoft.Quantum.Oracles.DeterministicStateOracle
+    /// - Microsoft.Quantum.Oracles.ObliviousOracle
     function ObliviousOracleFromDeterministicStateOracle(ancillaOracle : DeterministicStateOracle, signalOracle : ObliviousOracle)
     : ObliviousOracle {
         return ObliviousOracle(ApplyObliviousOracleFromDeterministicStateOracle(ancillaOracle, signalOracle, _, _));
@@ -59,8 +59,8 @@ namespace Microsoft.Quantum.Oracles {
     /// longer explicitly separate, e.g.  $A\ket{0\psi}\_{as}$.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.StateOracle
-    /// - Microsoft.Quantum.Canon.DeterministicStateOracle
+    /// - Microsoft.Quantum.Oracles.StateOracle
+    /// - Microsoft.Quantum.Oracles.DeterministicStateOracle
     function DeterministicStateOracleFromStateOracle (idxFlagQubit : Int, stateOracle : StateOracle)
     : DeterministicStateOracle {
         return DeterministicStateOracle(ApplyDeterministicStateOracleFromStateOracle(idxFlagQubit, stateOracle, _));
@@ -88,8 +88,8 @@ namespace Microsoft.Quantum.Oracles {
     /// dummy variable and has no effect.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.DeterministicStateOracle
-    /// - Microsoft.Quantum.Canon.StateOracle
+    /// - Microsoft.Quantum.Oracles.DeterministicStateOracle
+    /// - Microsoft.Quantum.Oracles.StateOracle
     function StateOracleFromDeterministicStateOracle (deterministicStateOracle : DeterministicStateOracle) : StateOracle
     {
         return StateOracle(ApplyStateOracleFromDeterministicStateOracle(_, deterministicStateOracle, _));

--- a/Standard/src/Preparation/Arbitrary.qs
+++ b/Standard/src/Preparation/Arbitrary.qs
@@ -351,7 +351,7 @@ namespace Microsoft.Quantum.Preparation {
     /// # Summary
     /// Implementation step of arbitrary state preparation procedure.
     /// # See Also
-    /// - Microsoft.Quantum.Canon.PrepareArbitraryState
+    /// - Microsoft.Quantum.Preparation.PrepareArbitraryState
     function _StatePreparationSBMComputeCoefficients (coefficients : ComplexPolar[]) : (Double[], Double[], ComplexPolar[]) {
         mutable disentanglingZ = new Double[Length(coefficients) / 2];
         mutable disentanglingY = new Double[Length(coefficients) / 2];

--- a/Standard/src/Preparation/Mixed.qs
+++ b/Standard/src/Preparation/Mixed.qs
@@ -49,7 +49,7 @@ namespace Microsoft.Quantum.Preparation {
     /// described above.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.preparesinglequbitidentity"
+    /// - Microsoft.Quantum.Preparation.PrepareSingleQubitIdentity
     operation PrepareIdentity(register : Qubit[]) : Unit {
         ApplyToEach(PrepareSingleQubitIdentity, register);
     }

--- a/Standard/src/Preparation/Reference.qs
+++ b/Standard/src/Preparation/Reference.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Preparation {
@@ -60,9 +60,9 @@ namespace Microsoft.Quantum.Preparation {
     /// *quantum process tomography*.
     ///
     /// # See Also
-    /// - PrepareChoiStateA
-    /// - PrepareChoiStateC
-    /// - PrepareChoiStateCA
+    /// - Microsoft.Quantum.Preparation.PrepareChoiStateA
+    /// - Microsoft.Quantum.Preparation.PrepareChoiStateC
+    /// - Microsoft.Quantum.Preparation.PrepareChoiStateCA
     operation PrepareChoiState (op : (Qubit[] => Unit), reference : Qubit[], target : Qubit[]) : Unit {
         PrepareEntangledState(reference, target);
         op(target);
@@ -74,7 +74,7 @@ namespace Microsoft.Quantum.Preparation {
     /// and target registers.
     ///
     /// # See Also
-    /// - PrepareChoiState
+    /// - Microsoft.Quantum.Preparation.PrepareChoiState
     operation PrepareChoiStateC(op : (Qubit[] => Unit is Ctl), reference : Qubit[], target : Qubit[]) : Unit is Ctl {
         PrepareEntangledState(reference, target);
         op(target);
@@ -86,7 +86,7 @@ namespace Microsoft.Quantum.Preparation {
     /// and target registers.
     ///
     /// # See Also
-    /// - PrepareChoiState
+    /// - Microsoft.Quantum.Preparation.PrepareChoiState
     operation PrepareChoiStateA (op : (Qubit[] => Unit is Adj), reference : Qubit[], target : Qubit[]) : Unit is Adj {
         PrepareEntangledState(reference, target);
         op(target);
@@ -98,7 +98,7 @@ namespace Microsoft.Quantum.Preparation {
     /// and target registers.
     ///
     /// # See Also
-    /// - PrepareChoiState
+    /// - Microsoft.Quantum.Preparation.PrepareChoiState
     operation PrepareChoiStateCA(op : (Qubit[] => Unit is Adj + Ctl), reference : Qubit[], target : Qubit[]) : Unit is Adj + Ctl {
         PrepareEntangledState(reference, target);
         op(target);

--- a/Standard/src/Simulation/BlockEncoding.qs
+++ b/Standard/src/Simulation/BlockEncoding.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Simulation {
@@ -54,7 +54,7 @@ namespace Microsoft.Quantum.Simulation {
     /// encodes $H$.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.BlockEncoding
+    /// - Microsoft.Quantum.Simulation.BlockEncoding
     newtype BlockEncodingReflection = BlockEncoding;
 
     /// # Summary
@@ -110,8 +110,8 @@ namespace Microsoft.Quantum.Simulation {
     ///   https://arxiv.org/abs/1610.06546
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.BlockEncoding
-    /// - Microsoft.Quantum.Canon.BlockEncodingReflection
+    /// - Microsoft.Quantum.Simulation.BlockEncoding
+    /// - Microsoft.Quantum.Simulation.BlockEncodingReflection
     function BlockEncodingToReflection(blockEncoding: BlockEncoding)
     : BlockEncodingReflection {
         return BlockEncodingReflection(BlockEncoding(ApplyBlockEncodingAsReflection(blockEncoding, _, _)));
@@ -137,7 +137,7 @@ namespace Microsoft.Quantum.Simulation {
     /// walk $W$ containing the spectrum of $\pm e^{\pm i\sin^{-1}(H)}$.
     ///
     /// # Input
-    /// ## blockEncodingReflection
+    /// ## blockEncoding
     /// A `BlockEncodingReflection` unitary $U$ to be converted into a Quantum
     /// walk.
     ///
@@ -151,8 +151,8 @@ namespace Microsoft.Quantum.Simulation {
     ///   https://arxiv.org/abs/1610.06546
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.BlockEncoding
-    /// - Microsoft.Quantum.Canon.BlockEncodingReflection
+    /// - Microsoft.Quantum.Simulation.BlockEncoding
+    /// - Microsoft.Quantum.Simulation.BlockEncodingReflection
     function QuantumWalkByQubitization(blockEncoding: BlockEncodingReflection)
     : ((Qubit[], Qubit[]) => Unit is Adj + Ctl) {
         return ApplyQuantumWalkByQubitization(blockEncoding, _, _);
@@ -196,8 +196,8 @@ namespace Microsoft.Quantum.Simulation {
     /// `BlockEncodingReflection`.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.BlockEncoding
-    /// - Microsoft.Quantum.Canon.BlockEncodingReflection
+    /// - Microsoft.Quantum.Simulation.BlockEncoding
+    /// - Microsoft.Quantum.Simulation.BlockEncodingReflection
     function BlockEncodingByLCU<'T,'S>(
         statePreparation: ('T => Unit is Adj + Ctl),
         selector: (('T, 'S) => Unit is Adj + Ctl)
@@ -242,8 +242,8 @@ namespace Microsoft.Quantum.Simulation {
     /// `BlockEncodingReflection`.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.BlockEncoding
-    /// - Microsoft.Quantum.Canon.BlockEncodingReflection
+    /// - Microsoft.Quantum.Simulation.BlockEncoding
+    /// - Microsoft.Quantum.Simulation.BlockEncodingReflection
     function BlockEncodingReflectionByLCU(
         statePreparation : (Qubit[] => Unit is Adj + Ctl),
         selector : ((Qubit[], Qubit[]) => Unit is Adj + Ctl)

--- a/Standard/src/Simulation/Data/GeneratorRepresentation.qs
+++ b/Standard/src/Simulation/Data/GeneratorRepresentation.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Simulation {
@@ -31,8 +31,8 @@ namespace Microsoft.Quantum.Simulation {
     /// ```
     ///
     /// # See Also
-    /// - EvolutionSet
-    /// - PauliEvolutionSet
+    /// - Microsoft.Quantum.Simulation.EvolutionSet
+    /// - Microsoft.Quantum.Simulation.PauliEvolutionSet
     newtype GeneratorIndex = ((Int[], Double[]), Int[]);
 
     /// # Summary
@@ -47,7 +47,7 @@ namespace Microsoft.Quantum.Simulation {
     /// <xref:microsoft.quantum.arrays.lookupfunction> function.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.lookupfunction"
+    /// - Microsoft.Quantum.Arrays.LookupFunction
     newtype GeneratorSystem = (Int, (Int -> GeneratorIndex));
     
     /// # Summary
@@ -167,9 +167,8 @@ namespace Microsoft.Quantum.Simulation {
     /// The number of terms in a `GeneratorSystem`.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.generatorsystem"
-    function GetGeneratorSystemNTerms (generatorSystem : GeneratorSystem) : Int
-    {
+    /// - Microsoft.Quantum.Simulation.GeneratorSystem
+    function GetGeneratorSystemNTerms (generatorSystem : GeneratorSystem) : Int {
         let (nTerms, generatorIndexFunction) = generatorSystem!;
         return nTerms;
     }
@@ -186,8 +185,8 @@ namespace Microsoft.Quantum.Simulation {
     /// An function that indexes each `GeneratorIndex` term in a Hamiltonian.
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.generatorindex"
-    /// - @"microsoft.quantum.canon.generatorsystem"
+    /// - Microsoft.Quantum.Simulation.GeneratorIndex
+    /// - Microsoft.Quantum.Simulation.GeneratorSystem
     function GetGeneratorSystemFunction (generatorSystem : GeneratorSystem) : (Int -> GeneratorIndex)
     {
         let (nTerms, generatorIndexFunction) = generatorSystem!;
@@ -219,7 +218,7 @@ namespace Microsoft.Quantum.Simulation {
     /// ```
     ///
     /// # See Also
-    /// - @"microsoft.quantum.canon.generatorindex"
+    /// - Microsoft.Quantum.Simulation.GeneratorIndex
     function MultiplyGeneratorIndex (multiplier : Double, generatorIndex : GeneratorIndex) : GeneratorIndex
     {
         let ((idxTerms, idxDoubles), idxSystems) = generatorIndex!;
@@ -255,7 +254,7 @@ namespace Microsoft.Quantum.Simulation {
     /// `multiplier` larger.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.GeneratorSystem
+    /// - Microsoft.Quantum.Simulation.GeneratorSystem
     function MultiplyGeneratorSystem (multiplier : Double, generatorSystem : GeneratorSystem) : GeneratorSystem
     {
         let nTerms = GetGeneratorSystemNTerms(generatorSystem);
@@ -295,7 +294,7 @@ namespace Microsoft.Quantum.Simulation {
     /// input generator systems.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.GeneratorSystem
+    /// - Microsoft.Quantum.Simulation.GeneratorSystem
     function AddGeneratorSystems (generatorSystemA : GeneratorSystem, generatorSystemB : GeneratorSystem) : GeneratorSystem
     {
         let nTermsA = GetGeneratorSystemNTerms(generatorSystemA);
@@ -327,7 +326,7 @@ namespace Microsoft.Quantum.Simulation {
     /// and weight $s$ on `generatorSystemEnd`.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.GeneratorSystem
+    /// - Microsoft.Quantum.Simulation.GeneratorSystem
     function InterpolateGeneratorSystemsImpl (schedule : Double, generatorSystemStart : GeneratorSystem, generatorSystemEnd : GeneratorSystem) : GeneratorSystem
     {
         let sysStart = MultiplyGeneratorSystem(1.0 - schedule, generatorSystemStart);
@@ -352,8 +351,8 @@ namespace Microsoft.Quantum.Simulation {
     /// `generatorSystemStart` and weight $s$ on `generatorSystemEnd`.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.GeneratorSystem
-    /// - Microsoft.Quantum.Canon.TimeDependentGeneratorSystem
+    /// - Microsoft.Quantum.Simulation.GeneratorSystem
+    /// - Microsoft.Quantum.Simulation.TimeDependentGeneratorSystem
     function InterpolateGeneratorSystems (generatorSystemStart : GeneratorSystem, generatorSystemEnd : GeneratorSystem) : TimeDependentGeneratorSystem
     {
         return TimeDependentGeneratorSystem(InterpolateGeneratorSystemsImpl(_, generatorSystemStart, generatorSystemEnd));
@@ -371,7 +370,7 @@ namespace Microsoft.Quantum.Simulation {
     /// input generator systems.
     ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.GeneratorSystem
+    /// - Microsoft.Quantum.Simulation.GeneratorSystem
     function SumGeneratorSystems(generatorSystems: GeneratorSystem[]) : GeneratorSystem {
         return Fold(AddGeneratorSystems, IdentityGeneratorSystem(), generatorSystems);
     }

--- a/Standard/src/Simulation/QubitizationPauliEvolutionSet.qs
+++ b/Standard/src/Simulation/QubitizationPauliEvolutionSet.qs
@@ -114,15 +114,16 @@ namespace Microsoft.Quantum.Simulation {
     /// # Summary
     /// Used in implementation of `PauliBlockEncoding`
     /// # See Also
-    /// - Microsoft.Quantum.Canon.PauliBlockEncoding
+    /// - Microsoft.Quantum.Simulation.PauliBlockEncoding
     internal function IdxToCoeff(idx: Int, genFun: (Int -> GeneratorIndex), genIdxToCoeff: (GeneratorIndex -> Double)) : Double {
         return Sqrt(AbsD(genIdxToCoeff(genFun(idx))));
     }
 
     /// # Summary
     /// Used in implementation of `PauliBlockEncoding`
+    ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.PauliBlockEncoding
+    /// - Microsoft.Quantum.Simulation.PauliBlockEncoding
     internal function IdxToUnitary(idx: Int, genFun: (Int -> GeneratorIndex), genIdxToUnitary: (GeneratorIndex -> (Qubit[] => Unit is Adj + Ctl))) : (Qubit[] => Unit is Adj + Ctl) {
         return genIdxToUnitary(genFun(idx));
     }
@@ -130,16 +131,18 @@ namespace Microsoft.Quantum.Simulation {
 
     /// # Summary
     /// Used in implementation of `PauliBlockEncoding`
+    ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.PauliBlockEncoding
+    /// - Microsoft.Quantum.Simulation.PauliBlockEncoding
     internal function PauliLCUUnitary(generatorIndex: GeneratorIndex) : (Qubit[] => Unit is Adj + Ctl) {
         return ApplyPauliLCUUnitary(generatorIndex,_);
     }
 
     /// # Summary
     /// Used in implementation of `PauliBlockEncoding`
+    ///
     /// # See Also
-    /// - Microsoft.Quantum.Canon.PauliBlockEncoding
+    /// - Microsoft.Quantum.Simulation.PauliBlockEncoding
     internal operation ApplyPauliLCUUnitary(generatorIndex: GeneratorIndex, qubits: Qubit[])
     : Unit is Adj + Ctl {
         let ((idxPaulis, coeff), idxQubits) = generatorIndex!;

--- a/Standard/src/Simulation/Techniques.qs
+++ b/Standard/src/Simulation/Techniques.qs
@@ -28,7 +28,7 @@ namespace Microsoft.Quantum.Simulation {
     /// then this function returns an operation which performs adiabatic
     /// state preparation for the final dynamical generator.
     function InterpolatedEvolution(
-            inerpolationTime : Double,
+            interpolationTime : Double,
             evolutionGeneratorStart : EvolutionGenerator,
             evolutionGeneratorEnd : EvolutionGenerator,
             timeDependentSimulationAlgorithm : TimeDependentSimulationAlgorithm
@@ -38,7 +38,7 @@ namespace Microsoft.Quantum.Simulation {
         let (evolutionSetEnd, generatorSystemEnd) = evolutionGeneratorEnd!;
         let generatorSystemTimeDependent = InterpolateGeneratorSystems(generatorSystemStart, generatorSystemEnd);
         let evolutionSchedule = EvolutionSchedule(evolutionSetStart, generatorSystemTimeDependent!);
-        return timeDependentSimulationAlgorithm!(inerpolationTime, evolutionSchedule, _);
+        return timeDependentSimulationAlgorithm!(interpolationTime, evolutionSchedule, _);
     }
     
     

--- a/Standard/src/Simulation/Types.qs
+++ b/Standard/src/Simulation/Types.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.Simulation {
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.Simulation {
     /// # Output
     /// Unitary evolution by generator for time `Double`.
     newtype SimulationAlgorithm = ((Double, EvolutionGenerator, Qubit[]) => Unit is Adj + Ctl);
-    
+
     /// # Summary
 	/// Represents a time-dependent simulation algorithm.
 	/// 

--- a/Standard/src/Standard.csproj
+++ b/Standard/src/Standard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20102008-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.201016171-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20102008-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>

--- a/Standard/src/Standard.csproj
+++ b/Standard/src/Standard.csproj
@@ -1,11 +1,18 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Standard</AssemblyName>
-    <QsharpDocsGeneration>true</QsharpDocsGeneration>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages> <!-- otherwise the standard library is included by the Sdk -->
     <NoWarn>1591</NoWarn> <!-- warning regarding missing C# doc comments -->
+  </PropertyGroup>
+
+  <!-- Documentation generation options -->
+  <PropertyGroup>
+    <QsharpDocsGeneration>true</QsharpDocsGeneration>
+    <!-- Since Microsoft.Quantum.Standard is brought in by default,
+         suppress package ID display in this project only. -->
+    <QsharpDocsPackageId></QsharpDocsPackageId>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -30,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20082515-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.201016171-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>

--- a/Standard/tests/Standard.Tests.csproj
+++ b/Standard/tests/Standard.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.20082515-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Standard/tests/Standard.Tests.csproj
+++ b/Standard/tests/Standard.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.12.201016171-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.12.20102008-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Visualization/src/Visualization.csproj
+++ b/Visualization/src/Visualization.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20082515-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.201016171-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.12.20082515-beta" />
+    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.12.201016171-beta" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>
 

--- a/Visualization/src/Visualization.csproj
+++ b/Visualization/src/Visualization.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.201016171-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.12.20102008-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.12.201016171-beta" />
+    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.12.20102008-beta" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR uses the new warnings provided with the Markdown-based documentation generation tool to improve overall quality of API documentation, to resolve `/// # See Also` links to the most up-to-date format, and to make other miscellaneous fixes to API documentation using the new tool.