### PR TITLE
Optimization and formatting in amplitude amplification

### DIFF
--- a/Standard/src/AmplitudeAmplification/AmplitudeAmplification.qs
+++ b/Standard/src/AmplitudeAmplification/AmplitudeAmplification.qs
@@ -38,7 +38,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     /// for some unitary $U$.
     /// By a sequence of reflections about the start and target states on the
     /// auxiliary register interleaved by applications of `signalOracle` and its
-    /// adjoint, the success probability of applying U$$ may be altered.
+    /// adjoint, the success probability of applying $U$ may be altered.
     ///
     /// In most cases, `auxiliaryRegister` is initialized in the state $\ket{\text{start}}\_a$.
     ///

--- a/Standard/src/AmplitudeAmplification/AmplitudeAmplification.qs
+++ b/Standard/src/AmplitudeAmplification/AmplitudeAmplification.qs
@@ -5,6 +5,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     open Microsoft.Quantum.Arrays;
     open Microsoft.Quantum.Intrinsic;
     open Microsoft.Quantum.Convert;
+    open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Math;
     open Microsoft.Quantum.Canon;
     open Microsoft.Quantum.Oracles;
@@ -37,16 +38,14 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
     /// for some unitary $U$.
     /// By a sequence of reflections about the start and target states on the
     /// auxiliary register interleaved by applications of `signalOracle` and its
-    /// adjoint, the success probability of applying U may be altered.
+    /// adjoint, the success probability of applying U$$ may be altered.
     ///
     /// In most cases, `auxiliaryRegister` is initialized in the state $\ket{\text{start}}\_a$.
     ///
     /// # References
-    /// See
-    /// - [ *D.W. Berry, A.M. Childs, R. Cleve, R. Kothari, R.D. Somma* ](https://arxiv.org/abs/1312.1414)
+    /// - See [*D.W. Berry, A.M. Childs, R. Cleve, R. Kothari, R.D. Somma*](https://arxiv.org/abs/1312.1414)
     /// for the standard version.
-    /// See
-    /// - [ *G.H. Low, I.L. Chuang* ](https://arxiv.org/abs/1610.06546)
+    /// - See [*G.H. Low, I.L. Chuang*](https://arxiv.org/abs/1610.06546)
     /// for a generalization to partial reflections.
     operation ApplyObliviousAmplitudeAmplification(
         phases : ReflectionPhases,
@@ -57,24 +56,33 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
         systemRegister : Qubit[]
     )
     : Unit is Adj + Ctl {
-        for (startPhase, targetPhase) in Zipped(phases!) {
+        EqualityFactI(Length(phases::AboutStart), Length(phases::AboutTarget), "number of phases about start and target state must be equal");
+        let numPhases = Length(phases::AboutStart);
+
+        for (idx, (startPhase, targetPhase)) in Enumerated(Zipped(phases!)) {
             if startPhase != 0.0 {
-                startStateReflection::ApplyReflection(
-                    startPhase, auxiliaryRegister
-                );
+                startStateReflection::ApplyReflection(startPhase, auxiliaryRegister);
             }
 
             if targetPhase != 0.0 {
-                within {
+                // In the last iteration we do not need to apply `Adjoint signalOracle`
+                if idx == numPhases - 1 {
                     signalOracle!(auxiliaryRegister, systemRegister);
-                } apply {
-                    targetStateReflection!(targetPhase, auxiliaryRegister);
+                    targetStateReflection::ApplyReflection(targetPhase, auxiliaryRegister);
+                } else {
+                    within {
+                        signalOracle!(auxiliaryRegister, systemRegister);
+                    } apply {
+                        targetStateReflection::ApplyReflection(targetPhase, auxiliaryRegister);
+                    }
                 }
             }
         }
-        // This gives us one extra application of Adjoint signalOracle!, so we
-        // apply the forward direction at the end.
-        signalOracle!(auxiliaryRegister, systemRegister);
+
+        // We do need one more `signalOracle` call, if the last phase about the target state was 0.0
+        if numPhases == 0 or phases::AboutTarget[numPhases - 1] == 0.0 {
+            signalOracle!(auxiliaryRegister, systemRegister);
+        }
     }
 
 
@@ -90,7 +98,7 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
         targetStateReflection : ReflectionOracle,
         signalOracle : ObliviousOracle
     )
-    : ((Qubit[], Qubit[]) => Unit is Adj + Ctl) {
+    : (Qubit[], Qubit[]) => Unit is Adj + Ctl {
         return ApplyObliviousAmplitudeAmplification(
             phases, startStateReflection, targetStateReflection, signalOracle,
             _, _
@@ -243,9 +251,9 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
         let systemRegister = [];
         let signalOracle = ObliviousOracle(NoOp);
         let startStateOracle = DeterministicStateOracleFromStateOracle(idxFlagQubit, stateOracle);
-        return (ObliviousAmplitudeAmplificationFromStatePreparation(
+        return ObliviousAmplitudeAmplificationFromStatePreparation(
             phases, startStateOracle, signalOracle, idxFlagQubit
-        ))(_, systemRegister);
+        )(_, systemRegister);
     }
 
 
@@ -324,9 +332,9 @@ namespace Microsoft.Quantum.AmplitudeAmplification {
             repeat {
                 let queries = 2 ^ exponentCurrent;
                 let phases = FixedPointReflectionPhases(queries, successMin);
-                (AmplitudeAmplificationFromStatePreparation(phases, statePrepOracle, idxFlagQubit))(qubits);
+                AmplitudeAmplificationFromStatePreparation(phases, statePrepOracle, idxFlagQubit)(qubits);
                 set finished = M(flagQubit);
-                set exponentCurrent = exponentCurrent + 1;
+                set exponentCurrent += 1;
             }
             until finished == One or exponentCurrent > exponentMax
             fixup {

--- a/Standard/src/Canon/CommonGates.qs
+++ b/Standard/src/Canon/CommonGates.qs
@@ -179,9 +179,7 @@ namespace Microsoft.Quantum.Canon {
     /// The register whose state is to be rotated by $R$.
     operation RAll1 (phase : Double, qubits : Qubit[]) : Unit {
         body (...) {
-            let nQubits = Length(qubits);
-            let flagQubit = qubits[0];
-            let systemRegister = qubits[1 .. nQubits - 1];
+            let (flagQubit, systemRegister) = HeadAndRest(qubits);
             Controlled (R1(phase, _))(systemRegister, flagQubit);
         }
 

--- a/Standard/src/Oracles/Types.qs
+++ b/Standard/src/Oracles/Types.qs
@@ -17,7 +17,7 @@ namespace Microsoft.Quantum.Oracles {
     /// performs a partial reflection by a phase $\phi$ about a single pure state
     /// $\ket{\psi}$.
     newtype ReflectionOracle = (
-        ApplyReflection: ((Double, Qubit[]) => Unit is Adj + Ctl)
+        ApplyReflection: (Double, Qubit[]) => Unit is Adj + Ctl
     );
 
     // This oracle O|s>_a|ψ>_s = λ |t>_a U |ψ>_s + ... acts on the ancilla state |s>_a to implement the unitary U on any system state |ψ>_s with amplitude λ in the |t>_a basis.
@@ -37,7 +37,7 @@ namespace Microsoft.Quantum.Oracles {
     /// $$
     /// acts on the ancilla state $\ket{s}\_a$ to implement the unitary $U$ on any system state $\ket{\psi}\_s$ with amplitude $\lambda$ in the basis flagged by $\ket{t}\_a$.
     /// The first parameter is the qubit register of $\ket{s}\_a$. The second parameter is the qubit register of $\ket{\psi}\_s$.
-    newtype ObliviousOracle = ((Qubit[], Qubit[]) => Unit is Adj + Ctl);
+    newtype ObliviousOracle = (Qubit[], Qubit[]) => Unit is Adj + Ctl;
 
     /// # Summary
     /// Represents an oracle for state preparation.
@@ -54,7 +54,7 @@ namespace Microsoft.Quantum.Oracles {
     /// $$
     /// acts on the on computational basis state $\ket{0}\_{f}\ket{0}\_s$ to create the target state $\ket{\psi}\_s$ with amplitude $\lambda$ in the basis flagged by $\ket{1}\_f$.
     /// The first parameter is an index to the qubit register of $\ket{0}\_f$. The second parameter encompassed both registers.
-    newtype StateOracle = ((Int, Qubit[]) => Unit is Adj + Ctl);
+    newtype StateOracle = (Int, Qubit[]) => Unit is Adj + Ctl;
 
     /// # Summary
     /// Represents an oracle for deterministic state preparation.
@@ -66,7 +66,7 @@ namespace Microsoft.Quantum.Oracles {
     /// # Remarks
     /// This oracle defined by $O\ket{0}=\ket{\psi}$ acts on the on computational basis state $\ket{0}$ to create the state $\ket{\psi}$.
     /// The first parameter is the qubit register of $\ket{\psi}$.
-    newtype DeterministicStateOracle = (Qubit[] => Unit is Adj + Ctl);
+    newtype DeterministicStateOracle = Qubit[] => Unit is Adj + Ctl;
 
 
     /// # Summary
@@ -75,7 +75,7 @@ namespace Microsoft.Quantum.Oracles {
     /// # Description
     /// This is an oracle that implements $U^m$ for a fixed operation $U$
     /// and a non-negative integer $m$.
-    newtype DiscreteOracle = ((Int, Qubit[]) => Unit is Adj + Ctl);
+    newtype DiscreteOracle = (Int, Qubit[]) => Unit is Adj + Ctl;
 
     /// # Summary
     /// Represents a continuous-time oracle.
@@ -85,7 +85,7 @@ namespace Microsoft.Quantum.Oracles {
     /// $U(\delta t) : \ket{\psi(t)} \mapsto \ket{\psi(t + \delta t)}$
     /// for all times $t$, where $U$ is a fixed operation, and where
     /// $\delta t$ is a non-negative real number.
-    newtype ContinuousOracle = ((Double, Qubit[]) => Unit is Adj + Ctl);
+    newtype ContinuousOracle = (Double, Qubit[]) => Unit is Adj + Ctl;
 
 }
 


### PR DESCRIPTION
This PR optimizes some code in amplitude amplification (no execution of sequence `Adjoint Op; Op`) updates formatting to newer Q# language features. It also has some updates to documentation.