### PR TITLE
Y22K bug in package version

### DIFF
--- a/Build/e2e.yml
+++ b/Build/e2e.yml
@@ -1,4 +1,4 @@
-name: $(Build.Major).$(Build.Minor).$(date:yyMM).$(BuildId)
+name: $(Build.Major).$(Build.Minor).$(BuildId)
 
 parameters:
 - name: validation_level


### PR DESCRIPTION
In order to keep build numbers consistent with upcoming changes in the qdk-release versions, we are removing the YYMM element for the patch version and using the buildId instead.