### PR TITLE
Update Quantum Libraries executables to .NET 6

### DIFF
--- a/Build/manifest.ps1
+++ b/Build/manifest.ps1
@@ -38,7 +38,7 @@ $artifacts = @{
         ".\Chemistry\src\DataModel\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Chemistry.DataModel.dll",
         ".\Chemistry\src\Jupyter\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Chemistry.Jupyter.dll",
         ".\Chemistry\src\Runtime\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Chemistry.Runtime.dll",
-        ".\Chemistry\src\Tools\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\qdk-chem.dll"
+        ".\Chemistry\src\Tools\bin\$Env:BUILD_CONFIGURATION\net6.0\qdk-chem.dll"
     ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };
 } 
 

--- a/Chemistry/src/Tools/Tools.csproj
+++ b/Chemistry/src/Tools/Tools.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PlatformTarget>x64</PlatformTarget>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.Quantum.Chemistry.Tools</RootNamespace>
     <AssemblyName>qdk-chem</AssemblyName>
     <Nullable>enable</Nullable>

--- a/Chemistry/tests/ChemistryTests/QSharpTests.csproj
+++ b/Chemistry/tests/ChemistryTests/QSharpTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\Build\props\tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>
   </PropertyGroup>
 

--- a/Chemistry/tests/DataModelTests/DataModelTests.csproj
+++ b/Chemistry/tests/DataModelTests/DataModelTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Quantum.Chemistry.Tests.CSharp</AssemblyName>

--- a/Chemistry/tests/JupyterTests/JupyterTests.csproj
+++ b/Chemistry/tests/JupyterTests/JupyterTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Chemistry/tests/SamplesTests/SamplesTests.csproj
+++ b/Chemistry/tests/SamplesTests/SamplesTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Chemistry/tests/SystemTests/SystemTests.csproj
+++ b/Chemistry/tests/SystemTests/SystemTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\Build\props\tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>
   </PropertyGroup>
 

--- a/MachineLearning/tests/MachineLearningTests.csproj
+++ b/MachineLearning/tests/MachineLearningTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\Build\props\tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Standard.Tests</AssemblyName>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>
   </PropertyGroup>

--- a/Numerics/tests/NumericsTests.csproj
+++ b/Numerics/tests/NumericsTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\Build\props\tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>
   </PropertyGroup>
 

--- a/Standard/tests/Standard.Tests.csproj
+++ b/Standard/tests/Standard.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\Build\props\tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Standard.Tests</AssemblyName>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>
   </PropertyGroup>


### PR DESCRIPTION
In accordance with the changes tracked by the issue below, we're updating the libraries to target .NET6
https://github.com/microsoft/qsharp-compiler/issues/1224
