### PR TITLE
```Q# → ```qsharp

### DIFF
--- a/MachineLearning/src/Structure.qs
+++ b/MachineLearning/src/Structure.qs
@@ -148,7 +148,7 @@ namespace Microsoft.Quantum.MachineLearning {
     ///
     /// # Example
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let layer = CyclicEntanglingLayer(3, PauliX, 2);
     /// let layer = [
     ///     ControlledRotation((0, [2]), PauliX, 0),
@@ -185,7 +185,7 @@ namespace Microsoft.Quantum.MachineLearning {
     ///
     /// # Example
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let structure = CombinedStructure([
     ///     LocalRotationLayer(2, PauliY),
     ///     CyclicEntanglingLayer(3, PauliX, 2)

--- a/MachineLearning/src/Types.qs
+++ b/MachineLearning/src/Types.qs
@@ -29,7 +29,7 @@ namespace Microsoft.Quantum.MachineLearning {
     /// The following represents a rotation about the $X$-axis of the first
     /// qubit in a register, controlled on the second qubit, and with an
     /// angle given by the fourth parameter in a sequential model:
-    /// ```Q#
+    /// ```qsharp
     /// let controlledRotation = ControlledRotation(
     ///     (0, [1]),
     ///     PauliX,
@@ -195,7 +195,7 @@ namespace Microsoft.Quantum.MachineLearning {
     ///
     /// For example, to use 100,000 measurements and at most 8 training
     /// epochs:
-    /// ```Q#
+    /// ```qsharp
     /// let options = DefaultTrainingOptions()
     ///               w/ NMeasurements <- 100000
     ///               w/ MaxEpochs <- 8;
@@ -225,7 +225,7 @@ namespace Microsoft.Quantum.MachineLearning {
     /// # Example
     /// To use the default options, but with additional measurements, use the
     /// `w/` operator:
-    /// ```Q#
+    /// ```qsharp
     /// let options = DefaultTrainingOptions()
     ///     w/ NMeasurements <- 1000000;
     /// ```

--- a/MachineLearning/src/Validation.qs
+++ b/MachineLearning/src/Validation.qs
@@ -19,7 +19,7 @@ namespace Microsoft.Quantum.MachineLearning {
     /// `inferredLabels[idx] != actualLabels[idx]`.
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// let misclassifications = Misclassifications([0, 1, 0, 0], [0, 1, 1, 0]);
     /// Message($"{misclassifications}"); // Will print [2].
     /// ```
@@ -46,7 +46,7 @@ namespace Microsoft.Quantum.MachineLearning {
     /// `inferredLabels[idx] != actualLabels[idx]`.
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// let nMisclassifications = NMisclassifications([1, 1, 0, 0], [0, 1, 1, 0]);
     /// Message($"{nMisclassifications}"); // Will print 2.
     /// ```

--- a/Standard/src/Arrays/Arrays.qs
+++ b/Standard/src/Arrays/Arrays.qs
@@ -385,7 +385,7 @@ namespace Microsoft.Quantum.Arrays {
     /// # Example
     /// The following Q# code prints the message "All diagnostics completed
     /// successfully":
-    /// ```Q#
+    /// ```qsharp
     /// Fact(IsPermutation([2, 0, 1], "");
     /// Contradiction(IsPermutation([5, 0, 1], "[5, 0, 1] isn't a permutation");
     /// Message("All diagnostics completed successfully.");

--- a/Standard/src/Arrays/DrawMany.qs
+++ b/Standard/src/Arrays/DrawMany.qs
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.Arrays {
     /// # Example
     /// The following samples an integer, given an operation
     /// that samples a single bit at a time.
-    /// ```Q#
+    /// ```qsharp
     /// let randomInteger = BoolArrayAsInt(DrawMany(SampleRandomBit, 16, ()));
     /// ```
     ///

--- a/Standard/src/Arrays/Enumeration.qs
+++ b/Standard/src/Arrays/Enumeration.qs
@@ -23,7 +23,7 @@ namespace Microsoft.Quantum.Arrays {
     ///
     /// # Example
     /// The following `for` loops are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// for (idx in IndexRange(array)) {
     ///     let element = array[idx];
     ///     ...

--- a/Standard/src/Arrays/Filter.qs
+++ b/Standard/src/Arrays/Filter.qs
@@ -105,7 +105,7 @@ namespace Microsoft.Quantum.Arrays {
     /// # Example
     /// The following code demonstrates the "Count" function.
     /// A predicate is defined using the @"microsoft.quantum.logical.greaterthani" function:
-    /// ```Q#
+    /// ```qsharp
     ///  let predicate = GreaterThanI(_, 5);
     ///  let count = Count(predicate, [2, 5, 9, 1, 8]);
     ///  // count = 2

--- a/Standard/src/Arrays/Interleaved.qs
+++ b/Standard/src/Arrays/Interleaved.qs
@@ -30,7 +30,7 @@ namespace Microsoft.Quantum.Arrays {
     /// Interleaved array
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// // same as int1 = [1, -1, 2, -2, 3, -3]
     /// let int1 = Interleaved([1, 2, 3], [-1, -2, -3])
     ///

--- a/Standard/src/Arrays/Map.qs
+++ b/Standard/src/Arrays/Map.qs
@@ -112,7 +112,7 @@ namespace Microsoft.Quantum.Arrays {
     ///
     /// # Example
     /// This example adds 1 to a range of even numbers:
-    /// ```Q#
+    /// ```qsharp
     /// let numbers = MappedOverRange(PlusI(1, _), 0..2..10);
     /// // numbers = [1, 3, 5, 7, 9, 11]
     /// ```
@@ -158,7 +158,7 @@ namespace Microsoft.Quantum.Arrays {
     /// the mapping function.
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// let Numbers = SequenceI(1, _); // generates numbers starting from 1
     /// let values = FlatMapped(Numbers, [1, 2, 3]);
     /// // values = [1, 1, 2, 1, 2, 3]
@@ -182,7 +182,7 @@ namespace Microsoft.Quantum.Arrays {
     /// Concatenation of all arrays.
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// let flattened = Flattened([[1, 2], [3], [4, 5, 6]]);
     /// // flattened = [1, 2, 3, 4, 5, 6]
     /// ```

--- a/Standard/src/Arrays/Multidimensional.qs
+++ b/Standard/src/Arrays/Multidimensional.qs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.Arrays {
     /// Transposed $c \times r$ matrix
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// // same as [[1, 4], [2, 5], [3, 6]]
     /// let transposed = Transposed([[1, 2, 3], [4, 5, 6]]);
     /// ```
@@ -67,7 +67,7 @@ namespace Microsoft.Quantum.Arrays {
     /// # Example
     /// Get the third number in four famous integer sequences. (note
     /// that the 0 index corresponds to the _first_ value of the sequence.)
-    /// ```Q#
+    /// ```qsharp
     /// let lucas = [2, 1, 3, 4, 7, 11, 18, 29, 47, 76];
     /// let prime = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29];
     /// let fibonacci = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34];
@@ -101,7 +101,7 @@ namespace Microsoft.Quantum.Arrays {
     /// # Example
     /// Get the odd indexes in famous integer sequences. (note
     /// that the 0 index corresponds to the _first_ value of the sequence.)
-    /// ```Q#
+    /// ```qsharp
     /// let lucas = [2, 1, 3, 4, 7, 11, 18, 29, 47, 76];
     /// let prime = [2, 3, 5, 7, 11, 13, 17, 19, 23, 29];
     /// let fibonacci = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34];
@@ -136,7 +136,7 @@ namespace Microsoft.Quantum.Arrays {
     /// 2-dimensional matrix in row-wise order
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// let matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
     /// let column = ColumnAt(0, matrix);
     /// // same as: column = [1, 4, 7]
@@ -180,7 +180,7 @@ namespace Microsoft.Quantum.Arrays {
     /// 2-dimensional matrix in row-wise order
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// let matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
     /// let diagonal = Diagonal(matrix);
     /// // same as: column = [1, 5, 9]
@@ -218,7 +218,7 @@ namespace Microsoft.Quantum.Arrays {
     /// A message to be printed if the array is not a rectangular array
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// RectangularArrayFact([[1, 2], [3, 4]], "Array is not rectangular");       // okay
     /// RectangularArrayFact([[1, 2, 3], [4, 5, 6]], "Array is not rectangular"); // okay
     /// RectangularArrayFact([[1, 2], [3, 4, 5]], "Array is not rectangular");    // will fail
@@ -255,7 +255,7 @@ namespace Microsoft.Quantum.Arrays {
     /// A message to be printed if the array is not a square array
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// SquareArrayFact([[1, 2], [3, 4]], "Array is not a square");       // okay
     /// SquareArrayFact([[1, 2, 3], [4, 5, 6]], "Array is not a square"); // will fail
     /// SquareArrayFact([[1, 2], [3, 4, 5]], "Array is not a square");    // will fail

--- a/Standard/src/Arrays/Reductions.qs
+++ b/Standard/src/Arrays/Reductions.qs
@@ -37,7 +37,7 @@ namespace Microsoft.Quantum.Arrays {
     /// `Tail(CumulativeFolded(fn, state, array))` is the same as `Fold(fn, state, array)`.
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// // same as sums = [1, 3, 6, 10, 15]
     /// let sums = CumulativeFolded(PlusI, 0, SequenceI(1, 5));
     /// ```

--- a/Standard/src/Arrays/Search.qs
+++ b/Standard/src/Arrays/Search.qs
@@ -23,7 +23,7 @@ namespace Microsoft.Quantum.Arrays {
     /// Suppose that `IsEven : Int -> Bool` is a function that returns `true`
     /// if and only if its input is even. Then, this can be used with `IndexOf`
     /// to find the first even element in an array:
-    /// ```Q#
+    /// ```qsharp
     /// let items = [1, 3, 17, 2, 21];
     /// let idx = IndexOf(IsEven, items); // returns 3
     /// ```

--- a/Standard/src/Arrays/Sorted.qs
+++ b/Standard/src/Arrays/Sorted.qs
@@ -82,7 +82,7 @@ namespace Microsoft.Quantum.Arrays {
     /// # Example
     /// The following snippet sorts an array of integers to occur in ascending
     /// order:
-    /// ```Q#
+    /// ```qsharp
     /// let sortedArray = Sorted(LessThanOrEqualI, [3, 17, 11, -201, -11]);
     /// ```
     /// 
@@ -101,7 +101,7 @@ namespace Microsoft.Quantum.Arrays {
     /// appear before `b` in the output.
     ///
     /// For example:
-    /// ```Q#
+    /// ```qsharp
     /// function LastDigitLessThanOrEqual(left : Int, right : Int) : Bool {
     ///     return LessThanOrEqualI(
     ///         left % 10, right % 10

--- a/Standard/src/Arrays/Unique.qs
+++ b/Standard/src/Arrays/Unique.qs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.Arrays {
     /// together with `Sorted` to get an array with overall unique elements.
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// let unique1 = Unique(EqualI, [1, 1, 3, 3, 2, 5, 5, 5, 7]);
     /// // same as [1, 3, 2, 5, 7]
     /// let unique2 = Unique(EqualI, [2, 2, 1, 1, 2, 2, 1, 1]);

--- a/Standard/src/Arrays/Windows.qs
+++ b/Standard/src/Arrays/Windows.qs
@@ -26,7 +26,7 @@ namespace Microsoft.Quantum.Arrays {
     /// An array of elements.
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// // same as [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
     /// let windows = Windows(3, [1, 2, 3, 4, 5]);
     /// ```
@@ -62,7 +62,7 @@ namespace Microsoft.Quantum.Arrays {
     /// An array of elements.
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// let prefixes = Prefixes([23, 42, 144]);
     /// // prefixes = [[23], [23, 42], [23, 42, 144]]
     /// ```

--- a/Standard/src/Arrays/Zip.qs
+++ b/Standard/src/Arrays/Zip.qs
@@ -151,7 +151,7 @@ namespace Microsoft.Quantum.Arrays {
     /// tuples, the second one containing all second elements of the input tuples.
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// // split is same as ([6, 5, 5, 3, 2, 1], [true, false, false, false, true, false])
     /// let split = Unzipped([(6, true), (5, false), (5, false), (3, false), (2, true), (1, false)]);
     /// ```

--- a/Standard/src/Bitwise/Bitwise.qs
+++ b/Standard/src/Bitwise/Bitwise.qs
@@ -19,7 +19,7 @@ namespace Microsoft.Quantum.Bitwise {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let c = a <<< b;
     /// let c = LeftShiftedI(a, b);
     /// ```
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.Bitwise {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let c = a <<< b;
     /// let c = LeftShiftedL(a, b);
     /// ```
@@ -67,7 +67,7 @@ namespace Microsoft.Quantum.Bitwise {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let c = a >>> b;
     /// let c = RightShiftedI(a, b);
     /// ```
@@ -91,7 +91,7 @@ namespace Microsoft.Quantum.Bitwise {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let c = a >>> b;
     /// let c = RightShiftedL(a, b);
     /// ```

--- a/Standard/src/Canon/And.qs
+++ b/Standard/src/Canon/And.qs
@@ -153,7 +153,7 @@ namespace Microsoft.Quantum.Canon {
     /// next one.
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// GrayCode(2); // [(0, 0),(1, 1),(3, 0),(2, 1)]
     /// ```
     internal function GrayCode(n : Int) : (Int, Int)[] {

--- a/Standard/src/Canon/Combinators/ApplyIf.qs
+++ b/Standard/src/Canon/Combinators/ApplyIf.qs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.Canon {
     /// The following prepares a register of qubits into a computational basis
     /// state represented by a classical bit string given as an array of `Bool`
     /// values:
-    /// ```Q#
+    /// ```qsharp
     /// let bitstring = [true, false, true];
     /// using (register = Qubit(3)) {
     ///     ApplyToEach(ApplyIf(X, _, _), Zipped(bitstring, register));
@@ -74,7 +74,7 @@ namespace Microsoft.Quantum.Canon {
     /// The following prepares a register of qubits into a computational basis
     /// state represented by a classical bit string given as an array of `Bool`
     /// values:
-    /// ```Q#
+    /// ```qsharp
     /// let bitstring = [true, false, true];
     /// using (register = Qubit(3)) {
     ///     ApplyToEach(ApplyIf(X, _, _), Zipped(bitstring, register));
@@ -117,7 +117,7 @@ namespace Microsoft.Quantum.Canon {
     /// The following prepares a register of qubits into a computational basis
     /// state represented by a classical bit string given as an array of `Bool`
     /// values:
-    /// ```Q#
+    /// ```qsharp
     /// let bitstring = [true, false, true];
     /// using (register = Qubit(3)) {
     ///     ApplyToEach(ApplyIf(X, _, _), Zipped(bitstring, register));
@@ -161,7 +161,7 @@ namespace Microsoft.Quantum.Canon {
     /// The following prepares a register of qubits into a computational basis
     /// state represented by a classical bit string given as an array of `Bool`
     /// values:
-    /// ```Q#
+    /// ```qsharp
     /// let bitstring = [true, false, true];
     /// using (register = Qubit(3)) {
     ///     ApplyToEach(ApplyIf(X, _, _), Zipped(bitstring, register));

--- a/Standard/src/Canon/Combinators/ApplyToArray.qs
+++ b/Standard/src/Canon/Combinators/ApplyToArray.qs
@@ -23,7 +23,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Example
     /// The following Q# snippets are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// ApplyToHead(H, register);
     /// H(Head(register));
     /// ```
@@ -130,7 +130,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Example
     /// The following Q# snippets are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// ApplyToRest(ApplyCNOTChain, register);
     /// ApplyCNOTChain(Rest(register));
     /// ```
@@ -237,7 +237,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Example
     /// The following Q# snippets are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// ApplyToTail(H, register);
     /// H(Tail(register));
     /// ```
@@ -344,7 +344,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Example
     /// The following Q# snippets are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// ApplyToMost(ApplyCNOTChain, register);
     /// ApplyCNOTChain(Most(register));
     /// ```

--- a/Standard/src/Canon/IterateThroughCartesianProduct.qs
+++ b/Standard/src/Canon/IterateThroughCartesianProduct.qs
@@ -21,10 +21,10 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Example
     /// Given an operation `op`, the following two snippets are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// IterateThroughCartesianProduct([3, 4, 5], op);
     /// ```
-    /// ```Q#
+    /// ```qsharp
     /// op([0, 0, 0]);
     /// op([1, 0, 0]);
     /// op([2, 0, 0]);
@@ -86,10 +86,10 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Example
     /// Given an operation `op`, the following two snippets are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// IterateThroughCartesianPower(2, 3, op);
     /// ```
-    /// ```Q#
+    /// ```qsharp
     /// op([0, 0]);
     /// op([1, 0]);
     /// op([2, 0]);

--- a/Standard/src/Canon/Repeat.qs
+++ b/Standard/src/Canon/Repeat.qs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Example
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// Repeat(U, 17, target);
     /// (Bound(ConstantArray(17, U)))(target);
     /// ```
@@ -53,7 +53,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Example
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// RepeatA(U, 17, target);
     /// (BoundA(ConstantArray(17, U)))(target);
     /// ```
@@ -86,7 +86,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Example
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// RepeatC(U, 17, target);
     /// (BoundC(ConstantArray(17, U)))(target);
     /// ```
@@ -119,7 +119,7 @@ namespace Microsoft.Quantum.Canon {
     ///
     /// # Example
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// RepeatCA(U, 17, target);
     /// (BoundCA(ConstantArray(17, U)))(target);
     /// ```

--- a/Standard/src/Diagnostics/Allows.qs
+++ b/Standard/src/Diagnostics/Allows.qs
@@ -18,7 +18,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// # Example
     /// The following snippet will fail when executed on machines which
     /// support this diagnostic:
-    /// ```Q#
+    /// ```qsharp
     /// using (register = Qubit[4]) {
     ///     within {
     ///         AllowAtMostNCallsCA(3, H, "Too many calls to H.");
@@ -54,7 +54,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// # Example
     /// The following snippet will fail when executed on machines which
     /// support this diagnostic:
-    /// ```Q#
+    /// ```qsharp
     /// within {
     ///     AllowAtMostNQubits(3, "Too many qubits allocated.");
     /// } apply {

--- a/Standard/src/Diagnostics/Dump.qs
+++ b/Standard/src/Diagnostics/Dump.qs
@@ -22,7 +22,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// will output the matrix
     /// $\left(\begin{matrix} 0.0 & 0.707 \\\\ 0.707 & 0.0\end{matrix}\right)$:
     ///
-    /// ```Q#
+    /// ```qsharp
     /// open Microsoft.Quantum.Arrays as Arrays;
     /// 
     /// operation ApplyH(register : Qubit[]) : Unit is Adj + Ctl {
@@ -48,7 +48,7 @@ namespace Microsoft.Quantum.Diagnostics {
     /// \end{aligned}.
     /// $$
     ///
-    /// ```Q#
+    /// ```qsharp
     /// operation DumpCnot() : Unit {
     ///     DumpOperation(2, ApplyToFirstTwoQubitsCA(CNOT, _));
     /// }

--- a/Standard/src/Logical/BooleanOperators.qs
+++ b/Standard/src/Logical/BooleanOperators.qs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let x = not value;
     /// let x = Not(value);
     /// ```
@@ -42,7 +42,7 @@ namespace Microsoft.Quantum.Logical {
     /// both inputs are fully evaluated.
     ///
     /// Up to short-circuiting behavior, the following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let x = a and b;
     /// let x = And(a, b);
     /// ```
@@ -67,7 +67,7 @@ namespace Microsoft.Quantum.Logical {
     /// both inputs are fully evaluated.
     ///
     /// Up to short-circuiting behavior, the following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let x = a or b;
     /// let x = Or(a, b);
     /// ```
@@ -109,7 +109,7 @@ namespace Microsoft.Quantum.Logical {
     /// both inputs are fully evaluated.
     ///
     /// Up to short-circuiting behavior, the following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let x = condition ? ifTrue | ifFalse;
     /// let x = Conditioned(condition, ifTrue, ifFalse);
     /// ```

--- a/Standard/src/Logical/Comparisons.qs
+++ b/Standard/src/Logical/Comparisons.qs
@@ -37,7 +37,7 @@ namespace Microsoft.Quantum.Logical {
     ///   the other, the shorter array is said to occur first.
     ///
     /// # Examples
-    /// ```Q#
+    /// ```qsharp
     /// let arrayComparison = LexographicComparison(LessThanOrEqualD);
     /// let data = [
     ///     [1.1, 2.2, 3.3],

--- a/Standard/src/Logical/Predicates.qs
+++ b/Standard/src/Logical/Predicates.qs
@@ -18,7 +18,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a == b;
     /// let cond = EqualI(a, b);
     /// ```
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a == b;
     /// let cond = EqualL(a, b);
     /// ```
@@ -62,7 +62,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a == b;
     /// let cond = EqualD(a, b);
     /// ```
@@ -85,7 +85,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = Microsoft.Quantum.Math.AbsD(a - b) < 1e-12;
     /// let cond = NearlyEqualD(a, b);
     /// ```
@@ -107,7 +107,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a == b;
     /// let cond = EqualR(a, b);
     /// ```
@@ -129,7 +129,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a == b;
     /// let cond = EqualB(a, b);
     /// ```
@@ -182,7 +182,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a != b;
     /// let cond = NotEqualI(a, b);
     /// ```
@@ -204,7 +204,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a != b;
     /// let cond = NotEqualL(a, b);
     /// ```
@@ -226,7 +226,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a != b;
     /// let cond = NotEqualD(a, b);
     /// ```
@@ -249,7 +249,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = Microsoft.Quantum.Math.AbsD(a - b) >= 1e-12;
     /// let cond = NotNearlyEqualD(a, b);
     /// ```
@@ -271,7 +271,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a != b;
     /// let cond = NotEqualR(a, b);
     /// ```
@@ -293,7 +293,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a != b;
     /// let cond = NotEqualB(a, b);
     /// ```
@@ -345,7 +345,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a > b;
     /// let cond = GreaterThanI(a, b);
     /// ```
@@ -367,7 +367,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a > b;
     /// let cond = GreaterThanL(a, b);
     /// ```
@@ -389,7 +389,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a > b;
     /// let cond = GreaterThanD(a, b);
     /// ```
@@ -412,7 +412,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a >= b;
     /// let cond = GreaterThanOrEqualI(a, b);
     /// ```
@@ -435,7 +435,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a >= b;
     /// let cond = GreaterThanOrEqualL(a, b);
     /// ```
@@ -458,7 +458,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a >= b;
     /// let cond = GreaterThanOrEqualD(a, b);
     /// ```
@@ -480,7 +480,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a < b;
     /// let cond = LessThanI(a, b);
     /// ```
@@ -502,7 +502,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a < b;
     /// let cond = LessThanL(a, b);
     /// ```
@@ -524,7 +524,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a < b;
     /// let cond = LessThanD(a, b);
     /// ```
@@ -547,7 +547,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a <= b;
     /// let cond = LessThanOrEqualI(a, b);
     /// ```
@@ -570,7 +570,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a <= b;
     /// let cond = LessThanOrEqualL(a, b);
     /// ```
@@ -593,7 +593,7 @@ namespace Microsoft.Quantum.Logical {
     ///
     /// # Remarks
     /// The following are equivalent:
-    /// ```Q#
+    /// ```qsharp
     /// let cond = a <= b;
     /// let cond = LessThanOrEqualD(a, b);
     /// ```

--- a/Standard/src/Preparation/QuantumROM.qs
+++ b/Standard/src/Preparation/QuantumROM.qs
@@ -76,7 +76,7 @@ namespace Microsoft.Quantum.Preparation {
     /// $\rho=\sum_{j=0}^{4}\frac{|alpha_j|}{\sum_k |\alpha_k|}\ket{j}\bra{j}$, where
     /// $\vec\alpha=(1.0, 2.0, 3.0, 4.0, 5.0)$, and the target error is
     /// $10^{-3}$:
-    /// ```Q#
+    /// ```qsharp
     /// let coefficients = [1.0, 2.0, 3.0, 4.0, 5.0];
     /// let targetError = 1e-3;
     /// let purifiedState = PurifiedMixedState(targetError, coefficients);

--- a/Standard/src/Synthesis/ControlledOnTruthTable.qs
+++ b/Standard/src/Synthesis/ControlledOnTruthTable.qs
@@ -21,7 +21,7 @@ namespace Microsoft.Quantum.Synthesis {
     /// Spectral coefficients of the function
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// FastHadamardTransformed([1, 1, 1, -1]); // [2, 2, 2, -2]
     /// ```
     ///
@@ -58,7 +58,7 @@ namespace Microsoft.Quantum.Synthesis {
     /// Coefficients followed by inverted copy
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// Extended([2, 2, 2, -2]); // [2, 2, 2, -2, -2, -2, -2, 2]
     /// ```
     internal function Extended(spectrum : Int[]) : Int[] {
@@ -89,7 +89,7 @@ namespace Microsoft.Quantum.Synthesis {
     /// Truth table as array of {1,-1} integers
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// Encoded([false, false, false, true]); // [1, 1, 1, -1]
     /// ```
     internal function Encoded(table : Bool[]) : Int[] {

--- a/Standard/src/Synthesis/DecompositionBased.qs
+++ b/Standard/src/Synthesis/DecompositionBased.qs
@@ -219,7 +219,7 @@ namespace Microsoft.Quantum.Synthesis {
     ///
     /// # Example
     /// To synthesize a `SWAP` operation:
-    /// ```Q#
+    /// ```qsharp
     /// using (qubits = Qubit[2]) {
     ///   ApplyPermutationUsingDecomposition([0, 2, 1, 3], LittleEndian(qubits));
     /// }
@@ -260,7 +260,7 @@ namespace Microsoft.Quantum.Synthesis {
     ///
     /// # Example
     /// To synthesize a `SWAP` operation:
-    /// ```Q#
+    /// ```qsharp
     /// using (qubits = Qubit[2]) {
     ///   ApplyPermutationUsingDecompositionWithVariableOrder([0, 2, 1, 3], [1, 0], LittleEndian(qubits));
     /// }

--- a/Standard/src/Synthesis/TransformationBased.qs
+++ b/Standard/src/Synthesis/TransformationBased.qs
@@ -46,7 +46,7 @@ namespace Microsoft.Quantum.Synthesis {
     /// increasing order.
     ///
     /// # Example
-    /// ```Q#
+    /// ```qsharp
     /// IntegerBits(23, 5); // [0, 1, 2, 4]
     /// IntegerBits(10, 4); // [1, 3]
     /// ```
@@ -150,7 +150,7 @@ namespace Microsoft.Quantum.Synthesis {
     ///
     /// # Example
     /// To synthesize a `SWAP` operation:
-    /// ```Q#
+    /// ```qsharp
     /// using (qubits = Qubit[2]) {
     ///   ApplyPermutationUsingTransformation([0, 2, 1, 3], LittleEndian(qubits));
     /// }

--- a/Standard/src/Synthesis/Transposition.qs
+++ b/Standard/src/Synthesis/Transposition.qs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.Synthesis {
     /// # Example
     /// Prepare a uniform superposition of number states $|1\rangle$, $|2\rangle$, and
     /// $|3\rangle$ on 2 qubits.
-    /// ```Q#
+    /// ```qsharp
     /// using (qubits = Qubit[2]) {
     ///   let register = LittleEndian(qubits);
     ///   PrepareUniformSuperposition(3, register);


### PR DESCRIPTION
This PR fixes documentation comments to use ```` ```qsharp ```` instead of ```` ```Q# ````, fixing a lack of syntax highlighting reported by @guenp.