### PR TITLE
Add ApplyUnitary operation

### DIFF
--- a/Standard/src/Synthesis/MatrixUtils.cs
+++ b/Standard/src/Synthesis/MatrixUtils.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System.Diagnostics;
 using System.Numerics;
 using Microsoft.Quantum.Simulation.Core;
@@ -7,7 +10,7 @@ namespace Microsoft.Quantum.Synthesis
     internal class MatrixUtils
     {
         // Checks whether given matrix is unitary.
-        public static bool isMatrixUnitary(Complex[,] matrix)
+        public static bool IsMatrixUnitary(Complex[,] matrix)
         {
             int n = matrix.GetLength(0);
             if (matrix.GetLength(1) != n) return false; // Unitary matrix must be square.
@@ -32,7 +35,7 @@ namespace Microsoft.Quantum.Synthesis
         }
 
         // Converts matrix from C# array to Q# array.
-        public static QArray<QArray<Quantum.Math.Complex>> matrixToQs(Complex[,] b)
+        public static QArray<QArray<Quantum.Math.Complex>> MatrixToQs(Complex[,] b)
         {
             long n1 = b.GetLength(0);
             long n2 = b.GetLength(1);
@@ -50,7 +53,7 @@ namespace Microsoft.Quantum.Synthesis
         }
 
         // Converts square matrix from Q# array to C#.
-        public static Complex[,] squareMatrixFromQs(IQArray<IQArray<Quantum.Math.Complex>> a)
+        public static Complex[,] SquareMatrixFromQs(IQArray<IQArray<Quantum.Math.Complex>> a)
         {
             long n = a.Length;
             var b = new Complex[n, n];

--- a/Standard/src/Synthesis/MatrixUtils.cs
+++ b/Standard/src/Synthesis/MatrixUtils.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics;
+using System.Numerics;
+using Microsoft.Quantum.Simulation.Core;
+
+namespace Microsoft.Quantum.Synthesis
+{
+    internal class MatrixUtils {
+        // Checks whether given matrix is unitary.
+        public static bool isMatrixUnitary(Complex[,] matrix)
+        {
+            int n = matrix.GetLength(0);
+            if (matrix.GetLength(1) != n) return false; // Unitary matrix must be square.
+
+            for (int i = 0; i < n; i++)
+            {
+                for (int j = 0; j < n; j++)
+                {
+                    Complex dotProduct = 0.0;
+                    for (int k = 0; k < n; k++)
+                    {
+                        dotProduct += matrix[i, k] * Complex.Conjugate(matrix[j, k]);
+                    }
+                    Complex expectedDotProduct = (i == j) ? 1.0 : 0.0;
+                    if ((dotProduct - expectedDotProduct).Magnitude > 1e-9)
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        // Converts matrix from C# array to Q# array.
+        public static QArray<QArray<Quantum.Math.Complex>> matrixToQs(Complex[,] b)
+        {
+            long n1 = b.GetLength(0);
+            long n2 = b.GetLength(1);
+            var a = new QArray<Quantum.Math.Complex>[n1];
+            for (long i = 0; i < n1; i++)
+            {
+                var row = new Quantum.Math.Complex[n2];
+                for (int j = 0; j < n2; j++)
+                {
+                    row[j] = new Quantum.Math.Complex((b[i, j].Real, b[i, j].Imaginary));
+                }
+                a[i] = new QArray<Quantum.Math.Complex>(row);
+            }
+            return new QArray<QArray<Quantum.Math.Complex>>(a);
+        }
+
+        // Converts square matrix from Q# array to C#.
+        public static Complex[,] squareMatrixFromQs(IQArray<IQArray<Quantum.Math.Complex>> a)
+        {
+            long n = a.Length;
+            var b = new Complex[n, n];
+            for (long i = 0; i < n; i++)
+            {
+                Debug.Assert(a[i].Length == n, "Matrix is not square");
+                for (long j = 0; j < n; j++)
+                {
+                    b[i, j] = new Complex(a[i][j].Real, a[i][j].Imag);
+                }
+            }
+            return b;
+        }
+    }
+}

--- a/Standard/src/Synthesis/MatrixUtils.cs
+++ b/Standard/src/Synthesis/MatrixUtils.cs
@@ -4,7 +4,8 @@ using Microsoft.Quantum.Simulation.Core;
 
 namespace Microsoft.Quantum.Synthesis
 {
-    internal class MatrixUtils {
+    internal class MatrixUtils
+    {
         // Checks whether given matrix is unitary.
         public static bool isMatrixUnitary(Complex[,] matrix)
         {

--- a/Standard/src/Synthesis/MatrixUtils.cs
+++ b/Standard/src/Synthesis/MatrixUtils.cs
@@ -9,8 +9,10 @@ namespace Microsoft.Quantum.Synthesis
 {
     internal class MatrixUtils
     {
-        // Checks whether given matrix is unitary.
-        public static bool IsMatrixUnitary(Complex[,] matrix)
+        /// <summary>
+        /// Checks whether given matrix is unitary.
+        /// </summary>
+        public static bool IsMatrixUnitary(Complex[,] matrix, double tol = 1e-10)
         {
             int n = matrix.GetLength(0);
             if (matrix.GetLength(1) != n) return false; // Unitary matrix must be square.
@@ -25,7 +27,7 @@ namespace Microsoft.Quantum.Synthesis
                         dotProduct += matrix[i, k] * Complex.Conjugate(matrix[j, k]);
                     }
                     Complex expectedDotProduct = (i == j) ? 1.0 : 0.0;
-                    if ((dotProduct - expectedDotProduct).Magnitude > 1e-9)
+                    if ((dotProduct - expectedDotProduct).Magnitude > tol)
                     {
                         return false;
                     }
@@ -34,7 +36,9 @@ namespace Microsoft.Quantum.Synthesis
             return true;
         }
 
-        // Converts matrix from C# array to Q# array.
+        /// <summary>
+        /// Converts matrix from C# array to Q# array.
+        /// </summary>
         public static QArray<QArray<Quantum.Math.Complex>> MatrixToQs(Complex[,] b)
         {
             long n1 = b.GetLength(0);
@@ -52,15 +56,18 @@ namespace Microsoft.Quantum.Synthesis
             return new QArray<QArray<Quantum.Math.Complex>>(a);
         }
 
-        // Converts square matrix from Q# array to C#.
-        public static Complex[,] SquareMatrixFromQs(IQArray<IQArray<Quantum.Math.Complex>> a)
+        /// <summary>
+        /// Converts matrix from Q# array to C# array.
+        /// </summary>
+        public static Complex[,] MatrixFromQs(IQArray<IQArray<Quantum.Math.Complex>> a)
         {
-            long n = a.Length;
-            var b = new Complex[n, n];
-            for (long i = 0; i < n; i++)
+            long n1 = a.Length;
+            long n2 = a[0].Length;
+            var b = new Complex[n1, n2];
+            for (long i = 0; i < n1; i++)
             {
-                Debug.Assert(a[i].Length == n, "Matrix is not square");
-                for (long j = 0; j < n; j++)
+                Debug.Assert(a[i].Length == n2);
+                for (long j = 0; j < n2; j++)
                 {
                     b[i, j] = new Complex(a[i][j].Real, a[i][j].Imag);
                 }

--- a/Standard/src/Synthesis/TwoLevelUnitary.cs
+++ b/Standard/src/Synthesis/TwoLevelUnitary.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 using System;
 using System.Diagnostics;
 using System.Numerics;
@@ -5,8 +8,11 @@ using Microsoft.Quantum.Simulation.Core;
 
 namespace Microsoft.Quantum.Synthesis
 {
-    // Represents a square matrix which is an identity matrix with elements on positions
-    // (i1, i1), (i1, i2), (i2, i1), (i2, i2) replaced with elements from unitary matrix `mx`. 
+
+    /// <summary>
+    /// Represents a square matrix which is an identity matrix with elements on positions
+    /// (i1, i1), (i1, i2), (i2, i1), (i2, i2) replaced with elements from unitary matrix <c>mx</c>. 
+    /// </summary>
     internal class TwoLevelUnitary
     {
         private Complex[,] mx;   // 2x2 non-trivial principal submatrix.
@@ -14,13 +20,13 @@ namespace Microsoft.Quantum.Synthesis
 
         public TwoLevelUnitary(Complex[,] mx, int i1, int i2)
         {
-            Debug.Assert(MatrixUtils.isMatrixUnitary(mx), "Matrix is not unitary");
+            Debug.Assert(MatrixUtils.IsMatrixUnitary(mx), "Matrix is not unitary");
             this.mx = mx;
             this.i1 = i1;
             this.i2 = i2;
         }
 
-        public void applyPermutation(int[] perm)
+        public void ApplyPermutation(int[] perm)
         {
             i1 = perm[i1];
             i2 = perm[i2];
@@ -56,16 +62,14 @@ namespace Microsoft.Quantum.Synthesis
             }
         }
 
-        public bool isIdentity()
-        {
-            return (mx[0, 0] - 1).Magnitude < 1e-9 && mx[0, 1].Magnitude < 1e-9 &&
-                    mx[1, 0].Magnitude < 1e-9 && (mx[1, 1] - 1).Magnitude < 1e-9;
-        }
+        public bool IsIdentity() =>
+            (mx[0, 0] - 1).Magnitude < 1e-9 && mx[0, 1].Magnitude < 1e-9 &&
+            mx[1, 0].Magnitude < 1e-9 && (mx[1, 1] - 1).Magnitude < 1e-9;
 
         // Converts to tuple to be passed to Q#.
         public (IQArray<IQArray<Quantum.Math.Complex>>, long, long) toQsharp()
         {
-            return (MatrixUtils.matrixToQs(this.mx), this.i1, this.i2);
+            return (MatrixUtils.MatrixToQs(this.mx), this.i1, this.i2);
         }
     }
 }

--- a/Standard/src/Synthesis/TwoLevelUnitary.cs
+++ b/Standard/src/Synthesis/TwoLevelUnitary.cs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-
 using System;
 using System.Diagnostics;
 using System.Numerics;
@@ -8,7 +7,6 @@ using Microsoft.Quantum.Simulation.Core;
 
 namespace Microsoft.Quantum.Synthesis
 {
-
     /// <summary>
     /// Represents a square matrix which is an identity matrix with elements on positions
     /// (i1, i1), (i1, i2), (i2, i1), (i2, i2) replaced with elements from unitary matrix <c>mx</c>. 
@@ -33,9 +31,9 @@ namespace Microsoft.Quantum.Synthesis
         }
 
         // Ensures that index1 < index2.
-        public void orderIndices()
+        public void OrderIndices()
         {
-            if (this.i1 > this.i2)
+            if (i1 > i2)
             {
                 (i1, i2) = (i2, i1);
                 (mx[0, 0], mx[1, 1]) = (mx[1, 1], mx[0, 0]);
@@ -43,8 +41,8 @@ namespace Microsoft.Quantum.Synthesis
             }
         }
 
-        // Equivalent to inversion.
-        public void conjugateTranspose()
+        // Equivalent to inversion (because matrix is unitary).
+        public void ConjugateTranspose()
         {
             mx[0, 0] = Complex.Conjugate(mx[0, 0]);
             mx[1, 1] = Complex.Conjugate(mx[1, 1]);
@@ -52,7 +50,7 @@ namespace Microsoft.Quantum.Synthesis
         }
 
         // Applies A = A * M, where M is this matrix.
-        public void multiplyRight(Complex[,] A)
+        public void MultiplyRight(Complex[,] A)
         {
             int n = A.GetLength(0);
             for (int i = 0; i < n; i++)
@@ -62,14 +60,12 @@ namespace Microsoft.Quantum.Synthesis
             }
         }
 
-        public bool IsIdentity() =>
-            (mx[0, 0] - 1).Magnitude < 1e-9 && mx[0, 1].Magnitude < 1e-9 &&
-            mx[1, 0].Magnitude < 1e-9 && (mx[1, 1] - 1).Magnitude < 1e-9;
+        public bool IsIdentity(double tol = 1e-10) =>
+            (mx[0, 0] - 1).Magnitude < tol && mx[0, 1].Magnitude < tol &&
+            mx[1, 0].Magnitude < tol && (mx[1, 1] - 1).Magnitude < tol;
 
         // Converts to tuple to be passed to Q#.
-        public (IQArray<IQArray<Quantum.Math.Complex>>, long, long) toQsharp()
-        {
-            return (MatrixUtils.MatrixToQs(this.mx), this.i1, this.i2);
-        }
+        public (IQArray<IQArray<Quantum.Math.Complex>>, long, long) ToQsharp() =>
+            (MatrixUtils.MatrixToQs(this.mx), this.i1, this.i2);
     }
 }

--- a/Standard/src/Synthesis/TwoLevelUnitary.cs
+++ b/Standard/src/Synthesis/TwoLevelUnitary.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using Microsoft.Quantum.Simulation.Core;
+
+namespace Microsoft.Quantum.Synthesis
+{
+    // Represents a square matrix which is an identity matrix with elements on positions
+    // (i1, i1), (i1, i2), (i2, i1), (i2, i2) replaced with elements from unitary matrix `mx`. 
+    internal class TwoLevelUnitary
+    {
+        private Complex[,] mx;   // 2x2 non-trivial principal submatrix.
+        private int i1, i2;      // Indices of non-trivial submatrix.
+
+        public TwoLevelUnitary(Complex[,] mx, int i1, int i2)
+        {
+            Debug.Assert(MatrixUtils.isMatrixUnitary(mx), "Matrix is not unitary");
+            this.mx = mx;
+            this.i1 = i1;
+            this.i2 = i2;
+        }
+
+        public void applyPermutation(int[] perm)
+        {
+            i1 = perm[i1];
+            i2 = perm[i2];
+        }
+
+        // Ensures that index1 < index2.
+        public void orderIndices()
+        {
+            if (this.i1 > this.i2)
+            {
+                (i1, i2) = (i2, i1);
+                (mx[0, 0], mx[1, 1]) = (mx[1, 1], mx[0, 0]);
+                (mx[0, 1], mx[1, 0]) = (mx[1, 0], mx[0, 1]);
+            }
+        }
+
+        // Equivalent to inversion.
+        public void conjugateTranspose()
+        {
+            mx[0, 0] = Complex.Conjugate(mx[0, 0]);
+            mx[1, 1] = Complex.Conjugate(mx[1, 1]);
+            (mx[0, 1], mx[1, 0]) = (Complex.Conjugate(mx[1, 0]), Complex.Conjugate(mx[0, 1]));
+        }
+
+        // Applies A = A * M, where M is this matrix.
+        public void multiplyRight(Complex[,] A)
+        {
+            int n = A.GetLength(0);
+            for (int i = 0; i < n; i++)
+            {
+                (A[i, i1], A[i, i2]) = (A[i, i1] * mx[0, 0] + A[i, i2] * mx[1, 0], A[i, i1] * mx[0, 1] + A[i, i2] * mx[1, 1]);
+            }
+        }
+
+        public bool isIdentity()
+        {
+            return (mx[0, 0] - 1).Magnitude < 1e-9 && mx[0, 1].Magnitude < 1e-9 && mx[1, 0].Magnitude < 1e-9 && (mx[1, 1] - 1).Magnitude < 1e-9;
+        }
+
+        // Converts to tuple to be passed to Q#.
+        public (IQArray<IQArray<Quantum.Math.Complex>>, long, long) toQsharp()
+        {
+            return (MatrixUtils.matrixToQs(this.mx), this.i1, this.i2);
+        }
+    }
+}

--- a/Standard/src/Synthesis/TwoLevelUnitary.cs
+++ b/Standard/src/Synthesis/TwoLevelUnitary.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Quantum.Synthesis
             (mx[0, 0] - 1).Magnitude < tol && mx[0, 1].Magnitude < tol &&
             mx[1, 0].Magnitude < tol && (mx[1, 1] - 1).Magnitude < tol;
 
-        // Converts to tuple to be passed to Q#.
+        // Converts to a tuple to be passed to Q#.
         public (IQArray<IQArray<Quantum.Math.Complex>>, long, long) ToQsharp() =>
             (MatrixUtils.MatrixToQs(this.mx), this.i1, this.i2);
     }

--- a/Standard/src/Synthesis/TwoLevelUnitary.cs
+++ b/Standard/src/Synthesis/TwoLevelUnitary.cs
@@ -51,13 +51,15 @@ namespace Microsoft.Quantum.Synthesis
             int n = A.GetLength(0);
             for (int i = 0; i < n; i++)
             {
-                (A[i, i1], A[i, i2]) = (A[i, i1] * mx[0, 0] + A[i, i2] * mx[1, 0], A[i, i1] * mx[0, 1] + A[i, i2] * mx[1, 1]);
+                (A[i, i1], A[i, i2]) = (A[i, i1] * mx[0, 0] + A[i, i2] * mx[1, 0],
+                                        A[i, i1] * mx[0, 1] + A[i, i2] * mx[1, 1]);
             }
         }
 
         public bool isIdentity()
         {
-            return (mx[0, 0] - 1).Magnitude < 1e-9 && mx[0, 1].Magnitude < 1e-9 && mx[1, 0].Magnitude < 1e-9 && (mx[1, 1] - 1).Magnitude < 1e-9;
+            return (mx[0, 0] - 1).Magnitude < 1e-9 && mx[0, 1].Magnitude < 1e-9 &&
+                    mx[1, 0].Magnitude < 1e-9 && (mx[1, 1] - 1).Magnitude < 1e-9;
         }
 
         // Converts to tuple to be passed to Q#.

--- a/Standard/src/Synthesis/UnitaryDecomposition.cs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+//using static System.Math;
+// TODO: trim not needed stuff.
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Quantum.Diagnostics.Emulation;
+using Microsoft.Quantum.Simulation.Common;
+using Microsoft.Quantum.Simulation.Core;
+using Microsoft.Quantum.Simulation.Simulators;
+using Microsoft.Quantum.Math;
+
+namespace Microsoft.Quantum.Synthesis {
+    public partial class TwoLevelDecomposition {
+        public class Native : TwoLevelDecomposition {
+            public Native(IOperationFactory m) : base(m) {}
+
+
+
+            private Complex[,] matrixFromQs(IQArray<IQArray<Complex>> a) {
+                long n = a.Length;
+                Complex[,] b = new Complex[n, n];
+                for(long i=0;i<n;i++) {
+                    Debug.Assert(a[i].Length == n, "Matrix is not square");
+                    for (long j=0;j<n;j++) {
+                        b[i,j] = a[i][j];
+                    }
+                }
+                return b;
+            }
+
+            private QArray<QArray<Complex>> matrixToQs(Complex[,] b) {
+                long n = b.GetLength(0);
+                QArray<Complex>[] a = new QArray<Complex>[n];
+                for(long i=0;i<n;i++) {
+                    Complex[] row = new Complex[n];
+                    for(int j = 0;j<n;j++) {
+                        row[j] = b[i,j];
+                    }
+                    a[i] = new QArray<Complex>(row);
+                }
+                return new QArray<QArray<Complex>>(a);
+            }
+
+            private QArray<QArray<QArray<Complex>>> matricesToQs(List<Complex[,]> matrices) {
+                int n = (int)matrices.Count;
+                QArray<QArray<Complex>>[] result = new QArray<QArray<Complex>>[n];
+                for(int i=0;i<n;i++) {
+                    result[i] = matrixToQs(matrices[i]);
+                }
+                return new QArray<QArray<QArray<Complex>>>(result);
+            }
+
+            private (IQArray<IQArray<IQArray<Complex>>>, IQArray<IQArray<long>>) TwoLevelDecomposeGray(IQArray<IQArray<Complex>> unitary) {
+                Complex[,] a = matrixFromQs(unitary);
+                List<Complex[,]> r1 = new List<Complex[,]>();
+                r1.Add(a);
+                
+                QArray<QArray<QArray<Complex>>> r2 = matricesToQs(r1);
+
+                QArray<long> r3 = new QArray<long> ( new long[] {0, 1});
+                QArray<QArray<long>> r4 = new QArray<QArray<long>>(new QArray<long>[] {r3});
+
+                return (r2, r4);
+            }
+
+            // Override __Body__ property to use C# function
+            public override Func<IQArray<IQArray<Complex>>, (IQArray<IQArray<IQArray<Complex>>>, IQArray<IQArray<long>>)> __Body__ => TwoLevelDecomposeGray;
+        }
+    }
+}

--- a/Standard/src/Synthesis/UnitaryDecomposition.cs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.cs
@@ -60,18 +60,20 @@ namespace Microsoft.Quantum.Synthesis
                             // to multiplying by identity matrix.
                             mx = new Complex[,] { { 1.0, 0.0 }, { 0.0, 1.0 } };
                             // But if it's last in a row, ensure that diagonal element will be 1.
-                            if (j == i + 1) {
-                                mx = new Complex[,] { { 1/a, 0.0 }, { 0.0, a } };
-                            }                            
+                            if (j == i + 1)
+                            {
+                                mx = new Complex[,] { { 1 / a, 0.0 }, { 0.0, a } };
+                            }
                         }
                         else if (A[i, j - 1].Magnitude <= tol)
                         {
                             // Just swap columns with Pauli X matrix.
                             mx = new Complex[,] { { 0.0, 1.0 }, { 1.0, 0.0 } };
                             // But if it's last in a row, ensure that diagonal element will be 1.
-                            if (j == i + 1) {
-                                mx = new Complex[,] { { 0.0, b }, { 1/b, 0.0 } };
-                            } 
+                            if (j == i + 1)
+                            {
+                                mx = new Complex[,] { { 0.0, b }, { 1 / b, 0.0 } };
+                            }
                         }
                         else
                         {
@@ -79,8 +81,9 @@ namespace Microsoft.Quantum.Synthesis
                         }
                         var u2x2 = new TwoLevelUnitary(mx, j - 1, j);
                         u2x2.MultiplyRight(A);
-                        u2x2.ConjugateTranspose();    
-                        if (!u2x2.IsIdentity()) {
+                        u2x2.ConjugateTranspose();
+                        if (!u2x2.IsIdentity())
+                        {
                             result.Add(u2x2);
                         }
                     }

--- a/Standard/src/Synthesis/UnitaryDecomposition.cs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Quantum.Synthesis
                             // Element is already zero. We shouldn't do anything, which equivalent 
                             // to multiplying by identity matrix.
                             mx = new Complex[,] { { 1.0, 0.0 }, { 0.0, 1.0 } };
-                            // But if it's last in row, ensure that diagonal element will be 1.
+                            // But if it's last in a row, ensure that diagonal element will be 1.
                             if (j == i + 1) {
                                 mx = new Complex[,] { { 1/a, 0.0 }, { 0.0, a } };
                             }                            
@@ -68,7 +68,7 @@ namespace Microsoft.Quantum.Synthesis
                         {
                             // Just swap columns with Pauli X matrix.
                             mx = new Complex[,] { { 0.0, 1.0 }, { 1.0, 0.0 } };
-                            // But if it's last in row, ensure that diagonal element will be 1.
+                            // But if it's last in a row, ensure that diagonal element will be 1.
                             if (j == i + 1) {
                                 mx = new Complex[,] { { 0.0, b }, { 1/b, 0.0 } };
                             } 
@@ -100,8 +100,8 @@ namespace Microsoft.Quantum.Synthesis
                 return result;
             }
 
-            // Returns permutation of numbers from 0 to n-1 such as any two consequent number 
-            // differ in exactly one bit.
+            // Returns permutation of numbers from 0 to n-1 such that any two consequent numbers in
+            // it differ in exactly one bit.
             private static int[] GrayCode(int n)
             {
                 var result = new int[n];
@@ -150,7 +150,8 @@ namespace Microsoft.Quantum.Synthesis
 
             // Decomposes unitary matrix into product of 2-level unitary matrices.
             // Every resulting 2-level matrix is represnted by 2x2 non-trivial submatrix and indices
-            // of this submatrix. Indices are guaranteed to be sorted and differ in exactly one bit.
+            // of this submatrix. Indices are guaranteed to be sorted and to differ in exactly one 
+            // bit.
             private IQArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)> Decompose(
                 IQArray<IQArray<Quantum.Math.Complex>> unitary)
             {

--- a/Standard/src/Synthesis/UnitaryDecomposition.cs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.cs
@@ -79,7 +79,8 @@ namespace Microsoft.Quantum.Synthesis
                 return result;
             }
 
-            // Returns permutation of numbers from 0 to n-1 such as any two consequent number differ in exactly one bit.
+            // Returns permutation of numbers from 0 to n-1 such as any two consequent number 
+            // differ in exactly one bit.
             private static int[] grayCode(int n)
             {
                 var result = new int[n];
@@ -108,8 +109,7 @@ namespace Microsoft.Quantum.Synthesis
             }
 
             // Returns list of two-level unitary matrices, which multiply to A.
-            //
-            // Every matrix has indices differing in exactly 1 bit (this is achieved with Gray code).
+            // Every matrix has indices differing in exactly 1 bit.
             private static List<TwoLevelUnitary> twoLevelDecomposeGray(Complex[,] A)
             {
                 int n = A.GetLength(0);
@@ -127,7 +127,8 @@ namespace Microsoft.Quantum.Synthesis
             }
 
             // Decomposes unitary matrix into product of 2-level unitary matrices.
-            private IQArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)> Decompose(IQArray<IQArray<Quantum.Math.Complex>> unitary)
+            private IQArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)> Decompose(
+                IQArray<IQArray<Quantum.Math.Complex>> unitary)
             {
                 Complex[,] a = MatrixUtils.squareMatrixFromQs(unitary);
                 List<TwoLevelUnitary> matrices = twoLevelDecomposeGray(a);
@@ -140,7 +141,9 @@ namespace Microsoft.Quantum.Synthesis
                 return new QArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)>(result);
             }
 
-            public override Func<IQArray<IQArray<Quantum.Math.Complex>>, IQArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)>> __Body__ => Decompose;
+            public override Func<IQArray<IQArray<Quantum.Math.Complex>>, 
+                IQArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)>> __Body__ => 
+                Decompose;
         }
     }
 }

--- a/Standard/src/Synthesis/UnitaryDecomposition.cs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.cs
@@ -134,21 +134,19 @@ namespace Microsoft.Quantum.Synthesis
 
             // Returns list of two-level unitary matrices, which multiply to A.
             // Every matrix has indices differing in exactly 1 bit.
-            private static List<TwoLevelUnitary> twoLevelDecomposeGray(Complex[,] A)
+            private static IEnumerable<TwoLevelUnitary> twoLevelDecomposeGray(Complex[,] A)
             {
                 int n = A.GetLength(0);
                 Debug.Assert(A.GetLength(1) == n, "Matrix is not square.");
                 Debug.Assert(MatrixUtils.IsMatrixUnitary(A), "Matrix is not unitary.");
-
                 int[] perm = GrayCode(n);
                 A = PermuteMatrix(A, perm);
-                List<TwoLevelUnitary> result = TwoLevelDecompose(A);
-                foreach (TwoLevelUnitary matrix in result)
+                foreach (TwoLevelUnitary matrix in  TwoLevelDecompose(A))
                 {
                     matrix.ApplyPermutation(perm);
                     matrix.OrderIndices();
+                    yield return matrix;
                 }
-                return result;
             }
 
             // Decomposes unitary matrix into product of 2-level unitary matrices.

--- a/Standard/src/Synthesis/UnitaryDecomposition.cs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.cs
@@ -134,14 +134,14 @@ namespace Microsoft.Quantum.Synthesis
 
             // Returns list of two-level unitary matrices, which multiply to A.
             // Every matrix has indices differing in exactly 1 bit.
-            private static IEnumerable<TwoLevelUnitary> twoLevelDecomposeGray(Complex[,] A)
+            private static IEnumerable<TwoLevelUnitary> TwoLevelDecomposeGray(Complex[,] A)
             {
                 int n = A.GetLength(0);
                 Debug.Assert(A.GetLength(1) == n, "Matrix is not square.");
                 Debug.Assert(MatrixUtils.IsMatrixUnitary(A), "Matrix is not unitary.");
                 int[] perm = GrayCode(n);
                 A = PermuteMatrix(A, perm);
-                foreach (TwoLevelUnitary matrix in  TwoLevelDecompose(A))
+                foreach (TwoLevelUnitary matrix in TwoLevelDecompose(A))
                 {
                     matrix.ApplyPermutation(perm);
                     matrix.OrderIndices();
@@ -158,7 +158,7 @@ namespace Microsoft.Quantum.Synthesis
             {
                 Complex[,] a = MatrixUtils.MatrixFromQs(unitary);
                 return new QArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)>(
-                    twoLevelDecomposeGray(a).Select(matrix => matrix.ToQsharp())
+                    TwoLevelDecomposeGray(a).Select(matrix => matrix.ToQsharp())
                 );
             }
 

--- a/Standard/src/Synthesis/UnitaryDecomposition.cs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.cs
@@ -15,15 +15,14 @@ using Microsoft.Quantum.Simulation.Simulators;
 using Microsoft.Quantum.Math;
 
 namespace Microsoft.Quantum.Synthesis {
-    public partial class TwoLevelDecomposition {
+    internal partial class TwoLevelDecomposition {
         public class Native : TwoLevelDecomposition {
             public Native(IOperationFactory m) : base(m) {}
 
 
-
             private Complex[,] matrixFromQs(IQArray<IQArray<Complex>> a) {
                 long n = a.Length;
-                Complex[,] b = new Complex[n, n];
+                var b = new Complex[n, n];
                 for(long i=0;i<n;i++) {
                     Debug.Assert(a[i].Length == n, "Matrix is not square");
                     for (long j=0;j<n;j++) {
@@ -35,9 +34,9 @@ namespace Microsoft.Quantum.Synthesis {
 
             private QArray<QArray<Complex>> matrixToQs(Complex[,] b) {
                 long n = b.GetLength(0);
-                QArray<Complex>[] a = new QArray<Complex>[n];
+                var a = new QArray<Complex>[n];
                 for(long i=0;i<n;i++) {
-                    Complex[] row = new Complex[n];
+                    var row = new Complex[n];
                     for(int j = 0;j<n;j++) {
                         row[j] = b[i,j];
                     }
@@ -47,29 +46,24 @@ namespace Microsoft.Quantum.Synthesis {
             }
 
             private QArray<QArray<QArray<Complex>>> matricesToQs(List<Complex[,]> matrices) {
-                int n = (int)matrices.Count;
-                QArray<QArray<Complex>>[] result = new QArray<QArray<Complex>>[n];
+                int n = matrices.Count;
+                var result = new QArray<QArray<Complex>>[n];
                 for(int i=0;i<n;i++) {
                     result[i] = matrixToQs(matrices[i]);
                 }
                 return new QArray<QArray<QArray<Complex>>>(result);
             }
 
-            private (IQArray<IQArray<IQArray<Complex>>>, IQArray<IQArray<long>>) TwoLevelDecomposeGray(IQArray<IQArray<Complex>> unitary) {
+            private IQArray<(IQArray<IQArray<Complex>>, long, long)> TwoLevelDecomposeGray(IQArray<IQArray<Complex>> unitary) {
                 Complex[,] a = matrixFromQs(unitary);
-                List<Complex[,]> r1 = new List<Complex[,]>();
-                r1.Add(a);
+                var result = new List<(IQArray<IQArray<Complex>>, long, long)>(); 
+                result.Add((matrixToQs(a), 0, 1));
                 
-                QArray<QArray<QArray<Complex>>> r2 = matricesToQs(r1);
-
-                QArray<long> r3 = new QArray<long> ( new long[] {0, 1});
-                QArray<QArray<long>> r4 = new QArray<QArray<long>>(new QArray<long>[] {r3});
-
-                return (r2, r4);
+                return new QArray<(IQArray<IQArray<Complex>>, long, long)>(result);
             }
 
             // Override __Body__ property to use C# function
-            public override Func<IQArray<IQArray<Complex>>, (IQArray<IQArray<IQArray<Complex>>>, IQArray<IQArray<long>>)> __Body__ => TwoLevelDecomposeGray;
+            public override Func<IQArray<IQArray<Complex>>, IQArray<(IQArray<IQArray<Complex>>, long, long)>> __Body__ => TwoLevelDecomposeGray;
         }
     }
 }

--- a/Standard/src/Synthesis/UnitaryDecomposition.cs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Numerics;
 using Microsoft.Quantum.Simulation.Core;
 
@@ -13,12 +14,14 @@ namespace Microsoft.Quantum.Synthesis
     {
         public class Native : TwoLevelDecomposition
         {
+            private const double tol = 1e-10;
+
             public Native(IOperationFactory m) : base(m) { }
 
-            // Returns special unitary 2x2 matrix U, s.t. [a, b] U = [c, 0].
-            private static Complex[,] makeEliminatingMatrix(Complex a, Complex b)
+            // Returns special unitary 2x2 matrix U, such that [a, b] U = [c, 0].
+            private static Complex[,] MakeEliminatingMatrix(Complex a, Complex b)
             {
-                Debug.Assert(a.Magnitude > 1e-9 && b.Magnitude > 1e-9);
+                Debug.Assert(a.Magnitude > tol && b.Magnitude > tol);
                 double theta = System.Math.Atan((b / a).Magnitude);
                 double lmbda = -a.Phase;
                 double mu = System.Math.PI + b.Phase - a.Phase - lmbda;
@@ -36,7 +39,7 @@ namespace Microsoft.Quantum.Synthesis
             // Matrices are listed in application order.
             // Every matrix has indices differring in 1.
             // A is modified as result of this function.
-            private static List<TwoLevelUnitary> twoLevelDecompose(Complex[,] A)
+            private static List<TwoLevelUnitary> TwoLevelDecompose(Complex[,] A)
             {
                 int n = A.GetLength(0);
                 var result = new List<TwoLevelUnitary>();
@@ -45,25 +48,25 @@ namespace Microsoft.Quantum.Synthesis
                 {
                     for (int j = n - 1; j > i; j--)
                     {
-                        if (A[i, j].Magnitude < 1e-9)
+                        if (A[i, j].Magnitude < tol)
                         {
                             // Element is already zero, skipping.
                         }
                         else
                         {
                             Complex[,] mx;
-                            if (A[i, j - 1].Magnitude < 1e-9)
+                            if (A[i, j - 1].Magnitude < tol)
                             {
                                 // Just swap columns with Pauli X matrix.
                                 mx = new Complex[,] { { 0.0, 1.0 }, { 1.0, 0.0 } };
                             }
                             else
                             {
-                                mx = makeEliminatingMatrix(A[i, j - 1], A[i, j]);
+                                mx = MakeEliminatingMatrix(A[i, j - 1], A[i, j]);
                             }
                             var u2x2 = new TwoLevelUnitary(mx, j - 1, j);
-                            u2x2.multiplyRight(A);
-                            u2x2.conjugateTranspose();
+                            u2x2.MultiplyRight(A);
+                            u2x2.ConjugateTranspose();
                             result.Add(u2x2);
                         }
                     }
@@ -72,7 +75,7 @@ namespace Microsoft.Quantum.Synthesis
                 var lastMatrix = new TwoLevelUnitary(new Complex[,] {
                     { A[n - 2, n - 2], A[n - 2, n - 1] },
                     { A[n - 1, n - 2], A[n - 1, n - 1] } }, n - 2, n - 1);
-                if (!lastMatrix.isIdentity())
+                if (!lastMatrix.IsIdentity())
                 {
                     result.Add(lastMatrix);
                 }
@@ -81,7 +84,7 @@ namespace Microsoft.Quantum.Synthesis
 
             // Returns permutation of numbers from 0 to n-1 such as any two consequent number 
             // differ in exactly one bit.
-            private static int[] grayCode(int n)
+            private static int[] GrayCode(int n)
             {
                 var result = new int[n];
                 for (int i = 0; i < n; i++)
@@ -92,7 +95,7 @@ namespace Microsoft.Quantum.Synthesis
             }
 
             // Applies permutation to columns and rows of matrix.
-            private static Complex[,] permuteMatrix(Complex[,] matrix, int[] perm)
+            private static Complex[,] PermuteMatrix(Complex[,] matrix, int[] perm)
             {
                 int n = perm.Length;
                 Debug.Assert(matrix.GetLength(0) == n);
@@ -114,31 +117,29 @@ namespace Microsoft.Quantum.Synthesis
             {
                 int n = A.GetLength(0);
                 Debug.Assert(A.GetLength(1) == n, "Matrix is not square.");
-                Debug.Assert(MatrixUtils.isMatrixUnitary(A), "Matrix is not unitary.");
+                Debug.Assert(MatrixUtils.IsMatrixUnitary(A), "Matrix is not unitary.");
 
-                int[] perm = grayCode(n);
-                A = permuteMatrix(A, perm);
-                List<TwoLevelUnitary> result = twoLevelDecompose(A);
+                int[] perm = GrayCode(n);
+                A = PermuteMatrix(A, perm);
+                List<TwoLevelUnitary> result = TwoLevelDecompose(A);
                 foreach (TwoLevelUnitary matrix in result)
                 {
-                    matrix.applyPermutation(perm);
+                    matrix.ApplyPermutation(perm);
+                    matrix.OrderIndices();
                 }
                 return result;
             }
 
             // Decomposes unitary matrix into product of 2-level unitary matrices.
+            // Every resulting 2-level matrix is represnted by 2x2 non-trivial submatrix and indices
+            // of this submatrix. Indices are guaranteed to be sorted and differ in exactly one bit.
             private IQArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)> Decompose(
                 IQArray<IQArray<Quantum.Math.Complex>> unitary)
             {
-                Complex[,] a = MatrixUtils.squareMatrixFromQs(unitary);
-                List<TwoLevelUnitary> matrices = twoLevelDecomposeGray(a);
-                var result = new List<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)>();
-                foreach (TwoLevelUnitary matrix in matrices)
-                {
-                    matrix.orderIndices();
-                    result.Add(matrix.toQsharp());
-                }
-                return new QArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)>(result);
+                Complex[,] a = MatrixUtils.MatrixFromQs(unitary);
+                return new QArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)>(
+                    twoLevelDecomposeGray(a).Select(matrix => matrix.ToQsharp())
+                );
             }
 
             public override Func<IQArray<IQArray<Quantum.Math.Complex>>,

--- a/Standard/src/Synthesis/UnitaryDecomposition.cs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.cs
@@ -141,8 +141,8 @@ namespace Microsoft.Quantum.Synthesis
                 return new QArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)>(result);
             }
 
-            public override Func<IQArray<IQArray<Quantum.Math.Complex>>, 
-                IQArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)>> __Body__ => 
+            public override Func<IQArray<IQArray<Quantum.Math.Complex>>,
+                IQArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)>> __Body__ =>
                 Decompose;
         }
     }

--- a/Standard/src/Synthesis/UnitaryDecomposition.cs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.cs
@@ -3,67 +3,267 @@
 
 using System;
 //using static System.Math;
-// TODO: trim not needed stuff.
-using System.Collections;
+//using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using Microsoft.Quantum.Diagnostics.Emulation;
-using Microsoft.Quantum.Simulation.Common;
+using System.Numerics;
+//using System.Diagnostics.CodeAnalysis;
+//using Microsoft.Quantum.Diagnostics.Emulation;
+//using Microsoft.Quantum.Simulation.Common;
 using Microsoft.Quantum.Simulation.Core;
-using Microsoft.Quantum.Simulation.Simulators;
-using Microsoft.Quantum.Math;
+//using Microsoft.Quantum.Simulation.Simulators;
 
-namespace Microsoft.Quantum.Synthesis {
-    internal partial class TwoLevelDecomposition {
-        public class Native : TwoLevelDecomposition {
-            public Native(IOperationFactory m) : base(m) {}
+namespace Microsoft.Quantum.Synthesis
+{
+
+    internal partial class TwoLevelDecomposition
+    {
+        public class Native : TwoLevelDecomposition
+        {
+            public Native(IOperationFactory m) : base(m) { }
+
+            // Represents a square matrix which is an identity matrix with elements on positions
+            // (i1, i1), (i1, i2), (i2, i1), (i2, i2) replaced with elements from mx. 
+            internal class TwoLevelUnitary
+            {
+                private Complex[,] mx;   // 2x2 non-trivial principal submatrix.
+                private int i1, i2;      // Indices of non-trivial submatrix.
+
+                public TwoLevelUnitary(Complex[,] mx, int i1, int i2)
+                {
+                    this.mx = mx;
+                    this.i1 = i1;
+                    this.i2 = i2;
+                }
+
+                public void applyPermutation(int[] perm)
+                {
+                    i1 = perm[i1];
+                    i2 = perm[i2];
+                }
+
+                // Ensures that index1 < index2.
+                public void orderIndices()
+                {
+                    if (this.i1 > this.i2)
+                    {
+                        (i1, i2) = (i2, i1);
+                        (mx[0, 0], mx[1, 1]) = (mx[1, 1], mx[0, 0]);
+                        (mx[0, 1], mx[1, 0]) = (mx[1, 0], mx[0, 1]);
+                    }
+                }
+
+                // Equivalent to inversion for unitary matrix.
+                public void conjugateTranspose()
+                {
+                    mx[0, 0] = Complex.Conjugate(mx[0, 0]);
+                    mx[1, 1] = Complex.Conjugate(mx[1, 1]);
+                    (mx[0, 1], mx[1, 0]) = (Complex.Conjugate(mx[1, 0]), Complex.Conjugate(mx[0, 1]));
+                }
+
+                // Applies A = A * M, where M is this matrix.
+                public void multiplyRight(Complex[,] A)
+                {
+                    int n = A.GetLength(0);
+                    for (int i = 0; i < n; i++)
+                    {
+                        (A[i, i1], A[i, i2]) = (A[i, i1] * mx[0, 0] + A[i, i2] * mx[1, 0], A[i, i1] * mx[0, 1] + A[i, i2] * mx[1, 1]);
+                    }
+                }
+
+                public bool isIdentity()
+                {
+                    // TODO: implement.
+                    return false;
+                }
+
+                // Converts square matrix from C# to Q#.
+                // TODO: can inline in toQsharp() and get rid of loops.
+                private static QArray<QArray<Quantum.Math.Complex>> matrixToQs(Complex[,] b)
+                {
+                    long n = b.GetLength(0);
+                    var a = new QArray<Quantum.Math.Complex>[n];
+                    for (long i = 0; i < n; i++)
+                    {
+                        var row = new Quantum.Math.Complex[n];
+                        for (int j = 0; j < n; j++)
+                        {
+                            row[j] = new Quantum.Math.Complex((b[i, j].Real, b[i, j].Imaginary));
+                        }
+                        a[i] = new QArray<Quantum.Math.Complex>(row);
+                    }
+                    return new QArray<QArray<Quantum.Math.Complex>>(a);
+                }
+
+                // Converts to tuple to be passed to Q#.
+                public (IQArray<IQArray<Quantum.Math.Complex>>, long, long) toQsharp()
+                {
+                    return (matrixToQs(this.mx), this.i1, this.i2);
+                }
+            }
+
+            // Returns unitary 2x2 matrix U, s.t. [a, b] U = [c, 0].
+            private static Complex[,] makeEliminatingMatrix(Complex a, Complex b)
+            {
+                Debug.Assert(a.Magnitude > 1e-9 && b.Magnitude > 1e-9);
+                double theta = System.Math.Atan((b / a).Magnitude);
+                double lmbda = -a.Phase;
+                double mu = System.Math.PI + b.Phase - a.Phase - lmbda;
+                return new Complex[,] {{
+                    System.Math.Cos(theta) * Complex.FromPolarCoordinates(1.0, lmbda),
+                    System.Math.Sin(theta) * Complex.FromPolarCoordinates(1.0, mu)
+                }, {
+                    -System.Math.Sin(theta) * Complex.FromPolarCoordinates(1.0, -mu),
+                    System.Math.Cos(theta) * Complex.FromPolarCoordinates(1.0, -lmbda)
+                }};
+            }
+
+            // Returns list of two-level unitary matrices, which multiply to A.
+            //
+            // Matrices are listed in application order.
+            // Every matrix has indices differring in 1.
+            // A is modified as result of this function.
+            private static List<TwoLevelUnitary> twoLevelDecompose(Complex[,] A)
+            {
+                int n = A.GetLength(0);
+                var result = new List<TwoLevelUnitary>();
+
+                for (int i = 0; i < n - 2; i++)
+                {
+                    for (int j = n - 1; j > i; j--)
+                    {
+                        if (A[i, j].Magnitude < 1e-9)
+                        {
+                            // Element is already zero, skipping.
+                        }
+                        else
+                        {
+                            Complex[,] mx;
+                            if (A[i, j - 1].Magnitude < 1e-9)
+                            {
+                                // Just swap columns with Pauli X matrix.
+                                mx = new Complex[,] { { 0.0, 1.0 }, { 1.0, 0.0 } };
+                            }
+                            else
+                            {
+                                mx = makeEliminatingMatrix(A[i, j - 1], A[i, j]);
+                            }
+                            var u2x2 = new TwoLevelUnitary(mx, j - 1, j);
+                            u2x2.multiplyRight(A);
+                            u2x2.conjugateTranspose();
+                            result.Add(u2x2);
+                        }
+                    }
+                }
+
+                var lastMatrix = new TwoLevelUnitary(new Complex[,] { { A[n - 2, n - 2], A[n - 2, n - 1] }, { A[n - 1, n - 2], A[n - 1, n - 1] } }, n - 2, n - 1);
+                if (!lastMatrix.isIdentity())
+                {
+                    result.Add(lastMatrix);
+                }
+                return result;
+            }
+
+            // Builds binary-reflected gray code.
+            // Returns permutation of numbers from 0 to n-1 such as any two consequent number differ in exactly one bit.
+            // n must be power of 2.
+            private static int[] grayCode(int n)
+            {
+                var result = new int[n];
+                for (int i = 0; i < n; i++)
+                {
+                    result[i] = i ^ (i / 2);
+                }
+                return result;
+            }
+
+            // Applies permutation to columns and rows of matrix.
+            private static void permuteMatrix(Complex[,] matrix, int[] perm)
+            {
+                int n = perm.Length;
+                Debug.Assert(matrix.GetLength(0) == n);
+                Debug.Assert(matrix.GetLength(1) == n);
+                for (int i = 0; i < n; i++)
+                {
+                    for (int j = 0; j < n; j++)
+                    {
+                        matrix[i, j] = matrix[i, perm[j]];
+                    }
+                }
+                for (int i = 0; i < n; i++)
+                {
+                    for (int j = 0; j < n; j++)
+                    {
+                        matrix[j, i] = matrix[perm[j], i];
+                    }
+                }
+            }
+
+            private static bool isPowerOfTwo(int x)
+            {
+                // TODO: implement.
+                return true;
+            }
+
+            private static bool isUnitary(Complex[,] matrix)
+            {
+                // TODO: implement.
+                return true;
+            }
 
 
-            private Complex[,] matrixFromQs(IQArray<IQArray<Complex>> a) {
+            // Returns list of two-level unitary matrices, which multiply to A.
+            //
+            // Every matrix has indices differing in exactly 1 bit (this is achieved with Gray code).
+            private static List<TwoLevelUnitary> twoLevelDecomposeGray(Complex[,] A)
+            {
+                int n = A.GetLength(0);
+                Debug.Assert(isPowerOfTwo(n), "Matrix sizeis not power of two.");
+                Debug.Assert(A.GetLength(1) == n, "Matrix is not square.");
+                Debug.Assert(isUnitary(A), "Matrix is not unitary.");
+
+                int[] perm = grayCode(n);
+                permuteMatrix(A, perm);
+                List<TwoLevelUnitary> result = twoLevelDecompose(A);
+                foreach (TwoLevelUnitary matrix in result)
+                {
+                    matrix.applyPermutation(perm);
+                }
+                return result;
+            }
+
+
+            // Converts square matrix from Q# to C#.
+            private static Complex[,] matrixFromQs(IQArray<IQArray<Quantum.Math.Complex>> a)
+            {
                 long n = a.Length;
                 var b = new Complex[n, n];
-                for(long i=0;i<n;i++) {
+                for (long i = 0; i < n; i++)
+                {
                     Debug.Assert(a[i].Length == n, "Matrix is not square");
-                    for (long j=0;j<n;j++) {
-                        b[i,j] = a[i][j];
+                    for (long j = 0; j < n; j++)
+                    {
+                        b[i, j] = new Complex(a[i][j].Real, a[i][j].Imag);
                     }
                 }
                 return b;
             }
 
-            private QArray<QArray<Complex>> matrixToQs(Complex[,] b) {
-                long n = b.GetLength(0);
-                var a = new QArray<Complex>[n];
-                for(long i=0;i<n;i++) {
-                    var row = new Complex[n];
-                    for(int j = 0;j<n;j++) {
-                        row[j] = b[i,j];
-                    }
-                    a[i] = new QArray<Complex>(row);
-                }
-                return new QArray<QArray<Complex>>(a);
-            }
-
-            private QArray<QArray<QArray<Complex>>> matricesToQs(List<Complex[,]> matrices) {
-                int n = matrices.Count;
-                var result = new QArray<QArray<Complex>>[n];
-                for(int i=0;i<n;i++) {
-                    result[i] = matrixToQs(matrices[i]);
-                }
-                return new QArray<QArray<QArray<Complex>>>(result);
-            }
-
-            private IQArray<(IQArray<IQArray<Complex>>, long, long)> TwoLevelDecomposeGray(IQArray<IQArray<Complex>> unitary) {
+            private IQArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)> DoThis(IQArray<IQArray<Quantum.Math.Complex>> unitary)
+            {
                 Complex[,] a = matrixFromQs(unitary);
-                var result = new List<(IQArray<IQArray<Complex>>, long, long)>(); 
-                result.Add((matrixToQs(a), 0, 1));
-                
-                return new QArray<(IQArray<IQArray<Complex>>, long, long)>(result);
+                List<TwoLevelUnitary> matrices = twoLevelDecomposeGray(a);
+                var result = new List<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)>();
+                foreach (TwoLevelUnitary matrix in matrices)
+                {
+                    matrix.orderIndices();
+                    result.Add(matrix.toQsharp());
+                }
+                return new QArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)>(result);
             }
 
             // Override __Body__ property to use C# function
-            public override Func<IQArray<IQArray<Complex>>, IQArray<(IQArray<IQArray<Complex>>, long, long)>> __Body__ => TwoLevelDecomposeGray;
+            public override Func<IQArray<IQArray<Quantum.Math.Complex>>, IQArray<(IQArray<IQArray<Quantum.Math.Complex>>, long, long)>> __Body__ => DoThis;
         }
     }
 }

--- a/Standard/src/Synthesis/UnitaryDecomposition.qs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.qs
@@ -76,20 +76,24 @@ namespace Microsoft.Quantum.Synthesis {
         let decomposition = TwoLevelDecomposition(unitary);
         let flipMasks = GetFlipMasks(decomposition, allQubitsMask);
         
+        Message($"START aqm={allQubitsMask}");
         for (i in 0..Length(decomposition)-1) {
             // i1, i2 - indices of non-trivial 2x2 submatrix of two-level unitary matrix being applied.
             // They differ in exactly one bit; i1 < i2.
             // matrix - 2x2 non-trivial unitary submatrix of said two-level unitary.
             let (matrix, i1, i2) = decomposition[i];
-            Message("${matrix}, {i1}, {i2}");
+            Message($"{matrix}, {i1}, {i2}");
 
             ApplyFlips(flipMasks[i+1] ^^^ flipMasks[i], qubits);
 
             let targetMask = i1 ^^^ i2;
             let controlMask = allQubitsMask - targetMask;
             let (controls, targets) = MaskToQubitsPair(qubits!, MCMTMask(controlMask, targetMask));
+            Message($"controls={controls}");
+            Message($"targets={targets}");
             Controlled ApplySingleQubitUnitary(controls, (matrix, targets[0])); 
         }   
         ApplyFlips(Tail(flipMasks), qubits);
+        Message($"END");
     }    
 }

--- a/Standard/src/Synthesis/UnitaryDecomposition.qs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.qs
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Synthesis {
     /// Assumed to be unitary. If it's not unitary, behaviour is undefined.
     /// ## qubit
     /// Qubit to which apply the operation.
-    operation ApplySingleQubitUnitary(u: Complex[][], qubit : Qubit) : Unit is Adj + Ctl {  
+    internal operation ApplySingleQubitUnitary(u: Complex[][], qubit : Qubit) : Unit is Adj + Ctl {  
         // ZYZ decomposition.
         let theta = ArcCos(AbsComplex(u[0][0]));
         let lmbda = ArgComplex(u[0][0]);
@@ -36,11 +36,11 @@ namespace Microsoft.Quantum.Synthesis {
         if(AbsD(phi) > 1e-9) {R1(phi, qubit);}
     }
 
-    function TwoLevelDecomposition(unitary: Complex[][]) : (Complex[][][], Int[][]) {
+    internal function TwoLevelDecomposition(unitary: Complex[][]) : (Complex[][], Int, Int)[] {
         body intrinsic;
     }
 
-    operation ApplyFlips(flipMask: Int, qubits : LittleEndian) : Unit is Adj + Ctl  {
+    internal operation ApplyFlips(flipMask: Int, qubits : LittleEndian) : Unit is Adj + Ctl  {
         // TODO: implement.
     }
 
@@ -56,14 +56,9 @@ namespace Microsoft.Quantum.Synthesis {
     operation ApplyUnitary(unitary: Complex[][], qubits : LittleEndian) : Unit is Adj + Ctl {
         // TODO: check that matrix dimension is equal to 2^len(qubits).
 
-        let (matrices, idx) = TwoLevelDecomposition(unitary);
-        let n = Length(matrices);
         
         mutable prevFlipMask = 0;
-        for (i in 0..n-1) {
-            let matrix = matrices[i]; // Matrix of FC gate.
-            let index1 = idx[i][0];   // Indices of non-tivial 2x2 submatrix.
-            let index2 = idx[i][0];
+        for ((matrix, index1, index2) in TwoLevelDecomposition(unitary)) {
             // matrix.order_indices()  # Ensures that index2 > index1. TODO: this must be done in C# code....
             let qubitIdMask = index1 ^ index2;
             // assert is_power_of_two(qubit_id_mask) # do we need this?

--- a/Standard/src/Synthesis/UnitaryDecomposition.qs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.qs
@@ -31,7 +31,8 @@ namespace Microsoft.Quantum.Synthesis {
     // For every 2-level unitary calculates "flip mask", which denotes qubit which should 
     // be inverted before and after applying corresponding 1-qubit gate.
     // For convenience prepends result with 0.
-    internal function GetFlipMasks(decomposition: (Complex[][], Int, Int)[], allQubitsMask: Int) : Int[] {
+    internal function GetFlipMasks(decomposition: (Complex[][], Int, Int)[], 
+                                   allQubitsMask: Int) : Int[] {
         let n = Length(decomposition);
         mutable flipMasks = new Int[n+1];
         set flipMasks w/= 0 <- 0;
@@ -69,8 +70,9 @@ namespace Microsoft.Quantum.Synthesis {
         let flipMasks = GetFlipMasks(decomposition, allQubitsMask);
         
         for (i in 0..Length(decomposition)-1) {
-            // i1, i2 - indices of non-trivial 2x2 submatrix of two-level unitary matrix being applied.
-            // They differ in exactly one bit; i1 < i2.
+            // i1, i2 - indices of non-trivial 2x2 submatrix of two-level unitary matrix being 
+            // applied. 
+            // i1 and i2 differ in exactly one bit; i1 < i2.
             // matrix - 2x2 non-trivial unitary submatrix of said two-level unitary.
             let (matrix, i1, i2) = decomposition[i];
 

--- a/Standard/src/Synthesis/UnitaryDecomposition.qs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.qs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Synthesis {
+    open Microsoft.Quantum.Arithmetic;
+    open Microsoft.Quantum.Arrays;
+    open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Logical;
+
+
+    // # Summary
+    /// Applies single-qubit gate defined by 2x2 unitary matrix.
+    ///
+    /// # Description
+    /// This operation swaps the amplitude at index `a` with the
+    /// amplitude at index `b` in the given state-vector of
+    /// `register` of length $n$.  If `a` equals `b`, the state-vector
+    /// is not changed.
+    ///
+    /// # Input
+    /// ## unitary
+    /// 2x2 unitary matrix describing the operation.
+    /// ## qubit
+    /// Qubit to which apply the operation.
+    operation ApplySingleQubitUnitary(qubit : Qubit) : Unit is Adj + Ctl {
+        X(qubit);
+    }
+
+
+    operation ApplyUnitary(qubits : LittleEndian) : Unit is Adj + Ctl {
+        ApplySingleQubitUnitary(qubits[0]);
+    }    
+}

--- a/Standard/src/Synthesis/UnitaryDecomposition.qs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.qs
@@ -5,10 +5,12 @@ namespace Microsoft.Quantum.Synthesis {
     open Microsoft.Quantum.Arithmetic;
     open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Math;
 
-    // Applies single-qubit gate defined by 2x2 unitary matrix.
+    /// # Summary
+    /// Applies single-qubit gate defined by 2x2 unitary matrix.
     internal operation ApplySingleQubitUnitary(u : Complex[][], qubit : Qubit) : Unit is Adj + Ctl {  
         // ZYZ decomposition.
         let theta = ArcCos(AbsComplex(u[0][0]));
@@ -54,9 +56,10 @@ namespace Microsoft.Quantum.Synthesis {
     /// ## qubits
     /// Qubits to which apply the operation - register of length n.
     operation ApplyUnitary(unitary: Complex[][], qubits : LittleEndian) : Unit is Adj + Ctl {
-        if (Length(unitary) != 1 <<< Length(qubits!)) {
-            fail "Matrix size is not consistent with register length.";
-        }
+        SquareMatrixFact(unitary);
+        EqualityFactI(Length(unitary), 1 <<< Length(qubits!),
+            "Matrix size is not consistent with register length.");
+
         let allQubitsMask = (1 <<< Length(qubits!)) - 1;
         let decomposition = TwoLevelDecomposition(unitary);
         let flipMasks = FlipMasks(decomposition, allQubitsMask);
@@ -75,4 +78,13 @@ namespace Microsoft.Quantum.Synthesis {
         }   
         ApplyXorInPlace(Tail(flipMasks), qubits);
     }    
+
+    /// # Summary
+    /// Checks that given array represents a square matrix.
+    internal function SquareMatrixFact(matrix : Complex[][]) : Unit {
+        let n = Length(matrix);
+        for (row in matrix) {
+            EqualityFactI(Length(row), n, "Matrix is not square.");
+        }
+    } 
 }

--- a/Standard/src/Synthesis/UnitaryDecomposition.qs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.qs
@@ -18,7 +18,7 @@ namespace Microsoft.Quantum.Synthesis {
         if (AbsD(theta) > 1e-9) { Ry(-2.0 * theta, qubit); }
         if (AbsD(lmbda + mu) > 1e-9) { Rz(- lmbda - mu, qubit); }
 
-        // If this is not special unitary, apply R1 to correct global phase.
+        // If this is not special unitary, apply R1 to correct the global phase.
         let det = MinusC(TimesC(u[0][0], u[1][1]), TimesC(u[0][1], u[1][0]));
         let phi = ArgComplex(det);
         if (AbsD(phi) > 1e-9) { R1(phi, qubit); }
@@ -29,25 +29,20 @@ namespace Microsoft.Quantum.Synthesis {
     }
 
     /// # Summary
-    /// For every 2-level unitary calculates "flip mask", which denotes qubit which should 
+    /// For every 2-level unitary calculates "flip mask", which denotes qubits which should 
     /// be inverted before and after applying corresponding 1-qubit gate.
     /// For convenience prepends result with 0.
     internal function FlipMasks(decomposition: (Complex[][], Int, Int)[], 
                                    allQubitsMask: Int) : Int[] {
         let n = Length(decomposition);
         mutable flipMasks = ConstantArray(n + 1, 0);
-        for ((i, (_, _, i2)) in Enumerated(decomposition)) {
+        for ((i, (_, i1, i2)) in Enumerated(decomposition)) {
             set flipMasks w/= (i+1) <- (allQubitsMask - i2); 
         }
         return flipMasks;
     }
 
-    // Applies X gates to qubits speicifed by flipMask.
-    internal operation ApplyFlips(flipMask: Int, qubits : LittleEndian) : Unit is Adj + Ctl  {
-        ApplyXorInPlace(flipMask, qubits);
-    }
-
-    // # Summary
+    /// # Summary
     /// Applies gate defined by 2^n x 2^n unitary matrix.
     ///
     /// Fails if matrix is not unitary, or has wrong size. 
@@ -64,21 +59,20 @@ namespace Microsoft.Quantum.Synthesis {
         }
         let allQubitsMask = (1 <<< Length(qubits!)) - 1;
         let decomposition = TwoLevelDecomposition(unitary);
-        let flipMasks = GetFlipMasks(decomposition, allQubitsMask);
+        let flipMasks = FlipMasks(decomposition, allQubitsMask);
         
         // i1, i2 - indices of non-trivial 2x2 submatrix of two-level unitary matrix being 
         // applied. 
         // i1 and i2 differ in exactly one bit; i1 < i2.
         // matrix - 2x2 non-trivial unitary submatrix of said two-level unitary.
         for ((i, (matrix, i1, i2)) in Enumerated(decomposition)) {
-
-            ApplyFlips(flipMasks[i+1] ^^^ flipMasks[i], qubits);
+            ApplyXorInPlace(flipMasks[i+1] ^^^ flipMasks[i], qubits);
 
             let targetMask = i1 ^^^ i2;
             let controlMask = allQubitsMask - targetMask;
             let (controls, targets) = MaskToQubitsPair(qubits!, MCMTMask(controlMask, targetMask));
             Controlled ApplySingleQubitUnitary(controls, (matrix, targets[0])); 
         }   
-        ApplyFlips(Tail(flipMasks), qubits);
+        ApplyXorInPlace(Tail(flipMasks), qubits);
     }    
 }

--- a/Standard/src/Synthesis/UnitaryDecomposition.qs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.qs
@@ -14,14 +14,14 @@ namespace Microsoft.Quantum.Synthesis {
         let theta = ArcCos(AbsComplex(u[0][0]));
         let lmbda = ArgComplex(u[0][0]);
         let mu = ArgComplex(u[0][1]);
-        if (AbsD(mu - lmbda) > 1e-9) { Rz(mu - lmbda, qubit); }
-        if (AbsD(theta) > 1e-9) { Ry(-2.0 * theta, qubit); }
-        if (AbsD(lmbda + mu) > 1e-9) { Rz(- lmbda - mu, qubit); }
+        if (AbsD(mu - lmbda) > 1e-10) { Rz(mu - lmbda, qubit); }
+        if (AbsD(theta) > 1e-10) { Ry(-2.0 * theta, qubit); }
+        if (AbsD(lmbda + mu) > 1e-10) { Rz(-lmbda - mu, qubit); }
 
         // If this is not special unitary, apply R1 to correct the global phase.
         let det = MinusC(TimesC(u[0][0], u[1][1]), TimesC(u[0][1], u[1][0]));
         let phi = ArgComplex(det);
-        if (AbsD(phi) > 1e-9) { R1(phi, qubit); }
+        if (AbsD(phi) > 1e-10) { R1(phi, qubit); }
     }
 
     internal function TwoLevelDecomposition(unitary: Complex[][]) : (Complex[][], Int, Int)[] {
@@ -33,11 +33,11 @@ namespace Microsoft.Quantum.Synthesis {
     /// be inverted before and after applying corresponding 1-qubit gate.
     /// For convenience prepends result with 0.
     internal function FlipMasks(decomposition: (Complex[][], Int, Int)[], 
-                                   allQubitsMask: Int) : Int[] {
+                                allQubitsMask: Int) : Int[] {
         let n = Length(decomposition);
         mutable flipMasks = ConstantArray(n + 1, 0);
         for ((i, (_, i1, i2)) in Enumerated(decomposition)) {
-            set flipMasks w/= (i+1) <- (allQubitsMask - i2); 
+            set flipMasks w/= (i + 1) <- (allQubitsMask - i2); 
         }
         return flipMasks;
     }
@@ -66,7 +66,7 @@ namespace Microsoft.Quantum.Synthesis {
         // i1 and i2 differ in exactly one bit; i1 < i2.
         // matrix - 2x2 non-trivial unitary submatrix of said two-level unitary.
         for ((i, (matrix, i1, i2)) in Enumerated(decomposition)) {
-            ApplyXorInPlace(flipMasks[i+1] ^^^ flipMasks[i], qubits);
+            ApplyXorInPlace(flipMasks[i + 1] ^^^ flipMasks[i], qubits);
 
             let targetMask = i1 ^^^ i2;
             let controlMask = allQubitsMask - targetMask;

--- a/Standard/src/Synthesis/UnitaryDecomposition.qs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.qs
@@ -8,29 +8,44 @@ namespace Microsoft.Quantum.Synthesis {
     open Microsoft.Quantum.Convert;
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Logical;
 
 
     // # Summary
     /// Applies single-qubit gate defined by 2x2 unitary matrix.
     ///
-    /// # Description
-    /// This operation swaps the amplitude at index `a` with the
-    /// amplitude at index `b` in the given state-vector of
-    /// `register` of length $n$.  If `a` equals `b`, the state-vector
-    /// is not changed.
+    /// # Input
+    /// ## u
+    /// 2x2 unitary matrix describing the operation. 
+    /// Assumed to be unitary. If it's not unitary, behaviour is undefined.
+    /// ## qubit
+    /// Qubit to which apply the operation.
+    operation ApplySingleQubitUnitary(u: Complex[][], qubit : Qubit) : Unit is Adj + Ctl {  
+        // ZYZ decomposition.
+        let theta = ArcCos(AbsComplex(u[0][0]));
+        let lmbda = ArgComplex(u[0][0]);
+        let mu = ArgComplex(u[0][1]);
+        if (AbsD(mu-lmbda) > 1e-9) { Rz(mu - lmbda, qubit); }
+        if (AbsD(theta) > 1e-9) { Ry(-2.0 * theta, qubit); }
+        if (AbsD(lmbda + mu) > 1e-9) { Rz(- lmbda - mu, qubit); }
+
+        // If this is not special unitary, apply R1 to correct global phase.
+        let det = MinusC(TimesC(u[0][0], u[1][1]), TimesC(u[0][1], u[1][0]));
+        let phi = ArgComplex(det);
+        if(AbsD(phi) > 1e-9) {R1(phi, qubit);}
+    }
+
+    // # Summary
+    /// Applies gate defined by 2^n x 2^n unitary matrix.
     ///
     /// # Input
     /// ## unitary
-    /// 2x2 unitary matrix describing the operation.
+    /// 2^n x 2^n unitary matrix describing the operation. 
+    /// If matrix is not unitary or not of suitable size, throws an exception.
     /// ## qubit
-    /// Qubit to which apply the operation.
-    operation ApplySingleQubitUnitary(qubit : Qubit) : Unit is Adj + Ctl {
-        X(qubit);
-    }
-
-
-    operation ApplyUnitary(qubits : LittleEndian) : Unit is Adj + Ctl {
-        ApplySingleQubitUnitary(qubits[0]);
+    /// Qubits to which apply the operation - register of length n.
+    operation ApplyUnitary(unitary: Complex[][], qubits : LittleEndian) : Unit is Adj + Ctl {
+        ApplySingleQubitUnitary(matrix, qubits![0]);
     }    
 }

--- a/Standard/src/Synthesis/UnitaryDecomposition.qs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.qs
@@ -9,33 +9,33 @@ namespace Microsoft.Quantum.Synthesis {
     open Microsoft.Quantum.Math;
 
     // Applies single-qubit gate defined by 2x2 unitary matrix.
-    internal operation ApplySingleQubitUnitary(u: Complex[][], qubit : Qubit) : Unit is Adj + Ctl {  
+    internal operation ApplySingleQubitUnitary(u : Complex[][], qubit : Qubit) : Unit is Adj + Ctl {  
         // ZYZ decomposition.
         let theta = ArcCos(AbsComplex(u[0][0]));
         let lmbda = ArgComplex(u[0][0]);
         let mu = ArgComplex(u[0][1]);
-        if (AbsD(mu-lmbda) > 1e-9) { Rz(mu - lmbda, qubit); }
+        if (AbsD(mu - lmbda) > 1e-9) { Rz(mu - lmbda, qubit); }
         if (AbsD(theta) > 1e-9) { Ry(-2.0 * theta, qubit); }
         if (AbsD(lmbda + mu) > 1e-9) { Rz(- lmbda - mu, qubit); }
 
         // If this is not special unitary, apply R1 to correct global phase.
         let det = MinusC(TimesC(u[0][0], u[1][1]), TimesC(u[0][1], u[1][0]));
         let phi = ArgComplex(det);
-        if(AbsD(phi) > 1e-9) {R1(phi, qubit);}
+        if (AbsD(phi) > 1e-9) { R1(phi, qubit); }
     }
 
     internal function TwoLevelDecomposition(unitary: Complex[][]) : (Complex[][], Int, Int)[] {
         body intrinsic;
     }
 
-    // For every 2-level unitary calculates "flip mask", which denotes qubit which should 
-    // be inverted before and after applying corresponding 1-qubit gate.
-    // For convenience prepends result with 0.
-    internal function GetFlipMasks(decomposition: (Complex[][], Int, Int)[], 
+    /// # Summary
+    /// For every 2-level unitary calculates "flip mask", which denotes qubit which should 
+    /// be inverted before and after applying corresponding 1-qubit gate.
+    /// For convenience prepends result with 0.
+    internal function FlipMasks(decomposition: (Complex[][], Int, Int)[], 
                                    allQubitsMask: Int) : Int[] {
         let n = Length(decomposition);
-        mutable flipMasks = new Int[n+1];
-        set flipMasks w/= 0 <- 0;
+        mutable flipMasks = ConstantArray(n + 1, 0);
         for ((i, (_, _, i2)) in Enumerated(decomposition)) {
             set flipMasks w/= (i+1) <- (allQubitsMask - i2); 
         }

--- a/Standard/src/Synthesis/UnitaryDecomposition.qs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.qs
@@ -36,8 +36,7 @@ namespace Microsoft.Quantum.Synthesis {
         let n = Length(decomposition);
         mutable flipMasks = new Int[n+1];
         set flipMasks w/= 0 <- 0;
-        for (i in 0..n-1) {
-            let (matrix, i1, i2) = decomposition[i];
+        for ((i, (_, _, i2)) in Enumerated(decomposition)) {
             set flipMasks w/= (i+1) <- (allQubitsMask - i2); 
         }
         return flipMasks;
@@ -45,9 +44,7 @@ namespace Microsoft.Quantum.Synthesis {
 
     // Applies X gates to qubits speicifed by flipMask.
     internal operation ApplyFlips(flipMask: Int, qubits : LittleEndian) : Unit is Adj + Ctl  {
-        for (qubitId in 0..Length(qubits!)-1) {
-            if ((flipMask &&& (1 <<< qubitId)) != 0) { X(qubits![qubitId]); }    
-        }
+        ApplyXorInPlace(flipMask, qubits);
     }
 
     // # Summary
@@ -69,12 +66,11 @@ namespace Microsoft.Quantum.Synthesis {
         let decomposition = TwoLevelDecomposition(unitary);
         let flipMasks = GetFlipMasks(decomposition, allQubitsMask);
         
-        for (i in 0..Length(decomposition)-1) {
-            // i1, i2 - indices of non-trivial 2x2 submatrix of two-level unitary matrix being 
-            // applied. 
-            // i1 and i2 differ in exactly one bit; i1 < i2.
-            // matrix - 2x2 non-trivial unitary submatrix of said two-level unitary.
-            let (matrix, i1, i2) = decomposition[i];
+        // i1, i2 - indices of non-trivial 2x2 submatrix of two-level unitary matrix being 
+        // applied. 
+        // i1 and i2 differ in exactly one bit; i1 < i2.
+        // matrix - 2x2 non-trivial unitary submatrix of said two-level unitary.
+        for ((i, (matrix, i1, i2)) in Enumerated(decomposition)) {
 
             ApplyFlips(flipMasks[i+1] ^^^ flipMasks[i], qubits);
 

--- a/Standard/src/Synthesis/UnitaryDecomposition.qs
+++ b/Standard/src/Synthesis/UnitaryDecomposition.qs
@@ -81,6 +81,7 @@ namespace Microsoft.Quantum.Synthesis {
             // They differ in exactly one bit; i1 < i2.
             // matrix - 2x2 non-trivial unitary submatrix of said two-level unitary.
             let (matrix, i1, i2) = decomposition[i];
+            Message("${matrix}, {i1}, {i2}");
 
             ApplyFlips(flipMasks[i+1] ^^^ flipMasks[i], qubits);
 

--- a/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
+++ b/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Tests {
+    open Microsoft.Quantum.Arithmetic;
+    open Microsoft.Quantum.Arrays;
+    open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Diagnostics;
+    open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Math;
+    open Microsoft.Quantum.Measurement;
+    open Microsoft.Quantum.Synthesis;
+    open Microsoft.Quantum.Random;
+
+ 
+
+    @Test("QuantumSimulator")
+    operation MyFirstQuantumTest () : Unit {
+        AssertOperationsEqualInPlace(1, ApplyUnitary, X);
+    }
+}

--- a/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
+++ b/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
@@ -23,14 +23,14 @@ namespace Microsoft.Quantum.Tests {
     }
 
     @Test("QuantumSimulator")
-    operation CheckApplyUnitaryAppliesIdentity () : Unit {
+    operation CheckApplyUnitaryAppliesIdentity() : Unit {
         let matrix = [[Complex(1.0, 0.0), Complex(0.0, 0.0)],
                       [Complex(0.0, 0.0), Complex(1.0, 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(I, _));
     }
 
     @Test("QuantumSimulator")
-    operation CheckApplyUnitaryAppliesPauliX () : Unit {
+    operation CheckApplyUnitaryAppliesPauliX() : Unit {
         let matrix = [[Complex(0.0, 0.0), Complex(1.0, 0.0)],
                       [Complex(1.0, 0.0), Complex(0.0, 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(X, _));
@@ -38,7 +38,7 @@ namespace Microsoft.Quantum.Tests {
 
 
     @Test("QuantumSimulator")
-    operation CheckApplyUnitaryAppliesPauliY () : Unit {
+    operation CheckApplyUnitaryAppliesPauliY() : Unit {
         let matrix = [[Complex(0.0, 0.0), Complex(0.0, -1.0)],
                       [Complex(0.0, 1.0), Complex(0.0, 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(Y, _));
@@ -46,42 +46,42 @@ namespace Microsoft.Quantum.Tests {
 
 
     @Test("QuantumSimulator")
-    operation CheckApplyUnitaryAppliesPauliZ () : Unit {
+    operation CheckApplyUnitaryAppliesPauliZ() : Unit {
         let matrix = [[Complex(1.0, 0.0), Complex(0.0, 0.0)],
                       [Complex(0.0, 0.0), Complex(-1.0, 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(Z, _));
     }
 
     @Test("QuantumSimulator")
-    operation CheckApplyUnitaryAppliesHadamard () : Unit {
+    operation CheckApplyUnitaryAppliesHadamard() : Unit {
         let matrix = [[Complex(Sqrt(0.5), 0.0), Complex(Sqrt(0.5), 0.0)],
                       [Complex(Sqrt(0.5), 0.0), Complex(-Sqrt(0.5), 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(H, _));
     }
 
     @Test("QuantumSimulator")
-    operation CheckApplyUnitaryAppliesHadamardY () : Unit {
+    operation CheckApplyUnitaryAppliesHadamardY() : Unit {
         let matrix = [[Complex(Sqrt(0.5), 0.0), Complex(Sqrt(0.5), 0.0)],
                       [Complex(0.0, Sqrt(0.5)), Complex(0.0, -Sqrt(0.5))]];
         CheckOperation(matrix, ApplyToHeadA(HY, _));
     }
 
     @Test("QuantumSimulator")
-    operation CheckApplyUnitaryAppliesRx () : Unit {
+    operation CheckApplyUnitaryAppliesRx() : Unit {
         let matrix = [[Complex(Cos(1.0), 0.0), Complex(0.0, -Sin(1.0))],
                       [Complex(0.0, -Sin(1.0)), Complex(Cos(1.0), 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(Rx(2.0, _), _));
     }
 
     @Test("QuantumSimulator")
-    operation CheckApplyUnitaryAppliesRy () : Unit {
+    operation CheckApplyUnitaryAppliesRy() : Unit {
         let matrix = [[Complex(Cos(1.0), 0.0), Complex(-Sin(1.0), 0.0)],
                       [Complex(Sin(1.0), 0.0), Complex(Cos(1.0), 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(Ry(2.0, _), _));
     }
 
     @Test("QuantumSimulator")
-    operation CheckApplyUnitaryAppliesCnot () : Unit {
+    operation CheckApplyUnitaryAppliesCnot() : Unit {
         let ZERO = Complex(0.0, 0.0);
         let ONE = Complex(1.0, 0.0);
         // Matrix for CNOT(q[0], q[1]).
@@ -93,7 +93,7 @@ namespace Microsoft.Quantum.Tests {
     }
 
     @Test("QuantumSimulator")
-    operation CheckApplyUnitaryAppliesSwap () : Unit {
+    operation CheckApplyUnitaryAppliesSwap() : Unit {
         let ZERO = Complex(0.0, 0.0);
         let ONE = Complex(1.0, 0.0);
         let matrix = [[ONE, ZERO, ZERO, ZERO],
@@ -108,7 +108,7 @@ namespace Microsoft.Quantum.Tests {
     }
 
     @Test("QuantumSimulator")
-    operation CheckApplyUnitaryAppliesQft () : Unit {
+    operation CheckApplyUnitaryAppliesQft() : Unit {
         let matrix = [
             [Complex(0.5, 0.0), Complex(0.5, 0.0), Complex(0.5, 0.0), Complex(0.5, 0.0)],
             [Complex(0.5, 0.0), Complex(0.0, 0.5), Complex(-0.5, 0.0), Complex(0.0, -0.5)],
@@ -118,7 +118,7 @@ namespace Microsoft.Quantum.Tests {
     }
     
     @Test("QuantumSimulator")
-    operation CheckApplyUnitaryAppliesCcnot () : Unit {
+    operation CheckApplyUnitaryAppliesCcnot() : Unit {
         // Matrix for CCNOT(q[0], q[1], q[2]).
         let ZERO = Complex(0.0, 0.0);
         let ONE = Complex(1.0, 0.0);
@@ -141,7 +141,7 @@ namespace Microsoft.Quantum.Tests {
     }   
 
     @Test("QuantumSimulator")
-    operation CheckApplyUnitaryAppliesFourControlledGates () : Unit {
+    operation CheckApplyUnitaryAppliesFourControlledGates() : Unit {
         let ZERO = Complex(0.0, 0.0);
         let ONE = Complex(1.0, 0.0);
         let SQRT_HALF = Sqrt(0.5);

--- a/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
+++ b/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
@@ -12,13 +12,12 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Measurement;
     open Microsoft.Quantum.Synthesis;
     open Microsoft.Quantum.Random;
-
-    // dotnet test tests --filter "Name~ApplyUnitary"
     
     internal operation ApplyUnitaryToRegister(matrix: Complex[][], qubits: Qubit[]) : Unit {
         ApplyUnitary(matrix, LittleEndian(qubits));
     }
 
+    // Checks that `ApplyUnitary(matrix)` is equvalent to `expected` operation.
     internal operation CheckOperation(matrix: Complex[][], expected: (Qubit[] => Unit is Adj)) : Unit {
         let nQubits = Floor(Lg(IntAsDouble(Length(matrix))));
         AssertOperationsEqualInPlace(nQubits, ApplyUnitaryToRegister(matrix, _), expected);
@@ -86,7 +85,7 @@ namespace Microsoft.Quantum.Tests {
     operation ApplyUnitary_CNOT () : Unit {
         let ZERO = Complex(0.0, 0.0);
         let ONE = Complex(1.0, 0.0);
-        // This is CNOT(q[0], q[1]).
+        // Matrix for CNOT(q[0], q[1]).
         let matrix = [[ONE, ZERO, ZERO, ZERO],
                       [ZERO, ZERO, ZERO, ONE],
                       [ZERO, ZERO, ONE, ZERO],
@@ -111,12 +110,26 @@ namespace Microsoft.Quantum.Tests {
 
     @Test("QuantumSimulator")
     operation ApplyUnitary_QFT () : Unit {
-        let ZERO = Complex(0.0, 0.0);
-        let ONE = Complex(1.0, 0.0);
         let matrix = [[Complex(0.5, 0.0), Complex(0.5, 0.0), Complex(0.5, 0.0), Complex(0.5, 0.0)],
                       [Complex(0.5, 0.0), Complex(0.0, 0.5), Complex(-0.5, 0.0), Complex(0.0, -0.5)],
                       [Complex(0.5, 0.0), Complex(-0.5, 0.0), Complex(0.5, 0.0), Complex(-0.5, 0.0)],
                       [Complex(0.5, 0.0), Complex(0.0, -0.5), Complex(-0.5, 0.0), Complex(0.0, 0.5)]];
         CheckOperation(matrix, ApplyQFT);
+    }
+    
+    @Test("QuantumSimulator")
+    operation ApplyUnitary_CCNOT () : Unit {
+        // Matrix for CCNOT(q[0], q[1], q[2]).
+        let ZERO = Complex(0.0, 0.0);
+        let ONE = Complex(1.0, 0.0);
+        let matrix = [[ONE, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO],
+                      [ZERO, ONE, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO],
+                      [ZERO, ZERO, ONE, ZERO, ZERO, ZERO, ZERO, ZERO],
+                      [ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ONE],
+                      [ZERO, ZERO, ZERO, ZERO, ONE, ZERO, ZERO, ZERO],
+                      [ZERO, ZERO, ZERO, ZERO, ZERO, ONE, ZERO, ZERO],
+                      [ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ONE, ZERO],
+                      [ZERO, ZERO, ZERO, ONE, ZERO, ZERO, ZERO, ZERO]];
+        CheckOperation(matrix, ApplyToFirstThreeQubitsA(CCNOT, _));
     }
 }

--- a/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
+++ b/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
@@ -25,14 +25,14 @@ namespace Microsoft.Quantum.Tests {
     }
 
     @Test("QuantumSimulator")
-    operation ApplyUnitary_Identity () : Unit {
+    operation CheckApplyUnitaryAppliesIdentity () : Unit {
         let matrix = [[Complex(1.0, 0.0), Complex(0.0, 0.0)],
                       [Complex(0.0, 0.0), Complex(1.0, 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(I, _));
     }
 
     @Test("QuantumSimulator")
-    operation ApplyUnitary_PauliX () : Unit {
+    operation CheckApplyUnitaryAppliesPauliX () : Unit {
         let matrix = [[Complex(0.0, 0.0), Complex(1.0, 0.0)],
                       [Complex(1.0, 0.0), Complex(0.0, 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(X, _));
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.Tests {
 
 
     @Test("QuantumSimulator")
-    operation ApplyUnitary_PauliY () : Unit {
+    operation CheckApplyUnitaryAppliesPauliY () : Unit {
         let matrix = [[Complex(0.0, 0.0), Complex(0.0, -1.0)],
                       [Complex(0.0, 1.0), Complex(0.0, 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(Y, _));
@@ -48,42 +48,42 @@ namespace Microsoft.Quantum.Tests {
 
 
     @Test("QuantumSimulator")
-    operation ApplyUnitary_PauliZ () : Unit {
+    operation CheckApplyUnitaryAppliesPauliZ () : Unit {
         let matrix = [[Complex(1.0, 0.0), Complex(0.0, 0.0)],
                       [Complex(0.0, 0.0), Complex(-1.0, 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(Z, _));
     }
 
     @Test("QuantumSimulator")
-    operation ApplyUnitary_Hadamard () : Unit {
+    operation CheckApplyUnitaryAppliesHadamard () : Unit {
         let matrix = [[Complex(Sqrt(0.5), 0.0), Complex(Sqrt(0.5), 0.0)],
                       [Complex(Sqrt(0.5), 0.0), Complex(-Sqrt(0.5), 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(H, _));
     }
 
     @Test("QuantumSimulator")
-    operation ApplyUnitary_HadamardY () : Unit {
+    operation CheckApplyUnitaryAppliesHadamardY () : Unit {
         let matrix = [[Complex(Sqrt(0.5), 0.0), Complex(Sqrt(0.5), 0.0)],
                       [Complex(0.0, Sqrt(0.5)), Complex(0.0, -Sqrt(0.5))]];
         CheckOperation(matrix, ApplyToHeadA(HY, _));
     }
 
     @Test("QuantumSimulator")
-    operation ApplyUnitary_Rx () : Unit {
+    operation CheckApplyUnitaryAppliesRx () : Unit {
         let matrix = [[Complex(Cos(1.0), 0.0), Complex(0.0, -Sin(1.0))],
                       [Complex(0.0, -Sin(1.0)), Complex(Cos(1.0), 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(Rx(2.0, _), _));
     }
 
     @Test("QuantumSimulator")
-    operation ApplyUnitary_Ry () : Unit {
+    operation CheckApplyUnitaryAppliesRy () : Unit {
         let matrix = [[Complex(Cos(1.0), 0.0), Complex(-Sin(1.0), 0.0)],
                       [Complex(Sin(1.0), 0.0), Complex(Cos(1.0), 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(Ry(2.0, _), _));
     }
 
     @Test("QuantumSimulator")
-    operation ApplyUnitary_CNOT () : Unit {
+    operation CheckApplyUnitaryAppliesCnot () : Unit {
         let ZERO = Complex(0.0, 0.0);
         let ONE = Complex(1.0, 0.0);
         // Matrix for CNOT(q[0], q[1]).
@@ -95,7 +95,7 @@ namespace Microsoft.Quantum.Tests {
     }
 
     @Test("QuantumSimulator")
-    operation ApplyUnitary_SWAP () : Unit {
+    operation CheckApplyUnitaryAppliesSwap () : Unit {
         let ZERO = Complex(0.0, 0.0);
         let ONE = Complex(1.0, 0.0);
         let matrix = [[ONE, ZERO, ZERO, ZERO],
@@ -110,7 +110,7 @@ namespace Microsoft.Quantum.Tests {
     }
 
     @Test("QuantumSimulator")
-    operation ApplyUnitary_QFT () : Unit {
+    operation CheckApplyUnitaryAppliesQft () : Unit {
         let matrix = [
             [Complex(0.5, 0.0), Complex(0.5, 0.0), Complex(0.5, 0.0), Complex(0.5, 0.0)],
             [Complex(0.5, 0.0), Complex(0.0, 0.5), Complex(-0.5, 0.0), Complex(0.0, -0.5)],
@@ -120,7 +120,7 @@ namespace Microsoft.Quantum.Tests {
     }
     
     @Test("QuantumSimulator")
-    operation ApplyUnitary_CCNOT () : Unit {
+    operation CheckApplyUnitaryAppliesCcnot () : Unit {
         // Matrix for CCNOT(q[0], q[1], q[2]).
         let ZERO = Complex(0.0, 0.0);
         let ONE = Complex(1.0, 0.0);

--- a/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
+++ b/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
@@ -132,4 +132,29 @@ namespace Microsoft.Quantum.Tests {
                       [ZERO, ZERO, ZERO, ONE, ZERO, ZERO, ZERO, ZERO]];
         CheckOperation(matrix, ApplyToFirstThreeQubitsA(CCNOT, _));
     }
+
+    operation ThreeControlledGates(qs: Qubit[]) : Unit is Adj {
+        Controlled X([qs[0]], qs[1]); 
+        Controlled T([qs[1]], qs[2]); 
+        Controlled Y([qs[2]], qs[0]);  
+        Controlled H([qs[1]], qs[2]); 
+    }   
+
+    @Test("QuantumSimulator")
+    operation CheckApplyUnitaryAppliesThreeControlledGates () : Unit {
+        let ZERO = Complex(0.0, 0.0);
+        let ONE = Complex(1.0, 0.0);
+        let SQRT_HALF = Sqrt(0.5);
+        let matrix = [
+            [ONE, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO],
+            [ZERO, ZERO, ZERO, ONE, ZERO, ZERO, ZERO, ZERO],
+            [ZERO, ZERO, Complex(Sqrt(0.5), 0.0), ZERO, ZERO, Complex(0.5, -0.5), ZERO, ZERO],
+            [ZERO, Complex(Sqrt(0.5), 0.0), ZERO, ZERO, ZERO, ZERO, Complex(-0.5, 0.5), ZERO],
+            [ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, Complex(0.0, -1.0)],
+            [ZERO, ZERO, ZERO, ZERO, Complex(0.0, 1.0), ZERO, ZERO, ZERO],
+            [ZERO, ZERO, Complex(Sqrt(0.5), 0.0), ZERO, ZERO, Complex(-0.5, 0.5), ZERO, ZERO],
+            [ZERO, Complex(Sqrt(0.5), 0.0), ZERO, ZERO, ZERO, ZERO, Complex(0.5, -0.5), ZERO],
+        ];
+        CheckOperation(matrix, ThreeControlledGates(_));
+    }
 }

--- a/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
+++ b/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
@@ -133,7 +133,7 @@ namespace Microsoft.Quantum.Tests {
         CheckOperation(matrix, ApplyToFirstThreeQubitsA(CCNOT, _));
     }
 
-    operation ThreeControlledGates(qs: Qubit[]) : Unit is Adj {
+    operation FourControlledGates(qs: Qubit[]) : Unit is Adj {
         Controlled X([qs[0]], qs[1]); 
         Controlled T([qs[1]], qs[2]); 
         Controlled Y([qs[2]], qs[0]);  
@@ -141,10 +141,11 @@ namespace Microsoft.Quantum.Tests {
     }   
 
     @Test("QuantumSimulator")
-    operation CheckApplyUnitaryAppliesThreeControlledGates () : Unit {
+    operation CheckApplyUnitaryAppliesFourControlledGates () : Unit {
         let ZERO = Complex(0.0, 0.0);
         let ONE = Complex(1.0, 0.0);
         let SQRT_HALF = Sqrt(0.5);
+        // This is unitary matrix of FourControlledGates operation above.
         let matrix = [
             [ONE, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO],
             [ZERO, ZERO, ZERO, ONE, ZERO, ZERO, ZERO, ZERO],
@@ -155,6 +156,6 @@ namespace Microsoft.Quantum.Tests {
             [ZERO, ZERO, Complex(Sqrt(0.5), 0.0), ZERO, ZERO, Complex(-0.5, 0.5), ZERO, ZERO],
             [ZERO, Complex(Sqrt(0.5), 0.0), ZERO, ZERO, ZERO, ZERO, Complex(0.5, -0.5), ZERO]
         ];
-        CheckOperation(matrix, ThreeControlledGates(_));
+        CheckOperation(matrix, FourControlledGates(_));
     }
 }

--- a/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
+++ b/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Tests {
     }
 
     internal operation CheckOperation(matrix: Complex[][], expected: (Qubit[] => Unit is Adj)) : Unit {
-        let nQubits = 1; // TODO: number of qubits is not always 1.
+        let nQubits = Floor(Lg(IntAsDouble(Length(matrix))));
         AssertOperationsEqualInPlace(nQubits, ApplyUnitaryToRegister(matrix, _), expected);
     }
 
@@ -86,10 +86,11 @@ namespace Microsoft.Quantum.Tests {
     operation ApplyUnitary_CNOT () : Unit {
         let ZERO = Complex(0.0, 0.0);
         let ONE = Complex(1.0, 0.0);
+        // This is CNOT(q[0], q[1]).
         let matrix = [[ONE, ZERO, ZERO, ZERO],
-                      [ZERO, ONE, ZERO, ZERO],
                       [ZERO, ZERO, ZERO, ONE],
-                      [ZERO, ZERO, ONE, ZERO]];
+                      [ZERO, ZERO, ONE, ZERO],
+                      [ZERO, ONE, ZERO, ZERO]];
         CheckOperation(matrix, ApplyToFirstTwoQubitsA(CNOT, _));
     }
 
@@ -102,5 +103,20 @@ namespace Microsoft.Quantum.Tests {
                       [ZERO, ONE, ZERO, ZERO],
                       [ZERO, ZERO, ZERO, ONE]];
         CheckOperation(matrix, ApplyToFirstTwoQubitsA(SWAP, _));
+    }
+
+    internal operation ApplyQFT(qubits: Qubit[]) : Unit is Adj {
+        QFT(BigEndian(Reversed(qubits)));
+    }
+
+    @Test("QuantumSimulator")
+    operation ApplyUnitary_QFT () : Unit {
+        let ZERO = Complex(0.0, 0.0);
+        let ONE = Complex(1.0, 0.0);
+        let matrix = [[Complex(0.5, 0.0), Complex(0.5, 0.0), Complex(0.5, 0.0), Complex(0.5, 0.0)],
+                      [Complex(0.5, 0.0), Complex(0.0, 0.5), Complex(-0.5, 0.0), Complex(0.0, -0.5)],
+                      [Complex(0.5, 0.0), Complex(-0.5, 0.0), Complex(0.5, 0.0), Complex(-0.5, 0.0)],
+                      [Complex(0.5, 0.0), Complex(0.0, -0.5), Complex(-0.5, 0.0), Complex(0.0, 0.5)]];
+        CheckOperation(matrix, ApplyQFT);
     }
 }

--- a/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
+++ b/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
@@ -12,6 +12,8 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Measurement;
     open Microsoft.Quantum.Synthesis;
     open Microsoft.Quantum.Random;
+
+    // dotnet test tests --filter "Name~ApplyUnitary"
     
     operation ApplyUnitaryToRegister(matrix: Complex[][], qubits: Qubit[]) : Unit {
         ApplyUnitary(matrix, LittleEndian(qubits));

--- a/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
+++ b/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
@@ -18,7 +18,8 @@ namespace Microsoft.Quantum.Tests {
     }
 
     // Checks that `ApplyUnitary(matrix)` is equvalent to `expected` operation.
-    internal operation CheckOperation(matrix: Complex[][], expected: (Qubit[] => Unit is Adj)) : Unit {
+    internal operation CheckOperation(matrix: Complex[][], 
+                                      expected: (Qubit[] => Unit is Adj)) : Unit {
         let nQubits = Floor(Lg(IntAsDouble(Length(matrix))));
         AssertOperationsEqualInPlace(nQubits, ApplyUnitaryToRegister(matrix, _), expected);
     }
@@ -110,10 +111,11 @@ namespace Microsoft.Quantum.Tests {
 
     @Test("QuantumSimulator")
     operation ApplyUnitary_QFT () : Unit {
-        let matrix = [[Complex(0.5, 0.0), Complex(0.5, 0.0), Complex(0.5, 0.0), Complex(0.5, 0.0)],
-                      [Complex(0.5, 0.0), Complex(0.0, 0.5), Complex(-0.5, 0.0), Complex(0.0, -0.5)],
-                      [Complex(0.5, 0.0), Complex(-0.5, 0.0), Complex(0.5, 0.0), Complex(-0.5, 0.0)],
-                      [Complex(0.5, 0.0), Complex(0.0, -0.5), Complex(-0.5, 0.0), Complex(0.0, 0.5)]];
+        let matrix = [
+            [Complex(0.5, 0.0), Complex(0.5, 0.0), Complex(0.5, 0.0), Complex(0.5, 0.0)],
+            [Complex(0.5, 0.0), Complex(0.0, 0.5), Complex(-0.5, 0.0), Complex(0.0, -0.5)],
+            [Complex(0.5, 0.0), Complex(-0.5, 0.0), Complex(0.5, 0.0), Complex(-0.5, 0.0)],
+            [Complex(0.5, 0.0), Complex(0.0, -0.5), Complex(-0.5, 0.0), Complex(0.0, 0.5)]];
         CheckOperation(matrix, ApplyQFT);
     }
     

--- a/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
+++ b/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
@@ -9,9 +9,7 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Math;
-    open Microsoft.Quantum.Measurement;
     open Microsoft.Quantum.Synthesis;
-    open Microsoft.Quantum.Random;
     
     internal operation ApplyUnitaryToRegister(matrix: Complex[][], qubits: Qubit[]) : Unit {
         ApplyUnitary(matrix, LittleEndian(qubits));

--- a/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
+++ b/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
@@ -81,4 +81,26 @@ namespace Microsoft.Quantum.Tests {
                       [Complex(Sin(1.0), 0.0), Complex(Cos(1.0), 0.0)]];
         CheckOperation(matrix, ApplyToHeadA(Ry(2.0, _), _));
     }
+
+    @Test("QuantumSimulator")
+    operation ApplyUnitary_CNOT () : Unit {
+        let ZERO = Complex(0.0, 0.0);
+        let ONE = Complex(1.0, 0.0);
+        let matrix = [[ONE, ZERO, ZERO, ZERO],
+                      [ZERO, ONE, ZERO, ZERO],
+                      [ZERO, ZERO, ZERO, ONE],
+                      [ZERO, ZERO, ONE, ZERO]];
+        CheckOperation(matrix, ApplyToFirstTwoQubitsA(CNOT, _));
+    }
+
+    @Test("QuantumSimulator")
+    operation ApplyUnitary_SWAP () : Unit {
+        let ZERO = Complex(0.0, 0.0);
+        let ONE = Complex(1.0, 0.0);
+        let matrix = [[ONE, ZERO, ZERO, ZERO],
+                      [ZERO, ZERO, ONE, ZERO],
+                      [ZERO, ONE, ZERO, ZERO],
+                      [ZERO, ZERO, ZERO, ONE]];
+        CheckOperation(matrix, ApplyToFirstTwoQubitsA(SWAP, _));
+    }
 }

--- a/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
+++ b/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
@@ -153,7 +153,7 @@ namespace Microsoft.Quantum.Tests {
             [ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO, Complex(0.0, -1.0)],
             [ZERO, ZERO, ZERO, ZERO, Complex(0.0, 1.0), ZERO, ZERO, ZERO],
             [ZERO, ZERO, Complex(Sqrt(0.5), 0.0), ZERO, ZERO, Complex(-0.5, 0.5), ZERO, ZERO],
-            [ZERO, Complex(Sqrt(0.5), 0.0), ZERO, ZERO, ZERO, ZERO, Complex(0.5, -0.5), ZERO],
+            [ZERO, Complex(Sqrt(0.5), 0.0), ZERO, ZERO, ZERO, ZERO, Complex(0.5, -0.5), ZERO]
         ];
         CheckOperation(matrix, ThreeControlledGates(_));
     }

--- a/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
+++ b/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
@@ -15,11 +15,11 @@ namespace Microsoft.Quantum.Tests {
 
     // dotnet test tests --filter "Name~ApplyUnitary"
     
-    operation ApplyUnitaryToRegister(matrix: Complex[][], qubits: Qubit[]) : Unit {
+    internal operation ApplyUnitaryToRegister(matrix: Complex[][], qubits: Qubit[]) : Unit {
         ApplyUnitary(matrix, LittleEndian(qubits));
     }
 
-    operation CheckOperation(matrix: Complex[][], expected: (Qubit[] => Unit is Adj)) : Unit {
+    internal operation CheckOperation(matrix: Complex[][], expected: (Qubit[] => Unit is Adj)) : Unit {
         let nQubits = 1; // TODO: number of qubits is not always 1.
         AssertOperationsEqualInPlace(nQubits, ApplyUnitaryToRegister(matrix, _), expected);
     }

--- a/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
+++ b/Standard/tests/Synthesis/UnitaryDecompositionTest.qs
@@ -12,11 +12,71 @@ namespace Microsoft.Quantum.Tests {
     open Microsoft.Quantum.Measurement;
     open Microsoft.Quantum.Synthesis;
     open Microsoft.Quantum.Random;
+    
+    operation ApplyUnitaryToRegister(matrix: Complex[][], qubits: Qubit[]) : Unit {
+        ApplyUnitary(matrix, LittleEndian(qubits));
+    }
 
- 
+    operation CheckOperation(matrix: Complex[][], expected: (Qubit[] => Unit is Adj)) : Unit {
+        let nQubits = 1; // TODO: number of qubits is not always 1.
+        AssertOperationsEqualInPlace(nQubits, ApplyUnitaryToRegister(matrix, _), expected);
+    }
 
     @Test("QuantumSimulator")
-    operation MyFirstQuantumTest () : Unit {
-        AssertOperationsEqualInPlace(1, ApplyUnitary, X);
+    operation ApplyUnitary_Identity () : Unit {
+        let matrix = [[Complex(1.0, 0.0), Complex(0.0, 0.0)],
+                      [Complex(0.0, 0.0), Complex(1.0, 0.0)]];
+        CheckOperation(matrix, ApplyToHeadA(I, _));
+    }
+
+    @Test("QuantumSimulator")
+    operation ApplyUnitary_PauliX () : Unit {
+        let matrix = [[Complex(0.0, 0.0), Complex(1.0, 0.0)],
+                      [Complex(1.0, 0.0), Complex(0.0, 0.0)]];
+        CheckOperation(matrix, ApplyToHeadA(X, _));
+    }
+
+
+    @Test("QuantumSimulator")
+    operation ApplyUnitary_PauliY () : Unit {
+        let matrix = [[Complex(0.0, 0.0), Complex(0.0, -1.0)],
+                      [Complex(0.0, 1.0), Complex(0.0, 0.0)]];
+        CheckOperation(matrix, ApplyToHeadA(Y, _));
+    }
+
+
+    @Test("QuantumSimulator")
+    operation ApplyUnitary_PauliZ () : Unit {
+        let matrix = [[Complex(1.0, 0.0), Complex(0.0, 0.0)],
+                      [Complex(0.0, 0.0), Complex(-1.0, 0.0)]];
+        CheckOperation(matrix, ApplyToHeadA(Z, _));
+    }
+
+    @Test("QuantumSimulator")
+    operation ApplyUnitary_Hadamard () : Unit {
+        let matrix = [[Complex(Sqrt(0.5), 0.0), Complex(Sqrt(0.5), 0.0)],
+                      [Complex(Sqrt(0.5), 0.0), Complex(-Sqrt(0.5), 0.0)]];
+        CheckOperation(matrix, ApplyToHeadA(H, _));
+    }
+
+    @Test("QuantumSimulator")
+    operation ApplyUnitary_HadamardY () : Unit {
+        let matrix = [[Complex(Sqrt(0.5), 0.0), Complex(Sqrt(0.5), 0.0)],
+                      [Complex(0.0, Sqrt(0.5)), Complex(0.0, -Sqrt(0.5))]];
+        CheckOperation(matrix, ApplyToHeadA(HY, _));
+    }
+
+    @Test("QuantumSimulator")
+    operation ApplyUnitary_Rx () : Unit {
+        let matrix = [[Complex(Cos(1.0), 0.0), Complex(0.0, -Sin(1.0))],
+                      [Complex(0.0, -Sin(1.0)), Complex(Cos(1.0), 0.0)]];
+        CheckOperation(matrix, ApplyToHeadA(Rx(2.0, _), _));
+    }
+
+    @Test("QuantumSimulator")
+    operation ApplyUnitary_Ry () : Unit {
+        let matrix = [[Complex(Cos(1.0), 0.0), Complex(-Sin(1.0), 0.0)],
+                      [Complex(Sin(1.0), 0.0), Complex(Cos(1.0), 0.0)]];
+        CheckOperation(matrix, ApplyToHeadA(Ry(2.0, _), _));
     }
 }


### PR DESCRIPTION
This PR adds Q# operation which applies arbitrary gate specified by 2^n x 2^n unitary matrix on a qubit register, as requested in #291.

It's based on an algorithm which I have implemented in Python in [this repository](https://github.com/fedimser/quantum_decomp).

Implementation consists of 3 parts:
1. Implementing 1-qubit gate specified by 2x2 matrix - in native Q#.
2. Matrix decomposition algorithm, which decomposes unitary matrix as product of two-level unitary matrices with indices differing exactly in 1 bit - in C#.
3. Q# operation which uses decomposition in (2) and implements arbitrary n-qubit unitary via multiple calls to controlled (1) operation and X gates.

Complexity of this algorithm is O(N^3) and size of output is O(N^2), where N is size of matrix (N=2^n, where n is number of qubits).