### PR TITLE
corrected invalid documentation reference in ApplyXorInPlace

### DIFF
--- a/Standard/src/Arithmetic/Arithmetic.qs
+++ b/Standard/src/Arithmetic/Arithmetic.qs
@@ -16,7 +16,7 @@ namespace Microsoft.Quantum.Arithmetic {
     /// 1 bits in an integer.
     ///
     /// Let us denote `value` by a and let y be an unsigned integer encoded in `target`,
-    /// then `InPlaceXorLE` performs an operation given by the following map:
+    /// then `ApplyXorInPlace` performs an operation given by the following map:
     /// $\ket{y}\rightarrow \ket{y\oplus a}$ , where $\oplus$ is the bitwise exclusive OR operator.
     ///
     /// # Input


### PR DESCRIPTION
It refers to the old operation `InPlaceXorLE` which it deprecates.