### PR TITLE
Set RobustPhaseEstimation test tolerance to 0.02

### DIFF
--- a/Standard/tests/QcvvTests.qs
+++ b/Standard/tests/QcvvTests.qs
@@ -107,7 +107,7 @@ namespace Microsoft.Quantum.Tests {
         for idxTest in 0 .. 9 {
             let phaseSet = ((2.0 * PI()) * IntAsDouble(idxTest - 5)) / 12.0;
             let phaseEst = RobustPhaseEstimationDemoImpl(phaseSet, bitsPrecision);
-            EqualityWithinToleranceFact(phaseEst, phaseSet, 0.01);
+            EqualityWithinToleranceFact(phaseEst, phaseSet, 0.02);
         }
     }
 


### PR DESCRIPTION
Because of intermittent test failures, I propose to increase the tolerance for this test.

See:
```
 X Microsoft.Quantum.Tests.TestRobustPhaseEstimation+QuantumSimulator.TestRobustPhaseEstimation [571ms] 
 Error Message: 
 Q# Test failed. For details see the Standard output below. 
Expected: True 
Actual: False 
 Stack Trace: 
 at Microsoft.Quantum.Tests.TestRobustPhaseEstimation.QuantumSimulator.TestRobustPhaseEstimation() in D:\a\1\s\submodules\QuantumLibraries\Standard\tests\QcvvTests.qs:line 104 
 Standard Output Messages: 
 Unhandled exception. Microsoft.Quantum.Simulation.Core.ExecutionFailException: Values were not equal within tolerance. 
 Expected: 0.5235987755982988 
 Actual: 0.5114440214174745 
 ---> Microsoft.Quantum.Tests.TestRobustPhaseEstimation on D:\a\1\s\submodules\QuantumLibraries\Standard\tests\QcvvTests.qs:line 107
```

https://dev.azure.com/ms-quantum-public/Microsoft%20Quantum%20(public)/_build/results?buildId=36719&view=logs&j=b78a1ffd-6a4f-5c9a-fd79-c70d65470011&t=713c2bf1-c2f4-550a-98c6-b26f5b9f3f7a&l=657
