### PR TITLE
Change syntax with respect to grammar

### DIFF
--- a/Standard/src/Canon/Multiplexer.qs
+++ b/Standard/src/Canon/Multiplexer.qs
@@ -105,7 +105,7 @@ namespace Microsoft.Quantum.Canon {
             }
         }
         adjoint auto;
-        controlled (controlRegister, (...)) {
+        controlled (controlRegister, ...) {
             MultiplexOperationsFromGeneratorImpl(unitaryGenerator, auxiliary + controlRegister, index, target);
         }
         adjoint controlled auto;


### PR DESCRIPTION
The syntax for the `controlled` specialization is not consistent with the [grammar specification](https://github.com/microsoft/qsharp-language/blob/9cb9b91a49341d691c4fdc7d3f464453cc8eae36/Specifications/Language/5_Grammar/QSharpParser.g4#L103).