### PR TITLE
Fix broken links to API docs

### DIFF
--- a/Standard/src/AmplitudeAmplification/AmplitudeAmplification.qs
+++ b/Standard/src/AmplitudeAmplification/AmplitudeAmplification.qs
@@ -149,7 +149,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     /// ## phases
     /// A set of phases describing the partial reflections at each step of the
     /// amplitude amplification algorithm. See
-    /// @"microsoft.quantum.amplitudeamplification.standardreflectionphases"
+    /// @"Microsoft.Quantum.AmplitudeAmplification.StandardReflectionPhases"
     /// for an example.
     /// ## startStateReflection
     /// An oracle that reflects about the initial state.

--- a/Standard/src/AmplitudeAmplification/Deprecated.qs
+++ b/Standard/src/AmplitudeAmplification/Deprecated.qs
@@ -7,7 +7,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
 
     /// # Deprecated
     /// Please use
-    /// @"microsoft.quantum.amplitudeamplification.rotationphasesasreflectionphases".
+    /// @"Microsoft.Quantum.AmplitudeAmplification.RotationPhasesAsReflectionPhases".
     @Deprecated("Microsoft.Quantum.AmplitudeAmplification.RotationPhasesAsReflectionPhases")
     function AmpAmpRotationToReflectionPhases (rotPhases : RotationPhases)
     : ReflectionPhases {
@@ -16,7 +16,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
 
     /// # Deprecated
     /// Please use
-    /// @"microsoft.quantum.amplitudeamplification.standardreflectionphases".
+    /// @"Microsoft.Quantum.AmplitudeAmplification.StandardReflectionPhases".
     @Deprecated("Microsoft.Quantum.AmplitudeAmplification.StandardReflectionPhases")
     function AmpAmpPhasesStandard(nIterations : Int) : ReflectionPhases {
         return StandardReflectionPhases(nIterations);
@@ -24,14 +24,14 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
 
     /// # Deprecated
     /// Please use
-    /// @"microsoft.quantum.amplitudeamplification.fixedpointreflectionphases".
+    /// @"Microsoft.Quantum.AmplitudeAmplification.FixedPointReflectionPhases".
     @Deprecated("Microsoft.Quantum.AmplitudeAmplification.FixedPointReflectionPhases")
     function AmpAmpPhasesFixedPoint(nQueries : Int, successMin : Double) : ReflectionPhases {
         return FixedPointReflectionPhases(nQueries, successMin);
     }
 
     /// # Deprecated
-    /// Please use @"microsoft.quantum.amplitudeamplification.obliviousamplitudeamplificationfrompartialreflections".
+    /// Please use @"Microsoft.Quantum.AmplitudeAmplification.ObliviousAmplitudeAmplificationFromPartialReflections".
     @Deprecated("Microsoft.Quantum.AmplitudeAmplification.ObliviousAmplitudeAmplificationFromPartialReflections")
     function AmpAmpObliviousByReflectionPhases(
         phases : ReflectionPhases,
@@ -46,7 +46,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     }
 
     /// # Deprecated
-    /// Please use @"microsoft.quantum.amplitudeamplification.obliviousamplitudeamplificationfromstatepreparation".
+    /// Please use @"Microsoft.Quantum.AmplitudeAmplification.ObliviousAmplitudeAmplificationFromStatePreparation".
     @Deprecated("Microsoft.Quantum.AmplitudeAmplification.ObliviousAmplitudeAmplificationFromStatePreparation")
     function AmpAmpObliviousByOraclePhases(
         phases : ReflectionPhases,
@@ -61,7 +61,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     }
 
     /// # Deprecated
-    /// Please use @"microsoft.quantum.amplitudeamplification.amplitudeamplificationfrompartialreflections".
+    /// Please use @"Microsoft.Quantum.AmplitudeAmplification.AmplitudeAmplificationFromPartialReflections".
     @Deprecated("Microsoft.Quantum.AmplitudeAmplification.AmplitudeAmplificationFromPartialReflections")
     function AmpAmpByReflectionPhases(
         phases : ReflectionPhases,
@@ -75,7 +75,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     }
 
     /// # Deprecated
-    /// Please use @"microsoft.quantum.amplitudeamplification.amplitudeamplificationfromstatepreparation".
+    /// Please use @"Microsoft.Quantum.AmplitudeAmplification.AmplitudeAmplificationFromStatePreparation".
     @Deprecated("Microsoft.Quantum.AmplitudeAmplification.AmplitudeAmplificationFromStatePreparation")
     function AmpAmpByOraclePhases(
         phases : ReflectionPhases,
@@ -89,7 +89,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     }
 
     /// # Deprecated
-    /// Please use @"microsoft.quantum.amplitudeamplification.standardamplitudeamplification".
+    /// Please use @"Microsoft.Quantum.AmplitudeAmplification.StandardAmplitudeAmplification".
     @Deprecated("Microsoft.Quantum.AmplitudeAmplification.StandardAmplitudeAmplification")
     function AmpAmpByOracle(
         nIterations : Int,
@@ -102,7 +102,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
 
 
     /// # Deprecated
-    /// Please use @"microsoft.quantum.amplitudeamplification.applyfixedpointamplification".
+    /// Please use @"Microsoft.Quantum.AmplitudeAmplification.ApplyFixedPointAmplification".
     @Deprecated("Microsoft.Quantum.AmplitudeAmplification.ApplyFixedPointAmplification")
     operation AmpAmpRUSByOracle(statePrepOracle : StateOracle, startQubits : Qubit[])
     : Unit {

--- a/Standard/src/Arithmetic/Deprecated.qs
+++ b/Standard/src/Arithmetic/Deprecated.qs
@@ -146,14 +146,14 @@ namespace Microsoft.Quantum.Canon {
     }
 
     /// # Deprecated
-    /// Please use @"microsoft.quantum.canon.applycnotchain".
+    /// Please use @"Microsoft.Quantum.Canon.ApplyCNOTChain".
     @Deprecated("Microsoft.Quantum.Canon.ApplyCNOTChain")
     operation CascadeCNOT (register : Qubit[]) : Unit is Adj + Ctl {
         Microsoft.Quantum.Canon.ApplyCNOTChain(register);
     }
 
     /// # Deprecated
-    /// Please use @"microsoft.quantum.arithmetic.applymajorityinplace".
+    /// Please use @"Microsoft.Quantum.Arithmetic.ApplyMajorityInPlace".
     @Deprecated("Microsoft.Quantum.Arithmetic.ApplyMajorityInPlace")
     operation InPlaceMajority(output: Qubit, input: Qubit[])
     : Unit is Adj + Ctl {

--- a/Standard/src/Arrays/Filter.qs
+++ b/Standard/src/Arrays/Filter.qs
@@ -28,7 +28,7 @@ namespace Microsoft.Quantum.Arrays {
     ///
     /// # Example
     /// The following code demonstrates the "Filtered" function.
-    /// A predicate is defined using the @"microsoft.quantum.logical.greaterthani" function:
+    /// A predicate is defined using the @"Microsoft.Quantum.Logical.GreaterThanI" function:
     /// ```qsharp
     /// open Microsoft.Quantum.Arrays;
     /// open Microsoft.Quantum.Logical;
@@ -104,7 +104,7 @@ namespace Microsoft.Quantum.Arrays {
     ///
     /// # Example
     /// The following code demonstrates the "Count" function.
-    /// A predicate is defined using the @"microsoft.quantum.logical.greaterthani" function:
+    /// A predicate is defined using the @"Microsoft.Quantum.Logical.GreaterThanI" function:
     /// ```qsharp
     ///  let predicate = GreaterThanI(_, 5);
     ///  let count = Count(predicate, [2, 5, 9, 1, 8]);

--- a/Standard/src/Canon/Deprecated.qs
+++ b/Standard/src/Canon/Deprecated.qs
@@ -6,7 +6,7 @@ namespace Microsoft.Quantum.Canon {
     open Microsoft.Quantum.Logical;
 
     /// # Deprecated
-    /// Please use @"microsoft.quantum.logical.xor".
+    /// Please use @"Microsoft.Quantum.Logical.Xor".
     @Deprecated("Microsoft.Quantum.Logical.Xor")
     function XOR(bit1 : Bool, bit2 : Bool) : Bool {
         return Xor(bit1, bit2);

--- a/Standard/src/Characterization/Deprecated.qs
+++ b/Standard/src/Characterization/Deprecated.qs
@@ -7,7 +7,7 @@ namespace Microsoft.Quantum.Characterization {
     open Microsoft.Quantum.Arrays;
 
     /// # Deprecated
-    /// Please use @"microsoft.quantum.measurement.measureAllZ".
+    /// Please use @"Microsoft.Quantum.Measurement.MeasureAllZ".
     @Deprecated("Microsoft.Quantum.Measurement.MeasureAllZ")
     operation MeasureAllZ(register : Qubit[]) : Result {
         return Measure(ConstantArray(Length(register), PauliZ), register);

--- a/Standard/src/Preparation/QuantumROM.qs
+++ b/Standard/src/Preparation/QuantumROM.qs
@@ -32,20 +32,20 @@ namespace Microsoft.Quantum.Preparation {
     /// of the mixed state
     /// $$
     /// \begin{align}
-    ///     \rho = \sum_{j = 0}^{N-1}\ frac{|alpha_j|}{\sum_k |\alpha_k|} \ket{j}\bra{j},
+    ///     \rho = \sum_{j = 0}^{N-1} \frac{|alpha_j|}{\sum_k |\alpha_k|} \ket{j}\bra{j},
     /// \end{align}
     /// $$
     /// where each $p_j$ is an approximation to the given coefficient $\alpha_j$
     /// such that
     /// $$
     /// \begin{align}
-    ///     \left| p_j - \frac{ |\alpha_j| }{ \sum_k |\alpha_k| } \le \frac{\epsilon}{N}
+    ///     \left| p_j - \frac{ |\alpha_j| }{ \sum_k |\alpha_k| } \right| \le \frac{\epsilon}{N}
     /// \end{align}
     /// $$
     /// for each $j$.
     ///
     /// When passed an index register and a register of garbage qubits,
-    /// initially in the state $\ket{0} \ket{00\cdots 0}, the returned operation
+    /// initially in the state $\ket{0} \ket{00\cdots 0}$, the returned operation
     /// prepares both registers into the purification of $\tilde \rho$,
     /// $$
     /// \begin{align}
@@ -142,13 +142,13 @@ namespace Microsoft.Quantum.Preparation {
     /// such that
     /// $$
     /// \begin{align}
-    ///     \left| p_j - \frac{ |\alpha_j| }{ \sum_k |\alpha_k| } \le \frac{\epsilon}{N}
+    ///     \left| p_j - \frac{ |\alpha_j| }{ \sum_k |\alpha_k| } \right| \le \frac{\epsilon}{N}
     /// \end{align}
     /// $$
     /// for each $j$.
     ///
     /// When passed an index register and a register of garbage qubits,
-    /// initially in the state $\ket{0} \ket{00\cdots 0}, the returned operation
+    /// initially in the state $\ket{0} \ket{00\cdots 0}$, the returned operation
     /// prepares both registers into the purification of $\tilde \rho$,
     /// $$
     /// \begin{align}
@@ -198,7 +198,7 @@ namespace Microsoft.Quantum.Preparation {
     /// # Summary
     /// Returns the total number of qubits that must be allocated
     /// in order to apply the operation returned by
-    /// @"microsoft.quantum.preparation.purifiedmixedstate".
+    /// @"Microsoft.Quantum.Preparation.PurifiedMixedState".
     ///
     /// # Input
     /// ## targetError
@@ -209,7 +209,7 @@ namespace Microsoft.Quantum.Preparation {
     /// # Output
     /// A description of how many qubits are required in total, and for each of
     /// the index and garbage registers used by the
-    /// @"microsoft.quantum.preparation.purifiedmixedstate" function.
+    /// @"Microsoft.Quantum.Preparation.PurifiedMixedState" function.
     ///
     /// # See Also
     /// - Microsoft.Quantum.Preparation.PurifiedMixedState

--- a/Standard/src/Synthesis/ControlledOnTruthTable.qs
+++ b/Standard/src/Synthesis/ControlledOnTruthTable.qs
@@ -123,7 +123,7 @@ namespace Microsoft.Quantum.Synthesis {
     }
 
     /// # Summary
-    /// Applies the @"microsoft.quantum.intrinsic.x" operation on `target`, if the Boolean function `func` evaluates
+    /// Applies the @"Microsoft.Quantum.Intrinsic.X" operation on `target`, if the Boolean function `func` evaluates
     /// to true for the classical assignment in `controlRegister`.
     ///
     /// # Description
@@ -141,8 +141,8 @@ namespace Microsoft.Quantum.Synthesis {
     /// in decimal notation.  The `L` suffix indicates that the constant is of type `BigInt`.
     /// More details on this representation can also be found in the [truth tables kata](https://github.com/microsoft/QuantumKatas/tree/main/TruthTables).
     ///
-    /// The implementation makes use of @"microsoft.quantum.intrinsic.cnot"
-    /// and @"microsoft.quantum.intrinsic.r1" gates.
+    /// The implementation makes use of @"Microsoft.Quantum.Intrinsic.Cnot"
+    /// and @"Microsoft.Quantum.Intrinsic.R1" gates.
     ///
     /// # Input
     /// ## func
@@ -198,15 +198,15 @@ namespace Microsoft.Quantum.Synthesis {
     }
 
     /// # Summary
-    /// Applies the @"microsoft.quantum.intrinsic.x" operation on `target`, if the Boolean function `func` evaluates
+    /// Applies the @"Microsoft.Quantum.Intrinsic.X" operation on `target`, if the Boolean function `func` evaluates
     /// to true for the classical assignment in `controlRegister`.
     ///
     /// # Description
-    /// This operation implements a special case of @"microsoft.quantum.synthesis.applyxcontrolledontruthtable",
+    /// This operation implements a special case of @"Microsoft.Quantum.Synthesis.ApplyXControlledOnTruthTable",
     /// in which the target qubit is known to be in the $\ket{0}$ state.
     ///
-    /// The implementation makes use of @"microsoft.quantum.intrinsic.cnot"
-    /// and @"microsoft.quantum.intrinsic.r1" gates.  The implementation of the
+    /// The implementation makes use of @"Microsoft.Quantum.Intrinsic.Cnot"
+    /// and @"Microsoft.Quantum.Intrinsic.R1" gates.  The implementation of the
     /// adjoint operation is optimized and uses measurement-based uncomputation.
     ///
     /// # Input

--- a/Standard/src/Synthesis/DecompositionBased.qs
+++ b/Standard/src/Synthesis/DecompositionBased.qs
@@ -205,11 +205,11 @@ namespace Microsoft.Quantum.Synthesis {
     ///
     /// After applying these steps for all variable indexes, the remaining
     /// permutation $\pi$ will be the identity, and based on the collected truth
-    /// tables and indexes, one can apply truth-table controlled @"microsoft.quantum.intrinsic.x"
-    /// operations using the @"microsoft.quantum.synthesis.applyxcontrolledontruthtable" operation.
+    /// tables and indexes, one can apply truth-table controlled @"Microsoft.Quantum.Intrinsic.X"
+    /// operations using the @"Microsoft.Quantum.Synthesis.ApplyXControlledOnTruthTable" operation.
     ///
     /// The variable order is $0, \dots, n - 1$.  A custom variable order can be specified
-    /// in the operation @"microsoft.quantum.synthesis.applypermutationusingdecompositionwithvariableorder".
+    /// in the operation @"Microsoft.Quantum.Synthesis.ApplyPermutationUsingDecompositionWithVariableOrder".
     ///
     /// # Input
     /// ## perm
@@ -243,10 +243,10 @@ namespace Microsoft.Quantum.Synthesis {
     /// using decomposition-based synthesis.
     ///
     /// # Description
-    /// This operation is a more general version of @"microsoft.quantum.synthesis.applypermutationusingdecomposition"
+    /// This operation is a more general version of @"Microsoft.Quantum.Synthesis.ApplyPermutationUsingDecomposition"
     /// in which the variable order can be specified. A different variable order
     /// changes the decomposition sequence and the truth tables used for the
-    /// controlled @"microsoft.quantum.intrinsic.x" gates.  Therefore, changing the
+    /// controlled @"Microsoft.Quantum.Intrinsic.X" gates.  Therefore, changing the
     /// variable order changes the number of overall gates used to realize the
     /// permutation.
     ///


### PR DESCRIPTION
@"" style of links doesn't seem to work if the reference is in lowercase.
Includes fixing broken formulas in PurifiedMixedState.