### PR TITLE
Fix link to QML library intro

### DIFF
--- a/MachineLearning/src/Properties/NamespaceInfo.qs
+++ b/MachineLearning/src/Properties/NamespaceInfo.qs
@@ -7,7 +7,7 @@
 ///
 /// # Description
 /// To learn more about this quantum machine learning library, see
-/// [Introduction to the Quantum Machine Learning Library](xref:microsoft.quantum.libraries-machine-learning.overview)
+/// [Introduction to the Quantum Machine Learning Library](xref:microsoft.quantum.libraries.overview.machine-learning.intro)
 /// in Q# documentation.
 ///
 /// # References


### PR DESCRIPTION
Currently the link "To learn more about this quantum machine learning library" at https://docs.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.machinelearning points to the same page, rather than to https://docs.microsoft.com/en-us/azure/quantum/user-guide/libraries/machine-learning/intro. I believe changing the xref to UID from https://github.com/MicrosoftDocs/quantum-docs/blob/main/articles/user-guide/libraries/machine-learning/intro.md should fix it.