### PR TITLE
Fix #454.

### DIFF
--- a/MachineLearning/src/Classification.qs
+++ b/MachineLearning/src/Classification.qs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.Quantum.MachineLearning {
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Characterization;
@@ -7,8 +10,7 @@ namespace Microsoft.Quantum.MachineLearning {
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Convert;
 
-
-    operation _PrepareClassification(
+    internal operation _PrepareClassification(
         encoder : (LittleEndian => Unit is Adj + Ctl),
         model : SequentialModel,
         target : Qubit[]

--- a/MachineLearning/src/GradientEstimation.qs
+++ b/MachineLearning/src/GradientEstimation.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.MachineLearning {
@@ -13,11 +13,11 @@ namespace Microsoft.Quantum.MachineLearning {
     open Microsoft.Quantum.Characterization;
 
     // NOTE: the last qubit of 'reg' in this context is the auxiliary qubit used in the Hadamard test.
-    operation _ApplyLEOperationToRawRegister(op : (LittleEndian => Unit is Adj), target : Qubit[]) : Unit is Adj {
+    internal operation _ApplyLEOperationToRawRegister(op : (LittleEndian => Unit is Adj), target : Qubit[]) : Unit is Adj {
         op(LittleEndian(target));
     }
 
-    operation _EstimateDerivativeWithParameterShift(
+    internal operation _EstimateDerivativeWithParameterShift(
         inputEncoder : StateGenerator,
         model : SequentialModel,
         parameters : (Double[], Double[]),

--- a/MachineLearning/src/InputEncoding.qs
+++ b/MachineLearning/src/InputEncoding.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.MachineLearning {
@@ -10,11 +10,11 @@ namespace Microsoft.Quantum.MachineLearning {
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Canon;
 
-    function _CanApplyTwoQubitCase(datum: Double[]) : Bool {
+    internal function _CanApplyTwoQubitCase(datum: Double[]) : Bool {
         return((Length(datum)==4) and (Microsoft.Quantum.Math.AbsD(datum[0]*datum[3]-datum[1]*datum[2])< 1E-12) and (Microsoft.Quantum.Math.AbsD(datum[0])> 1E-4));
     }
 
-    operation _ApplyTwoQubitCase(datum: Double[], reg: LittleEndian) : Unit is Adj + Ctl {
+    internal operation _ApplyTwoQubitCase(datum: Double[], reg: LittleEndian) : Unit is Adj + Ctl {
         let x = datum[1]/datum[0];
         let y = datum[2]/datum[0];
         // we now encoding [1,x,y,x*y]
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.MachineLearning {
         R(PauliY, ax, (reg!)[0]);
     }
 
-    function _Unnegate(negLocs: Int[], coefficients : ComplexPolar[]) : ComplexPolar[] {
+    internal function _Unnegate(negLocs: Int[], coefficients : ComplexPolar[]) : ComplexPolar[] {
         mutable ret = coefficients;
         for idxNegative in negLocs {
             if idxNegative >= Length(coefficients) {
@@ -36,7 +36,7 @@ namespace Microsoft.Quantum.MachineLearning {
         return ret;
     }
 
-    function _NegativeLocations(cNegative: Int, coefficients : ComplexPolar[]) : Int[] {
+    internal function _NegativeLocations(cNegative: Int, coefficients : ComplexPolar[]) : Int[] {
         mutable negLocs = new Int[0];
         for (idx, coefficient) in Enumerated(coefficients) {
             if (AbsD(coefficient::Argument - PI()) < 1E-9) {
@@ -47,7 +47,7 @@ namespace Microsoft.Quantum.MachineLearning {
     }
 
     /// Do special processing on the first cNegative entries
-    operation _ReflectAboutNegativeCoefficients(
+    internal operation _ReflectAboutNegativeCoefficients(
         negLocs : Int[],
         coefficients : ComplexPolar[],
         reg: LittleEndian

--- a/MachineLearning/src/Private.qs
+++ b/MachineLearning/src/Private.qs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.Quantum.MachineLearning {
     open Microsoft.Quantum.Logical;
     open Microsoft.Quantum.Arrays;
@@ -5,11 +8,11 @@ namespace Microsoft.Quantum.MachineLearning {
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Math;
 
-    function _AllNearlyEqualD(v1 : Double[], v2 : Double[]) : Bool {
+    internal function _AllNearlyEqualD(v1 : Double[], v2 : Double[]) : Bool {
         return Length(v1) == Length(v2) and All(NearlyEqualD, Zipped(v1, v2));
     }
 
-    function _TailMeasurement(nQubits : Int) : (Qubit[] => Result) {
+    internal function _TailMeasurement(nQubits : Int) : (Qubit[] => Result) {
         let paulis = ConstantArray(nQubits, PauliI) w/ (nQubits - 1) <- PauliZ;
         return Measure(paulis, _);
     }

--- a/MachineLearning/src/Training.qs
+++ b/MachineLearning/src/Training.qs
@@ -11,14 +11,14 @@ namespace Microsoft.Quantum.MachineLearning {
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Optimization;
 
-    function _MisclassificationRate(probabilities : Double[], labels : Int[], bias : Double) : Double {
+    internal function _MisclassificationRate(probabilities : Double[], labels : Int[], bias : Double) : Double {
         let proposedLabels = InferredLabels(bias, probabilities);
         return IntAsDouble(NMisclassifications(proposedLabels, labels)) / IntAsDouble(Length(probabilities));
     }
 
     /// # Summary
     /// Returns a bias value that leads to near-minimum misclassification score.
-    function _UpdatedBias(labeledProbabilities: (Double, Int)[], bias: Double, tolerance: Double) : Double {
+    internal function _UpdatedBias(labeledProbabilities: (Double, Int)[], bias: Double, tolerance: Double) : Double {
         mutable (min1, max0) = (1.0, 0.0);
 
         // Find the range of classification probabilities for each class.
@@ -122,7 +122,7 @@ namespace Microsoft.Quantum.MachineLearning {
     ///
     /// # Output
     /// (utility, (new)parameters) pair
-    operation _RunSingleTrainingStep(
+    internal operation _RunSingleTrainingStep(
         miniBatch : (LabeledSample, StateGenerator)[],
         options : TrainingOptions,
         model : SequentialModel
@@ -179,7 +179,7 @@ namespace Microsoft.Quantum.MachineLearning {
     /// - The smallest number of misclassifications observed through to this
     ///   epoch.
     /// - The new best sequential model found.
-    operation _RunSingleTrainingEpoch(
+    internal operation _RunSingleTrainingEpoch(
         encodedSamples : (LabeledSample, StateGenerator)[],
         schedule : SamplingSchedule, periodScore: Int,
         options : TrainingOptions,
@@ -246,13 +246,13 @@ namespace Microsoft.Quantum.MachineLearning {
 
     /// # Summary
     /// Randomly rescales an input to either grow or shrink by a given factor.
-    operation _RandomlyRescale(scale : Double, value : Double) : Double {
+    internal operation _RandomlyRescale(scale : Double, value : Double) : Double {
         return value * (
             1.0 + scale * (DrawRandomBool(0.5) ? 1.0 | -1.0)
         );
     }
 
-    function _EncodeSample(effectiveTolerance : Double, nQubits : Int, sample : LabeledSample)
+    internal function _EncodeSample(effectiveTolerance : Double, nQubits : Int, sample : LabeledSample)
     : (LabeledSample, StateGenerator) {
         return (
             sample,
@@ -327,7 +327,7 @@ namespace Microsoft.Quantum.MachineLearning {
     // Private operation used for the bulk of the implementation of
     // TrainSequentialClassifierAtModel, omitting the updating of the final
     // bias.
-    operation _TrainSequentialClassifierAtModel(
+    internal operation _TrainSequentialClassifierAtModel(
         model : SequentialModel,
         samples : LabeledSample[],
         options : TrainingOptions,

--- a/MachineLearning/src/Types.qs
+++ b/MachineLearning/src/Types.qs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.MachineLearning {

--- a/MachineLearning/src/Validation.qs
+++ b/MachineLearning/src/Validation.qs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 namespace Microsoft.Quantum.MachineLearning {
     open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Intrinsic;


### PR DESCRIPTION
This PR fixes #454 by marking as `internal` a few internal-only functions and operations that did not correctly have that modifier keyword.