### PR TITLE
Add Factorial function within the standard math library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,4 @@ __pycache__/
 *.odx.cs
 *.xsd.cs
 
+/ionqSandbox

--- a/Standard.sln
+++ b/Standard.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2024
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30804.86
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{561759D2-4D2D-4EE3-9565-9AAEC4A7D64B}"
 	ProjectSection(SolutionItems) = preProject
@@ -14,7 +14,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Standard.Tests", "Standard\
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Visualization", "Visualization", "{2C5BF171-7D32-4DEC-BD08-9667A55A36FF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Visualization", "Visualization\src\Visualization.csproj", "{AC5462CC-F249-48E4-BFBE-93FC5AAC0D4E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Visualization", "Visualization\src\Visualization.csproj", "{AC5462CC-F249-48E4-BFBE-93FC5AAC0D4E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ionqSandbox", "ionqSandbox\ionqSandbox.csproj", "{46396916-A107-412D-90EB-E679AD65C553}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -34,9 +36,16 @@ Global
 		{AC5462CC-F249-48E4-BFBE-93FC5AAC0D4E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AC5462CC-F249-48E4-BFBE-93FC5AAC0D4E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AC5462CC-F249-48E4-BFBE-93FC5AAC0D4E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{46396916-A107-412D-90EB-E679AD65C553}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{46396916-A107-412D-90EB-E679AD65C553}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{46396916-A107-412D-90EB-E679AD65C553}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{46396916-A107-412D-90EB-E679AD65C553}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{AC5462CC-F249-48E4-BFBE-93FC5AAC0D4E} = {2C5BF171-7D32-4DEC-BD08-9667A55A36FF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6869E5BF-551A-40F1-9B6B-D1B27A5676CB}
@@ -46,8 +55,5 @@ Global
 	EndGlobalSection
 	GlobalSection(Performance) = preSolution
 		HasPerformanceSessions = true
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{AC5462CC-F249-48E4-BFBE-93FC5AAC0D4E} = {2C5BF171-7D32-4DEC-BD08-9667A55A36FF}
 	EndGlobalSection
 EndGlobal

--- a/Standard/src/Math/Functions.qs
+++ b/Standard/src/Math/Functions.qs
@@ -693,6 +693,38 @@ namespace Microsoft.Quantum.Math {
        return x;
     }
 
+    /// # Summary
+    /// Returns a factorial as a BigInt.
+    ///
+    /// # Description
+    /// Returns the factorial as Big Integer, given an input of $n$ as an Integer.
+    ///
+    /// # Input
+    /// ## $n$
+    /// A whole number of any size, positive or negative.
+    ///
+    /// # Output
+    /// The factorial of the provided input with the type BigInt.
+    function FactorialB (n : Int) : BigInt
+    {
+        mutable an = 1;
+        mutable x = IntAsBigInt(1);
+        if (n < 0 ){
+            set an = AbsI(n);
+            set x = IntAsBigInt(-1);
+        }
+        elif(n == 0){
+            return x;
+        }
+        else{
+            set an = n;
+        }
+        for i in  1 .. an {
+            set x = x * IntAsBigInt(i);
+        }
+       return x;
+    }
+
 }
 
 

--- a/Standard/src/Math/Functions.qs
+++ b/Standard/src/Math/Functions.qs
@@ -657,6 +657,42 @@ namespace Microsoft.Quantum.Math {
         }
     }
 
+    /// # Summary
+    /// Returns a factorial as an int.
+    ///
+    /// # Description
+    /// Returns the factorial as Integer, given an input of $n$ as an Integer.
+    /// Maximum input is |20| to return as Int. For inputs greater than 20, use FactorialB(n).
+    ///
+    /// # Input
+    /// ## $n$
+    /// An Int between -20, 20.
+    ///
+    /// # Output
+    /// The factorial of the provided input with the datatype Int.
+    function FactorialI (n : Int) : Int
+    {
+        mutable an = 1;
+        mutable x = 1;
+        if (n < 0 ){
+            set an = AbsI(n);
+            set x = -1;
+        }
+        elif(n == 0){
+            return x;
+        }
+        elif(n >= 21){
+            fail "Largest factorial an Int can hold is |20|. Use Factorial BigInt.  \n \n >FactorialB(n) .";
+        }
+        else{
+            set an = n;
+        }
+        for i in  1 .. an {
+            set x = x * i;
+        }
+       return x;
+    }
+
 }
 
 


### PR DESCRIPTION
**Issue**
The standard math library does not have a function for Factorials.

**Discussion**
Factorials are commonly used functions in math and science packages, Q# did not have a factorial function previously.

**Recommendation**
I created a Factorial Function which returns an Int type. 
I recommend to merge as this function does not impede with other functionalities.


P.S. I'm also working on a function which returns a BigInt.