### PR TITLE
Add docs/ folders to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.g.cs
 bin/
 obj/
+docs/
 Documentation/Help/
 packages/
 *.obj


### PR DESCRIPTION
Building the libraries projects generates API documentation in a docs/ folder. Our release workflows use these files to update documentation in a separate repository, but we never commit the generated files to the libraries repo itself, so it makes sense to add those files to gitignore.