### PR TITLE
Unify Markdown for Examples section

### DIFF
--- a/Standard/src/Arrays/Arrays.qs
+++ b/Standard/src/Arrays/Arrays.qs
@@ -201,8 +201,7 @@ namespace Microsoft.Quantum.Arrays {
     /// such that `output[1]` is the second such element, and so
     /// forth.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// ```qsharp
     /// let array = [10, 11, 12, 13, 14, 15];
     /// // The following line returns [10, 12, 15].
@@ -258,8 +257,7 @@ namespace Microsoft.Quantum.Arrays {
     /// An array `output` that is the `inputArray` padded at the head
     /// with `defaultElement`s until `output` has length `nElementsTotal`
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// ```qsharp
     /// let array = [10, 11, 12];
     /// // The following line returns [10, 12, 15, 2, 2, 2].
@@ -324,8 +322,7 @@ namespace Microsoft.Quantum.Arrays {
     /// elements, while `Most(Partitioned(...))` will always return the complete
     /// partitions of the array.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// ```qsharp
     /// // The following returns [[1, 5], [3], [7]];
     /// let split = Partitioned([2,1], [1,5,3,7]);
@@ -409,19 +406,21 @@ namespace Microsoft.Quantum.Arrays {
     /// # Output
     /// The tuple represents the two indices to be swapped. The swaps begin at the lowest index.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// ```qsharp
     /// // The following returns [(0, 5),(0, 4),(0, 1),(0, 3)];
     /// let swapOrder = _SwapOrderToPermuteArray([5, 3, 2, 0, 1, 4]);
     /// ```
     ///
+    /// # Remarks
     /// ## Pseudocode
+    /// ```
     /// for index in 0..Length(newOrder) - 1 {
     ///     while newOrder[index] != index {
     ///         Switch newOrder[index] with newOrder[newOrder[index]]
     ///     }
     /// }
+    /// ```
     function _SwapOrderToPermuteArray(newOrder : Int[]) : (Int, Int)[] {
         // Check to verify the new ordering actually is a permutation of the indices
         Fact(IsPermutation(newOrder), $"The new ordering is not a permutation");
@@ -456,10 +455,11 @@ namespace Microsoft.Quantum.Arrays {
     /// # Output
     /// The array with the in place swap applied.
     ///
-    /// ## Example
+    /// # Example
     /// ```qsharp
     /// // The following returns [0, 3, 2, 1, 4]
     /// Swapped(1, 3, [0, 1, 2, 3, 4]);
+    /// ```
     function Swapped<'T>(firstIndex : Int, secondIndex : Int, arr : 'T[]) : 'T[] {
         return arr
             w/ firstIndex <- arr[secondIndex]
@@ -476,7 +476,7 @@ namespace Microsoft.Quantum.Arrays {
     /// # Output
     /// A nested array with length matching the tupleList.
     ///
-    /// ## Example
+    /// # Example
     /// ```qsharp
     /// // The following returns [[2, 3], [4, 5]]
     /// TupleArrayAsNestedArray([(2, 3), (4, 5)]);

--- a/Standard/src/Arrays/Deprecated.qs
+++ b/Standard/src/Arrays/Deprecated.qs
@@ -26,8 +26,7 @@ namespace Microsoft.Quantum.Arrays {
     /// each `idx`. If the two arrays are not of equal length, the output will
     /// be as long as the shorter of the inputs.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// ```qsharp
     /// let left = [1, 3, 71];
     /// let right = [false, true];
@@ -137,8 +136,7 @@ namespace Microsoft.Quantum.Arrays {
     /// such that `output[1]` is the second such element, and so
     /// forth.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// ```qsharp
     /// let array = [10, 11, 12, 13, 14, 15];
     /// // The following line returns [10, 12, 15].

--- a/Standard/src/Arrays/Fold.qs
+++ b/Standard/src/Arrays/Fold.qs
@@ -26,8 +26,7 @@ namespace Microsoft.Quantum.Arrays {
     /// The final state returned by the folder after iterating over
     /// all elements of `array`.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// ```qsharp
     /// function Plus(a : Double, b : Double) {
     ///     return a + b;

--- a/Standard/src/Arrays/Map.qs
+++ b/Standard/src/Arrays/Map.qs
@@ -67,8 +67,7 @@ namespace Microsoft.Quantum.Arrays {
     /// # Output
     /// An array `'U[]` of elements that are mapped by the `mapper` function.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// The following two lines are equivalent:
     /// ```qsharp
     /// let arr = MapIndex(f, [x0, x1, x2]);

--- a/Standard/src/Arrays/Sequence.qs
+++ b/Standard/src/Arrays/Sequence.qs
@@ -18,8 +18,7 @@ namespace Microsoft.Quantum.Arrays {
     /// An array containing the sequence of numbers `from`, `from + 1`, ...,
     /// `to`.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// ```qsharp
     /// let arr1 = SequenceI(0, 3); // [0, 1, 2, 3]
     /// let arr2 = SequenceI(23, 29); // [23, 24, 25, 26, 27, 28, 29]
@@ -57,7 +56,7 @@ namespace Microsoft.Quantum.Arrays {
     /// # Remarks
     /// The difference between `from` and `to` must fit into an `Int` value.
     ///
-    /// ## Example
+    /// # Example
     /// ```qsharp
     /// let arr1 = SequenceL(0L, 3L); // [0L, 1L, 2L, 3L]
     /// let arr2 = SequenceL(23L, 29L); // [23L, 24L, 25L, 26L, 27L, 28L, 29L]

--- a/Standard/src/Arrays/Zip.qs
+++ b/Standard/src/Arrays/Zip.qs
@@ -25,8 +25,7 @@ namespace Microsoft.Quantum.Arrays {
     /// each `idx`. If the two arrays are not of equal length, the output will
     /// be as long as the shorter of the inputs.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// ```qsharp
     /// let left = [1, 3, 71];
     /// let right = [false, true];

--- a/Standard/src/Canon/Combinators/ApplyToEach.qs
+++ b/Standard/src/Canon/Combinators/ApplyToEach.qs
@@ -19,12 +19,11 @@ namespace Microsoft.Quantum.Canon {
     /// ## 'T
     /// The target on which the operation acts.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// Prepare a three-qubit $\ket{+}$ state:
     /// ```qsharp
     /// using (register = Qubit[3]) {
-    ///     ApplyToEach(H, register);
+    ///     ApplyToEachCA(H, register);
     /// }
     /// ```
     ///
@@ -52,12 +51,11 @@ namespace Microsoft.Quantum.Canon {
     /// ## 'T
     /// The target on which the operation acts.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// Prepare a three-qubit $\ket{+}$ state:
     /// ```qsharp
     /// using (register = Qubit[3]) {
-    ///     ApplyToEach(H, register);
+    ///     ApplyToEachA(H, register);
     /// }
     /// ```
     ///
@@ -85,12 +83,11 @@ namespace Microsoft.Quantum.Canon {
     /// ## 'T
     /// The target on which the operation acts.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// Prepare a three-qubit $\ket{+}$ state:
     /// ```qsharp
     /// using (register = Qubit[3]) {
-    ///     ApplyToEach(H, register);
+    ///     ApplyToEachC(H, register);
     /// }
     /// ```
     ///
@@ -117,8 +114,7 @@ namespace Microsoft.Quantum.Canon {
     /// ## 'T
     /// The target on which the operation acts.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// Prepare a three-qubit $\ket{+}$ state:
     /// ```qsharp
     /// using (register = Qubit[3]) {

--- a/Standard/src/Canon/Combinators/Bind.qs
+++ b/Standard/src/Canon/Combinators/Bind.qs
@@ -29,8 +29,7 @@ namespace Microsoft.Quantum.Canon {
     /// ## 'T
     /// The target on which each of the operations in the array act.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// The following are equivalent:
     /// ```qsharp
     /// let bound = Bound([U, V]);
@@ -78,8 +77,7 @@ namespace Microsoft.Quantum.Canon {
     /// ## 'T
     /// The target on which each of the operations in the array act.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// The following are equivalent:
     /// ```qsharp
     /// let bound = BoundA([U, V]);
@@ -126,8 +124,7 @@ namespace Microsoft.Quantum.Canon {
     /// ## 'T
     /// The target on which each of the operations in the array act.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// The following are equivalent:
     /// ```qsharp
     /// let bound = BoundC([U, V]);
@@ -174,8 +171,7 @@ namespace Microsoft.Quantum.Canon {
     /// ## 'T
     /// The target on which each of the operations in the array act.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// The following are equivalent:
     /// ```qsharp
     /// let bound = BoundCA([U, V]);

--- a/Standard/src/Canon/Combinators/RestrictedToSubregister.qs
+++ b/Standard/src/Canon/Combinators/RestrictedToSubregister.qs
@@ -16,8 +16,7 @@ namespace Microsoft.Quantum.Canon {
     /// ## target
     /// Register on which the operation acts.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// Create three qubit state $\frac{1}{\sqrt{2}}\ket{0}\_2(\ket{0}\_1\ket{0}_3+\ket{1}\_1\ket{1}_3)$:
     /// ```qsharp
     ///     using (register = Qubit[3]) {

--- a/Standard/src/Canon/Enumeration/Trotter.qs
+++ b/Standard/src/Canon/Enumeration/Trotter.qs
@@ -24,8 +24,7 @@ namespace Microsoft.Quantum.Canon {
     /// ## target
     /// A quantum register on which the operations act.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// The following are equivalent:
     /// ```qsharp
     /// op(0, deltaT, target);
@@ -61,8 +60,7 @@ namespace Microsoft.Quantum.Canon {
     /// ## target
     /// A quantum register on which the operations act.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// The following are equivalent:
     /// ```qsharp
     /// op(0, deltaT / 2.0, target);

--- a/Standard/src/Convert/Convert.qs
+++ b/Standard/src/Convert/Convert.qs
@@ -210,8 +210,7 @@ namespace Microsoft.Quantum.Convert {
     /// # Output
     /// A new array of integers corresponding to values iterated over by `range`.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// ```qsharp
     /// // The following returns [1,3,5,7];
     /// let array = RangeAsIntArray(1..2..8);

--- a/Standard/src/Diagnostics/Asserts.qs
+++ b/Standard/src/Diagnostics/Asserts.qs
@@ -25,17 +25,16 @@ namespace Microsoft.Quantum.Diagnostics {
     /// ## tolerance
     /// Absolute tolerance on the difference between actual and expected.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// The following assert succeeds:
     /// `qubit` is in state $\ket{\psi}=e^{i 0.5}\sqrt{1/2}\ket{0}+e^{i 0.5}\sqrt{1/2}\ket{1}$;
-    /// - `AssertPhase(0.0,qubit,10e-10);`
+    /// - `AssertPhase(0.0, qubit, 10e-10);`
     ///
     /// `qubit` is in state $\ket{\psi}=e^{i 0.5}\sqrt{1/2}\ket{0}+e^{-i 0.5}\sqrt{1/2}\ket{1}$;
-    /// - `AssertPhase(0.5,qubit,10e-10);`
+    /// - `AssertPhase(0.5, qubit, 10e-10);`
     ///
     /// `qubit` is in state $\ket{\psi}=e^{-i 2.2}\sqrt{1/2}\ket{0}+e^{i 0.2}\sqrt{1/2}\ket{1}$;
-    /// - `AssertPhase(-1.2,qubit,10e-10);`
+    /// - `AssertPhase(-1.2, qubit, 10e-10);`
     operation AssertPhase(expected : Double, qubit : Qubit, tolerance : Double) : Unit {
         let exptectedProbX = Cos(expected) * Cos(expected);
         let exptectedProbY = Sin(-1.0 * expected + PI() / 4.0) * Sin(-1.0 * expected + PI() / 4.0);

--- a/Standard/src/ErrorCorrection/Types.qs
+++ b/Standard/src/ErrorCorrection/Types.qs
@@ -51,7 +51,7 @@ namespace Microsoft.Quantum.ErrorCorrection {
     /// qubits followed by a measurements of the auxiliary qubits to extract a
     /// `Syndrome` value representing the `Result[]` of these measurements.
     ///
-    /// ## Example
+    /// # Example
     /// Measure syndromes for the bit-flip code
     /// $S = \langle ZZI, IZZ \rangle$ using scratch qubits in a
     /// non–fault tolerant manner:

--- a/Standard/src/Math/Functions.qs
+++ b/Standard/src/Math/Functions.qs
@@ -83,7 +83,7 @@ namespace Microsoft.Quantum.Math {
     /// The `minValue` input then effectively specifies where to cut the
     /// unit circle.
     ///
-    /// ## Example
+    /// # Example
     /// ```qsharp
     ///     // Returns 3 π / 2.
     ///     let y = RealMod(5.5 * PI(), 2.0 * PI(), 0.0);

--- a/Standard/src/Oracles/Convert.qs
+++ b/Standard/src/Oracles/Convert.qs
@@ -139,8 +139,7 @@ namespace Microsoft.Quantum.Oracles {
     /// # Output
     /// An operation partially applied over the "black-box" oracle representing the discrete-time oracle
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// `OracleToDiscrete(U)(3, target)` is equivalent to `U(target)` repeated three times.
     function OracleToDiscrete (blackBoxOracle : (Qubit[] => Unit is Adj + Ctl)) : DiscreteOracle {
         return DiscreteOracle(ApplyOperationRepeatedlyCA(blackBoxOracle, _, _));

--- a/Standard/src/Preparation/Arbitrary.qs
+++ b/Standard/src/Preparation/Arbitrary.qs
@@ -93,7 +93,7 @@ namespace Microsoft.Quantum.Preparation {
     /// positive with value $|\alpha_j|$. `coefficients` will be padded with
     /// elements $\alpha_j = 0.0$ if fewer than $2^n$ are specified.
     ///
-    /// ## Example
+    /// # Example
     /// The following snippet prepares the quantum state $\ket{\psi}=\sqrt{1/8}\ket{0}+\sqrt{7/8}\ket{2}$
     /// in the qubit register `qubitsLE`.
     /// ```qsharp

--- a/Standard/src/Preparation/Deprecated.qs
+++ b/Standard/src/Preparation/Deprecated.qs
@@ -37,8 +37,7 @@ namespace Microsoft.Quantum.Preparation {
     /// ## Third parameter
     /// The unitary $U$.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// The following code snippet prepares an purification of the $3$-qubit state
     /// $\rho=\sum_{j=0}^{4}\frac{|alpha_j|}{\sum_k |\alpha_k|}\ket{j}\bra{j}$, where
     /// $\vec\alpha=(1.0,2.0,3.0,4.0,5.0)$, and the error is `1e-3`;
@@ -198,7 +197,7 @@ namespace Microsoft.Quantum.Preparation {
     /// elements $(r_j, t_j) = (0.0, 0.0)$ if fewer than $2^n$ are
     /// specified.
     ///
-    /// ## Example
+    /// # Example
     /// The following snippet prepares the quantum state $\ket{\psi}=e^{i 0.1}\sqrt{1/8}\ket{0}+\sqrt{7/8}\ket{2}$
     /// in the qubit register `qubitsLE`.
     /// ```qsharp
@@ -247,7 +246,7 @@ namespace Microsoft.Quantum.Preparation {
     /// positive with value $|\alpha_j|$. `coefficients` will be padded with
     /// elements $\alpha_j = 0.0$ if fewer than $2^n$ are specified.
     ///
-    /// ## Example
+    /// # Example
     /// The following snippet prepares the quantum state $\ket{\psi}=\sqrt{1/8}\ket{0}+\sqrt{7/8}\ket{2}$
     /// in the qubit register `qubitsLE`.
     /// ```qsharp

--- a/Standard/src/Simulation/Data/GeneratorRepresentation.qs
+++ b/Standard/src/Simulation/Data/GeneratorRepresentation.qs
@@ -23,7 +23,7 @@ namespace Microsoft.Quantum.Simulation {
     /// > The interpretation of an `GeneratorIndex` is not defined except
     /// > with reference to a particular set of generators.
     ///
-    /// ## Example
+    /// # Example
     /// Using <xref:Microsoft.Quantum.Simulation.PauliEvolutionSet>, the operator
     /// $\pi X_2 X_5 Y_9$ is represented as:
     /// ```qsharp
@@ -208,8 +208,7 @@ namespace Microsoft.Quantum.Simulation {
     /// A `GeneratorIndex` representing a term with coefficient a factor
     /// `multiplier` larger.
     ///
-    /// # Remarks
-    /// ## Example
+    /// # Example
     /// ```qsharp
     /// let gen = GeneratorIndex(([1,2,3],[coeff]),[1,2,3]);
     /// let ((idxPaulis, idxDoubles), idxQubits) = MultiplyGeneratorIndex(multiplier, gen);


### PR DESCRIPTION
Following up on discussion in #531, let's use `# Examples` consistently