### PR TITLE
Update QDK to .NET6.0 (QuantumLibraries)

### DIFF
--- a/Build/manifest.ps1
+++ b/Build/manifest.ps1
@@ -38,7 +38,7 @@ $artifacts = @{
         ".\Chemistry\src\DataModel\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Chemistry.DataModel.dll",
         ".\Chemistry\src\Jupyter\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Chemistry.Jupyter.dll",
         ".\Chemistry\src\Runtime\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Chemistry.Runtime.dll",
-        ".\Chemistry\src\Tools\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\qdk-chem.dll"
+        ".\Chemistry\src\Tools\bin\$Env:BUILD_CONFIGURATION\net6.0\qdk-chem.dll"
     ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };
 } 
 

--- a/Build/props/tests.props
+++ b/Build/props/tests.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.13.201118141-beta" />
+    <PackageReference Include="Microsoft.Quantum.Xunit" Version="0.21.2112181770-beta" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />

--- a/Chemistry/src/Runtime/Runtime.csproj
+++ b/Chemistry/src/Runtime/Runtime.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.17.2105143879">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.17.2105143879" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.21.2112181770-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chemistry/src/Tools/Tools.csproj
+++ b/Chemistry/src/Tools/Tools.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <PlatformTarget>x64</PlatformTarget>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Microsoft.Quantum.Chemistry.Tools</RootNamespace>
     <AssemblyName>qdk-chem</AssemblyName>
     <Nullable>enable</Nullable>

--- a/Chemistry/tests/ChemistryTests/QSharpTests.csproj
+++ b/Chemistry/tests/ChemistryTests/QSharpTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.17.2105143879">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
 
   <Import Project="..\..\..\Build\props\tests.props" />
 

--- a/Chemistry/tests/ChemistryTests/QSharpTests.csproj
+++ b/Chemistry/tests/ChemistryTests/QSharpTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\Build\props\tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>
   </PropertyGroup>
 

--- a/Chemistry/tests/DataModelTests/DataModelTests.csproj
+++ b/Chemistry/tests/DataModelTests/DataModelTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <AssemblyName>Microsoft.Quantum.Chemistry.Tests.CSharp</AssemblyName>

--- a/Chemistry/tests/JupyterTests/JupyterTests.csproj
+++ b/Chemistry/tests/JupyterTests/JupyterTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Chemistry/tests/SamplesTests/SamplesTests.csproj
+++ b/Chemistry/tests/SamplesTests/SamplesTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Chemistry/tests/SystemTests/SystemTests.csproj
+++ b/Chemistry/tests/SystemTests/SystemTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.17.2105143879">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
 
   <Import Project="..\..\..\Build\props\tests.props" />
 

--- a/Chemistry/tests/SystemTests/SystemTests.csproj
+++ b/Chemistry/tests/SystemTests/SystemTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\Build\props\tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>
   </PropertyGroup>
 

--- a/MachineLearning/src/MachineLearning.csproj
+++ b/MachineLearning/src/MachineLearning.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.17.2105143879">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.MachineLearning</AssemblyName>

--- a/MachineLearning/tests/MachineLearningTests.csproj
+++ b/MachineLearning/tests/MachineLearningTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.17.2105143879">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/MachineLearning/tests/MachineLearningTests.csproj
+++ b/MachineLearning/tests/MachineLearningTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\Build\props\tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Standard.Tests</AssemblyName>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>
   </PropertyGroup>

--- a/Numerics/src/Numerics.csproj
+++ b/Numerics/src/Numerics.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.17.2105143879">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.17.2105143879" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.21.2112181770-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/Numerics/tests/NumericsTests.csproj
+++ b/Numerics/tests/NumericsTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.17.2105143879">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Numerics/tests/NumericsTests.csproj
+++ b/Numerics/tests/NumericsTests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\Build\props\tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>
   </PropertyGroup>
 

--- a/Standard/src/Standard.csproj
+++ b/Standard/src/Standard.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.17.2105143879">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -38,8 +38,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.17.2105143879" />
-    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.17.2105143879" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.21.2112181770-beta" />
+    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.21.2112181770-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>

--- a/Standard/tests/Standard.Tests.csproj
+++ b/Standard/tests/Standard.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.17.2105143879">
+<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112181770-beta">
 
   <Import Project="..\..\Build\props\tests.props" />
 

--- a/Standard/tests/Standard.Tests.csproj
+++ b/Standard/tests/Standard.Tests.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\Build\props\tests.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Standard.Tests</AssemblyName>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>
   </PropertyGroup>

--- a/Visualization/src/Visualization.csproj
+++ b/Visualization/src/Visualization.csproj
@@ -32,9 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.17.2105143879" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.21.2112181770-beta" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.17.2105143879" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Quantum.IQSharp.Jupyter" Version="0.21.2112181770-beta" PrivateAssets="All" />
     <PackageReference Include="NumSharp" Version="0.20.5" />
   </ItemGroup>
 


### PR DESCRIPTION
We're migrating the QDK to the most recent Long Time Support version of the .NET framework. For details about this change, refer to the original issue [Q#C:1224](https://github.com/microsoft/qsharp-compiler/issues/1224).

As part of this change, we're:

- Re-targeting all .NetCoreApp3.1 binaries to .NET6.0
- Updating Docker images, samples and templates.
- Libraries using .NetStandard2.1 are not affected by this change.
- The minimum supported .NET version in the QDK will also be updated from 3.1 to 6.0

This is a multi-repo change, and all changes will need to be merged concurrently.