### PR TITLE
Enable PrepareArbitraryState to use state injection on Quantum Simulator

### DIFF
--- a/Chemistry/src/Runtime/Runtime.csproj
+++ b/Chemistry/src/Runtime/Runtime.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.14.20111301-pull">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118474-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.14.20111301-pull" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chemistry/src/Runtime/Runtime.csproj
+++ b/Chemistry/src/Runtime/Runtime.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118474-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chemistry/tests/ChemistryTests/QSharpTests.csproj
+++ b/Chemistry/tests/ChemistryTests/QSharpTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.14.20111301-pull">
 
   <Import Project="..\..\..\Build\props\tests.props" />
 

--- a/Chemistry/tests/ChemistryTests/QSharpTests.csproj
+++ b/Chemistry/tests/ChemistryTests/QSharpTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
 
   <Import Project="..\..\..\Build\props\tests.props" />
 

--- a/Chemistry/tests/SystemTests/SystemTests.csproj
+++ b/Chemistry/tests/SystemTests/SystemTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.14.20111301-pull">
 
   <Import Project="..\..\..\Build\props\tests.props" />
 

--- a/Chemistry/tests/SystemTests/SystemTests.csproj
+++ b/Chemistry/tests/SystemTests/SystemTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
 
   <Import Project="..\..\..\Build\props\tests.props" />
 

--- a/MachineLearning/src/MachineLearning.csproj
+++ b/MachineLearning/src/MachineLearning.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.14.20111301-pull">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.MachineLearning</AssemblyName>

--- a/MachineLearning/src/MachineLearning.csproj
+++ b/MachineLearning/src/MachineLearning.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.MachineLearning</AssemblyName>

--- a/MachineLearning/tests/MachineLearningTests.csproj
+++ b/MachineLearning/tests/MachineLearningTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/MachineLearning/tests/MachineLearningTests.csproj
+++ b/MachineLearning/tests/MachineLearningTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.14.20111301-pull">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Numerics/src/Numerics.csproj
+++ b/Numerics/src/Numerics.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118474-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Numerics/src/Numerics.csproj
+++ b/Numerics/src/Numerics.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.14.20111301-pull">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118474-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.14.20111301-pull" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Numerics/tests/NumericsTests.csproj
+++ b/Numerics/tests/NumericsTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Numerics/tests/NumericsTests.csproj
+++ b/Numerics/tests/NumericsTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.14.20111301-pull">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Standard/src/Preparation/Arbitrary.cs
+++ b/Standard/src/Preparation/Arbitrary.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.Preparation
                 var (polarAmplitudes, qubits) = _args;
 
                 // TODO: benchmark for small `qubits` arrays to find out in which cases emulation is actually
-                // benefitial.
+                // beneficial.
                 if (this.Simulator == null)
                 {
                     return base.__Body__(_args);

--- a/Standard/src/Preparation/Arbitrary.cs
+++ b/Standard/src/Preparation/Arbitrary.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Runtime.InteropServices;
+using Microsoft.Quantum.Simulation;
+using Microsoft.Quantum.Simulation.Core;
+using Microsoft.Quantum.Simulation.Simulators;
+
+
+namespace Microsoft.Quantum.Preparation
+{
+    public partial class PrepareArbitraryState
+    {
+        /// <summary>
+        ///  Provides a native emulation of the PrepareArbitraryState operation when
+        ///  the operation is executed using the full-state QuantumSimulator.
+        /// </summary>
+        public class Native : PrepareArbitraryState
+        {
+            [DllImport(QuantumSimulator.QSIM_DLL_NAME, ExactSpelling = true,
+                CallingConvention = CallingConvention.Cdecl, EntryPoint = "InjectState")]
+            private static extern double InjectState(uint sid, uint n, uint[] q, double[] re, double[] im);
+
+            private QuantumSimulator Simulator { get; }
+
+            public Native(IOperationFactory m) : base(m)
+            {
+                this.Simulator = m as QuantumSimulator;
+            }
+
+            /// <summary>
+            /// Overrides the body to do the emulation when possible. If emulation is not possible, then
+            /// it just invokes the default Q# implementation.
+            /// </summary>
+            public override Func<(IQArray<Math.ComplexPolar>, Arithmetic.LittleEndian), QVoid>__Body__ => (_args) =>
+            {
+                var (polar_amplitudes, qubits) = _args;
+
+                if (this.Simulator == null)
+                {
+                    return base.__Body__(_args);
+                }
+
+                // calculate the norm as we might need to normalize the state
+                var norm = 0.0;
+                foreach (var pa in polar_amplitudes) { norm += pa.Magnitude * pa.Magnitude; }
+                norm = System.Math.Sqrt(norm);
+
+                var state_size = polar_amplitudes.Length;
+                var re = new double[state_size];
+                var im = new double[state_size];
+                for (int i = 0; i < state_size; i++)
+                {
+                    var pa = polar_amplitudes[i];
+                    re[i] = (System.Math.Abs(pa.Magnitude) * System.Math.Cos(pa.Argument))/norm;
+                    im[i] = (System.Math.Abs(pa.Magnitude) * System.Math.Sin(pa.Argument))/norm;
+                }
+
+                InjectState(Simulator.Id, (uint)qubits.Data.Length, qubits.Data.GetIds(), re, im);
+                return QVoid.Instance;
+            };
+        }
+    }
+}

--- a/Standard/src/Preparation/Arbitrary.cs
+++ b/Standard/src/Preparation/Arbitrary.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
-using System.Collections;
 using System.Runtime.InteropServices;
 using Microsoft.Quantum.Simulation;
 using Microsoft.Quantum.Simulation.Core;
@@ -11,19 +12,19 @@ using Microsoft.Quantum.Simulation.Simulators;
 
 namespace Microsoft.Quantum.Preparation
 {
-    public partial class PrepareArbitraryState
+    public partial class ApproximatelyPrepareArbitraryState
     {
         /// <summary>
-        ///  Provides a native emulation of the PrepareArbitraryState operation when
+        ///  Provides a native emulation of the ApproximatelyPrepareArbitraryState operation when
         ///  the operation is executed using the full-state QuantumSimulator.
         /// </summary>
-        public class Native : PrepareArbitraryState
+        public class Native : ApproximatelyPrepareArbitraryState
         {
             [DllImport(QuantumSimulator.QSIM_DLL_NAME, ExactSpelling = true,
                 CallingConvention = CallingConvention.Cdecl, EntryPoint = "InjectState")]
             private static extern double InjectState(uint sid, uint n, uint[] q, double[] re, double[] im);
 
-            private QuantumSimulator Simulator { get; }
+            private QuantumSimulator? Simulator { get; }
 
             public Native(IOperationFactory m) : base(m)
             {
@@ -34,10 +35,12 @@ namespace Microsoft.Quantum.Preparation
             /// Overrides the body to do the emulation when possible. If emulation is not possible, then
             /// it just invokes the default Q# implementation.
             /// </summary>
-            public override Func<(IQArray<Math.ComplexPolar>, Arithmetic.LittleEndian), QVoid>__Body__ => (_args) =>
+            public override Func<(double, IQArray<Math.ComplexPolar>, Arithmetic.LittleEndian), QVoid>__Body__ => (_args) =>
             {
-                var (polar_amplitudes, qubits) = _args;
+                var (tolerance, polarAmplitudes, qubits) = _args;
 
+                // TODO: benchmark for small `qubits` arrays to find out in which cases emulation is actually
+                // benefitial.
                 if (this.Simulator == null)
                 {
                     return base.__Body__(_args);
@@ -45,20 +48,29 @@ namespace Microsoft.Quantum.Preparation
 
                 // calculate the norm as we might need to normalize the state
                 var norm = 0.0;
-                foreach (var pa in polar_amplitudes) { norm += pa.Magnitude * pa.Magnitude; }
+                foreach (var pa in polarAmplitudes) { norm += pa.Magnitude * pa.Magnitude; }
                 norm = System.Math.Sqrt(norm);
 
-                var state_size = polar_amplitudes.Length;
+                var state_size = polarAmplitudes.Length;
                 var re = new double[state_size];
                 var im = new double[state_size];
                 for (int i = 0; i < state_size; i++)
                 {
-                    var pa = polar_amplitudes[i];
+                    var pa = polarAmplitudes[i];
                     re[i] = (System.Math.Abs(pa.Magnitude) * System.Math.Cos(pa.Argument))/norm;
                     im[i] = (System.Math.Abs(pa.Magnitude) * System.Math.Sin(pa.Argument))/norm;
                 }
 
-                InjectState(Simulator.Id, (uint)qubits.Data.Length, qubits.Data.GetIds(), re, im);
+                // Replace implementation in the library to stop throwing and return success/failure result instead.
+                try
+                {
+                    // State injection is precise so tolerance isn't used.
+                    InjectState(Simulator.Id, (uint)qubits.Data.Length, qubits.Data.GetIds(), re, im);
+                }
+                catch
+                {
+                    return base.__Body__(_args);
+                }
                 return QVoid.Instance;
             };
         }

--- a/Standard/src/Preparation/Arbitrary.qs
+++ b/Standard/src/Preparation/Arbitrary.qs
@@ -162,6 +162,21 @@ namespace Microsoft.Quantum.Preparation {
     }
 
     /// # Summary
+    /// Given a set of coefficients and a little-endian encoded quantum register
+    /// of unentangled qubits, all of which are in zero state, prepares a state
+    /// on that register described by the given coefficients. Uses state emulation
+    /// if supported by the target.
+    ///
+    /// # Notes
+    /// If the register isn't in zero state, the emulation will fail and fallback
+    /// to quantum state preparation.
+    /// This operation doesn't provide Adj/Ctr variants, because, in general, there
+    /// are no efficient emulation algorithms for those.
+    operation _PrepareAmplitudesFromZeroState(coefficients : ComplexPolar[], qubits : LittleEndian) : Unit {
+        ApproximatelyPrepareArbitraryState(0.0, coefficients, qubits);
+    }
+
+    /// # Summary
     /// Given a set of coefficients and a little-endian encoded quantum register,
     /// prepares an state on that register described by the given coefficients,
     /// up to a given approximation tolerance.

--- a/Standard/src/Preparation/Arbitrary.qs
+++ b/Standard/src/Preparation/Arbitrary.qs
@@ -172,6 +172,9 @@ namespace Microsoft.Quantum.Preparation {
     /// to quantum state preparation.
     /// This operation doesn't provide Adj/Ctr variants, because, in general, there
     /// are no efficient emulation algorithms for those.
+    ///
+    /// For internal use only, until proposal https://github.com/microsoft/qsharp-language/pull/41
+    /// is finalized and implemented.
     operation _PrepareAmplitudesFromZeroState(coefficients : ComplexPolar[], qubits : LittleEndian) : Unit {
         ApproximatelyPrepareArbitraryState(0.0, coefficients, qubits);
     }

--- a/Standard/src/Standard.csproj
+++ b/Standard/src/Standard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118474-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>

--- a/Standard/src/Standard.csproj
+++ b/Standard/src/Standard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.14.20111301-pull">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -37,7 +37,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118474-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.14.20111301-pull" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>

--- a/Standard/tests/Standard.Tests.csproj
+++ b/Standard/tests/Standard.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118141-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Standard/tests/Standard.Tests.csproj
+++ b/Standard/tests/Standard.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.13.201118474-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.14.20111301-pull">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Visualization/src/Visualization.csproj
+++ b/Visualization/src/Visualization.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118474-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.14.20111301-pull" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.13.201118474-beta" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.14.20111301-pull" PrivateAssets="All" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>
 

--- a/Visualization/src/Visualization.csproj
+++ b/Visualization/src/Visualization.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.13.201118474-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.13.201118141-beta" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.13.201118474-beta" PrivateAssets="All" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>
 


### PR DESCRIPTION
Added new non-Adj/non-Ctr operation `_PrepareAmplitudesFromZeroState` that will emulate state preparation if running on a simulator that supports it and the prerequisites are met.

Had to move onto SDK 0.14.20111301-pull to pick up the new functionality in the Quantum Simulator.