### PR TITLE
Update build schedule

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -11,6 +11,14 @@ pr:
 - features/*
 - release/*
 
+schedules:
+- cron: "0 9 * * Sat"
+  displayName: 'Build for Component Governance'
+  branches:
+    include:
+    - main
+  always: true
+
 variables:
   Build.Major: 0
   Build.Minor: 10


### PR DESCRIPTION
Add a `main` build scheduled for 1AM PST on Saturdays to keep component governance detection current.