### PR TITLE
ApplyIf gets consistent with ApplyIfElse

### DIFF
--- a/Standard/src/Canon/Combinators/ApplyIf.qs
+++ b/Standard/src/Canon/Combinators/ApplyIf.qs
@@ -7,14 +7,14 @@ namespace Microsoft.Quantum.Canon {
     /// Applies an operation conditioned on a classical bit.
     ///
     /// # Description
-    /// Given an operation `op` and a bit value `bit`, applies `op` to the `target`
+    /// Given a bit value `bit` and an operation `op`, applies `op` to the `target`
     /// if `bit` is `true`. If `false`, nothing happens to the `target`.
     ///
     /// # Input
-    /// ## op
-    /// An operation to be conditionally applied.
     /// ## bit
     /// a boolean that controls whether op is applied or not.
+    /// ## op
+    /// An operation to be conditionally applied.
     /// ## target
     /// The input to which the operation is applied.
     ///
@@ -34,12 +34,12 @@ namespace Microsoft.Quantum.Canon {
     /// ```qsharp
     /// let bitstring = [true, false, true];
     /// using (register = Qubit(3)) {
-    ///     ApplyToEach(ApplyIf(X, _, _), Zipped(bitstring, register));
+    ///     ApplyToEach(ApplyIf(_, X, _), Zipped(bitstring, register));
     ///     // register should now be in the state |101⟩.
     ///     ...
     /// }
     /// ```
-    operation ApplyIf<'T> (op : ('T => Unit), bit : Bool, target : 'T) : Unit {
+    operation ApplyIf<'T> (bit : Bool, op : ('T => Unit), target : 'T) : Unit {
         if (bit) {
             op(target);
         }
@@ -49,15 +49,15 @@ namespace Microsoft.Quantum.Canon {
     /// Applies a controllable operation conditioned on a classical bit.
     ///
     /// # Description
-    /// Given an operation `op` and a bit value `bit`, applies `op` to the `target`
+    /// Given a bit value `bit` and an operation `op`, applies `op` to the `target`
     /// if `bit` is `true`. If `false`, nothing happens to the `target`.
     /// The suffix `C` indicates that the operation to be applied is controllable.
     ///
     /// # Input
-    /// ## op
-    /// An operation to be conditionally applied.
     /// ## bit
     /// a boolean that controls whether op is applied or not.
+    /// ## op
+    /// An operation to be conditionally applied.
     /// ## target
     /// The input to which the operation is applied.
     ///
@@ -77,12 +77,12 @@ namespace Microsoft.Quantum.Canon {
     /// ```qsharp
     /// let bitstring = [true, false, true];
     /// using (register = Qubit(3)) {
-    ///     ApplyToEach(ApplyIf(X, _, _), Zipped(bitstring, register));
+    ///     ApplyToEach(ApplyIf(_, X, _), Zipped(bitstring, register));
     ///     // register should now be in the state |101⟩.
     ///     ...
     /// }
     /// ```
-    operation ApplyIfC<'T> (op : ('T => Unit is Ctl), bit : Bool, target : 'T) : Unit is Ctl {
+    operation ApplyIfC<'T> (bit : Bool, op : ('T => Unit is Ctl), target : 'T) : Unit is Ctl {
         if (bit) {
             op(target);
         }
@@ -92,15 +92,15 @@ namespace Microsoft.Quantum.Canon {
     /// Applies a adjointable operation conditioned on a classical bit.
     ///
     /// # Description
-    /// Given an operation `op` and a bit value `bit`, applies `op` to the `target`
+    /// Given a bit value `bit` and an operation `op`, applies `op` to the `target`
     /// if `bit` is `true`. If `false`, nothing happens to the `target`.
     /// The suffix `A` indicates that the operation to be applied is adjointable.
     ///
     /// # Input
-    /// ## op
-    /// An operation to be conditionally applied.
     /// ## bit
     /// a boolean that controls whether op is applied or not.
+    /// ## op
+    /// An operation to be conditionally applied.
     /// ## target
     /// The input to which the operation is applied.
     ///
@@ -120,12 +120,12 @@ namespace Microsoft.Quantum.Canon {
     /// ```qsharp
     /// let bitstring = [true, false, true];
     /// using (register = Qubit(3)) {
-    ///     ApplyToEach(ApplyIf(X, _, _), Zipped(bitstring, register));
+    ///     ApplyToEach(ApplyIf(_, X, _), Zipped(bitstring, register));
     ///     // register should now be in the state |101⟩.
     ///     ...
     /// }
     /// ```
-    operation ApplyIfA<'T> (op : ('T => Unit is Adj), bit : Bool, target : 'T) : Unit is Adj {
+    operation ApplyIfA<'T> (bit : Bool, op : ('T => Unit is Adj), target : 'T) : Unit is Adj {
         if (bit) {
             op(target);
         }
@@ -135,16 +135,16 @@ namespace Microsoft.Quantum.Canon {
     /// Applies a unitary operation conditioned on a classical bit.
     ///
     /// # Description
-    /// Given an operation `op` and a bit value `bit`, applies `op` to the `target`
+    /// Given a bit value `bit` and an operation `op`, applies `op` to the `target`
     /// if `bit` is `true`. If `false`, nothing happens to the `target`.
     /// The suffix `CA` indicates that the operation to be applied is unitary
     /// (controllable and adjointable).
     ///
     /// # Input
-    /// ## op
-    /// An operation to be conditionally applied.
     /// ## bit
     /// a boolean that controls whether op is applied or not.
+    /// ## op
+    /// An operation to be conditionally applied.
     /// ## target
     /// The input to which the operation is applied.
     ///
@@ -164,12 +164,12 @@ namespace Microsoft.Quantum.Canon {
     /// ```qsharp
     /// let bitstring = [true, false, true];
     /// using (register = Qubit(3)) {
-    ///     ApplyToEach(ApplyIf(X, _, _), Zipped(bitstring, register));
+    ///     ApplyToEach(ApplyIf(_, X, _), Zipped(bitstring, register));
     ///     // register should now be in the state |101⟩.
     ///     ...
     /// }
     /// ```
-    operation ApplyIfCA<'T> (op : ('T => Unit is Ctl + Adj), bit : Bool, target : 'T) : Unit is Ctl + Adj {
+    operation ApplyIfCA<'T> (bit : Bool, op : ('T => Unit is Ctl + Adj), target : 'T) : Unit is Ctl + Adj {
         if (bit) {
             op(target);
         }

--- a/Standard/src/Canon/Combinators/CControlled.qs
+++ b/Standard/src/Canon/Combinators/CControlled.qs
@@ -23,7 +23,7 @@ namespace Microsoft.Quantum.Canon {
     /// - Microsoft.Quantum.Canon.CControlledA
     /// - Microsoft.Quantum.Canon.CControlledCA
     function CControlled<'T> (op : ('T => Unit)) : ((Bool, 'T) => Unit) {
-        return ApplyIf(op, _, _);
+        return ApplyIf(_, op, _);
     }
 
 
@@ -46,7 +46,7 @@ namespace Microsoft.Quantum.Canon {
     /// # See Also
     /// - Microsoft.Quantum.Canon.CControlled
     function CControlledC<'T> (op : ('T => Unit is Ctl)) : ((Bool, 'T) => Unit is Ctl) {
-        return ApplyIfC(op, _, _);
+        return ApplyIfC(_, op, _);
     }
 
 
@@ -69,7 +69,7 @@ namespace Microsoft.Quantum.Canon {
     /// # See Also
     /// - Microsoft.Quantum.Canon.CControlled
     function CControlledA<'T> (op : ('T => Unit is Adj)) : ((Bool, 'T) => Unit is Adj) {
-        return ApplyIfA(op, _, _);
+        return ApplyIfA(_, op, _);
     }
 
 
@@ -92,7 +92,7 @@ namespace Microsoft.Quantum.Canon {
     /// # See Also
     /// - Microsoft.Quantum.Canon.CControlled
     function CControlledCA<'T> (op : ('T => Unit is Ctl + Adj)) : ((Bool, 'T) => Unit is Ctl + Adj) {
-        return ApplyIfCA(op, _, _);
+        return ApplyIfCA(_, op, _);
     }
 
 }

--- a/Standard/tests/Synthesis.qs
+++ b/Standard/tests/Synthesis.qs
@@ -104,7 +104,7 @@ namespace Microsoft.Quantum.Tests {
                 use target = Qubit();
                 for i in 0..(2^numQubits - 1) {
                     let targetInit = RandomBool();
-                    ApplyIf(X, targetInit, target);
+                    ApplyIf(targetInit, X, target);
                     within {
                         ApplyXorInPlace(i, LittleEndian(controls));
                     } apply {
@@ -133,9 +133,9 @@ namespace Microsoft.Quantum.Tests {
                 for i in 0..(2^numQubits - 1) {
                     let controlInit = RandomBool();
                     let targetInit = RandomBool();
-                    ApplyIf(X, targetInit, target);
+                    ApplyIf(targetInit, X, target);
                     within {
-                        ApplyIfA(X, controlInit, control);
+                        ApplyIfA(controlInit, X, control);
                         ApplyXorInPlace(i, LittleEndian(controls));
                     } apply {
                         Controlled ApplyXControlledOnTruthTable([control], (func, controls, target));


### PR DESCRIPTION
Fixes #377.

This introduces a breaking change, since existing operations change the order of arguments.