### PR TITLE
Remove year:month from pipeline name field

### DIFF
--- a/build.yml
+++ b/build.yml
@@ -1,7 +1,7 @@
 #
 # Build configuration file to run build on azure-pipelines
 #
-name: $(Build.Major).$(Build.Minor).$(date:yyMM).$(DayOfMonth)$(rev:rr)
+name: $(Build.Major).$(Build.Minor).$(DayOfMonth)$(rev:rr)
 
 trigger: none
 


### PR DESCRIPTION
This PR removes the $(yy:MM) field from all pipelines to keep consistency with the new qdk package version format.