### PR TITLE
Adding explicit reference to Qsharp.Core package

### DIFF
--- a/Standard/src/Standard.csproj
+++ b/Standard/src/Standard.csproj
@@ -38,6 +38,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.14.20111301-pull" />
+    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.14.20111301-pull" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>


### PR DESCRIPTION
With the ongoing refactor of the qsharp-runtime repo to support target packages, the Microsoft.Quantum.Simulators package no longer automatically brings in the Microsoft.Quantum.QSharp.Core package, so projects need to explicitly add that reference if they are have suppressed loading of the core package via `IncludeQsharpCorePackages` set to false. See microsoft/qsharp-runtime#476, which this change will help unblock.