### PR TITLE
Initial work on Broombridge v.0.3

### DIFF
--- a/Chemistry/src/DataModel/OrbitalIntegral/OrbitalIntegralExtensions.cs
+++ b/Chemistry/src/DataModel/OrbitalIntegral/OrbitalIntegralExtensions.cs
@@ -20,6 +20,15 @@ namespace Microsoft.Quantum.Chemistry.OrbitalIntegrals
     /// </summary>
     public static partial class Extensions
     {
+        internal static OrbitalIntegral.PermutationSymmetry FromBroombridgeV0_3(this Broombridge.V0_3.PermutationSymmetry symmetry) =>
+            symmetry switch
+            {
+                Broombridge.V0_3.PermutationSymmetry.Eightfold => OrbitalIntegral.PermutationSymmetry.Eightfold,
+                Broombridge.V0_3.PermutationSymmetry.Fourfold => OrbitalIntegral.PermutationSymmetry.Fourfold,
+                Broombridge.V0_3.PermutationSymmetry.Trivial => OrbitalIntegral.PermutationSymmetry.Trivial,
+                _ => throw new Exception($"Broombridge v0.3 permutation symmetry kind {symmetry} is not supported.")
+            };
+
 
         /// <summary>
         /// Method for constructing a fermion Hamiltonian from an orbital integral Hamiltonian.
@@ -60,7 +69,8 @@ namespace Microsoft.Quantum.Chemistry.OrbitalIntegrals
         public static IEnumerable<(HermitianFermionTerm, double)> ToHermitianFermionTerms(
             this OrbitalIntegral orbitalIntegral,
             int nOrbitals,
-            IndexConvention indexConvention = IndexConvention.UpDown)
+            IndexConvention indexConvention = IndexConvention.UpDown,
+            OrbitalIntegral.PermutationSymmetry symmetry = OrbitalIntegral.PermutationSymmetry.Eightfold)
         {
             var termType = orbitalIntegral.TermType;
             if (termType == TermType.OrbitalIntegral.OneBody)
@@ -69,7 +79,7 @@ namespace Microsoft.Quantum.Chemistry.OrbitalIntegrals
             }
             else if (termType == TermType.OrbitalIntegral.TwoBody)
             {
-                return orbitalIntegral.ToTwoBodySpinOrbitalTerms(nOrbitals, indexConvention);
+                return orbitalIntegral.ToTwoBodySpinOrbitalTerms(nOrbitals, indexConvention, symmetry);
             }
             else if(termType == TermType.OrbitalIntegral.Identity)
             {
@@ -95,7 +105,9 @@ namespace Microsoft.Quantum.Chemistry.OrbitalIntegrals
         {
             // One-electron orbital integral symmetries
             // ij = ji
-            var pqSpinOrbitals = orbitalIntegral.EnumerateOrbitalSymmetries().EnumerateSpinOrbitals();
+            var pqSpinOrbitals = orbitalIntegral
+                .EnumerateOrbitalSymmetries(OrbitalIntegral.PermutationSymmetry.Eightfold)
+                .EnumerateSpinOrbitals();
 
             var coefficient = orbitalIntegral.Coefficient;
 
@@ -124,11 +136,12 @@ namespace Microsoft.Quantum.Chemistry.OrbitalIntegrals
         private static IEnumerable<(HermitianFermionTerm, double)> ToTwoBodySpinOrbitalTerms(
             this OrbitalIntegral orbitalIntegral,
             int nOrbitals,
-            IndexConvention indexConvention)
+            IndexConvention indexConvention,
+            OrbitalIntegral.PermutationSymmetry symmetry)
         {
             // Two-electron orbital integral symmetries
             // ijkl = lkji = jilk = klij = ikjl = ljki = kilj = jlik.
-            var pqrsSpinOrbitals = orbitalIntegral.EnumerateOrbitalSymmetries().EnumerateSpinOrbitals();
+            var pqrsSpinOrbitals = orbitalIntegral.EnumerateOrbitalSymmetries(symmetry).EnumerateSpinOrbitals();
             var coefficient = orbitalIntegral.Coefficient;
 
 

--- a/Chemistry/src/DataModel/Serialization/Broombridge/BroombridgeData.cs
+++ b/Chemistry/src/DataModel/Serialization/Broombridge/BroombridgeData.cs
@@ -22,6 +22,8 @@ namespace Microsoft.Quantum.Chemistry.Broombridge
     /// <summary>
     /// Latest Broombridge format.
     /// </summary>
+    // NB: When obsoleted, this should likely be made internal rather than
+    //     removed.
     [Obsolete(
         "Please use collections of ElectronicStructureProblem instead.",
         error: false
@@ -39,7 +41,7 @@ namespace Microsoft.Quantum.Chemistry.Broombridge
         /// <summary>
         /// Raw deserialized Broombridge data.
         /// </summary>
-        public V0_2.Data Raw { get; set; }
+        public V0_3.Data Raw { get; set; }
 
         // Root of Broombridge data structure
 
@@ -62,12 +64,12 @@ namespace Microsoft.Quantum.Chemistry.Broombridge
         /// <summary>
         /// Deserialized Broombridge data
         /// </summary>
-        /// <param name="broombridgeV0_2">Broombridge data structure.</param>
-        internal Data(Broombridge.V0_2.Data broombridgeV0_2)
+        /// <param name="broombridgeV0_3">Broombridge data structure.</param>
+        internal Data(Broombridge.V0_3.Data broombridgeV0_3)
         {
-            Raw = broombridgeV0_2;
-            Schema = broombridgeV0_2.Schema;
-            VersionNumber = VersionNumber.v0_2;
+            Raw = broombridgeV0_3;
+            Schema = broombridgeV0_3.Schema;
+            VersionNumber = VersionNumber.v0_3;
 
             ProblemDescriptions = Raw.ProblemDescriptions.Select(problem => ProblemDescription.ProcessRawProblemDescription(problem));
         }
@@ -114,14 +116,14 @@ namespace Microsoft.Quantum.Chemistry.Broombridge
         /// </summary>
         /// <param name="problem">Problem description to be converted</param>
         /// <returns>The internal problem description data structure.</returns>
-        public static ProblemDescription ProcessRawProblemDescription(Broombridge.V0_2.ProblemDescription problem)
+        public static ProblemDescription ProcessRawProblemDescription(Broombridge.V0_3.ProblemDescription problem)
         {
             var problemDescription = new ProblemDescription
             {
                 EnergyOffset = problem.EnergyOffset.Value + problem.CoulombRepulsion.Value,
                 NElectrons = problem.NElectrons,
                 NOrbitals = problem.NOrbitals,
-                OrbitalIntegralHamiltonian = V0_2.ToOrbitalIntegralHamiltonian(problem),
+                OrbitalIntegralHamiltonian = V0_3.ToOrbitalIntegralHamiltonian(problem),
                 Wavefunctions = problem.InitialStates?.FromBroombridgeV0_2() ?? new Dictionary<string, FermionWavefunction<SpinOrbital>>()
             };
             return problemDescription;

--- a/Chemistry/src/DataModel/Serialization/Broombridge/BroombridgeDataStructurev0.1.cs
+++ b/Chemistry/src/DataModel/Serialization/Broombridge/BroombridgeDataStructurev0.1.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Quantum.Chemistry.Broombridge
                              ConvertIndices(
                                  term
                                 .Key
-                                .ToCanonicalForm()
+                                .ToCanonicalForm(OrbitalIntegral.PermutationSymmetry.Eightfold)
                                 .OrbitalIndices,
                                 OrbitalIntegral.Convention.Dirac,
                                 OrbitalIntegral.Convention.Mulliken

--- a/Chemistry/src/DataModel/Serialization/Broombridge/BroombridgeDataStructurev0.3.cs
+++ b/Chemistry/src/DataModel/Serialization/Broombridge/BroombridgeDataStructurev0.3.cs
@@ -1,0 +1,408 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Linq;
+using System.Text.RegularExpressions;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using System.Numerics;
+
+using Microsoft.Quantum.Chemistry.OrbitalIntegrals;
+using Microsoft.Quantum.Chemistry.Fermion;
+using Microsoft.Quantum.Chemistry.LadderOperators;
+using Newtonsoft.Json;
+using System.Runtime.Serialization;
+
+using static Microsoft.Quantum.Chemistry.OrbitalIntegrals.IndexConventionConversions;
+
+namespace Microsoft.Quantum.Chemistry.Broombridge
+{
+    // What data structures are unmodified from previous versions?
+    using Format = V0_1.Format;
+    using Generator = V0_1.Generator;
+    using BibliographyItem = V0_1.BibliographyItem;
+    using Geometry = V0_1.Geometry;
+    using HasUnits = V0_1.HasUnits;
+    using BasisSet = V0_1.BasisSet;
+    using SimpleQuantity = V0_1.SimpleQuantity;
+    using BoundedQuantity = V0_1.BoundedQuantity;
+    using State = V0_2.State;
+    using ClusterOperator = V0_2.ClusterOperator;
+
+    internal static class BroombridgeExtensionsV0_3
+    {
+        internal static V0_3.ProblemDescription ToBroombridgeV0_3(
+                this ElectronicStructureProblem problem
+        ) => new V0_3.ProblemDescription
+            {
+                BasisSet = problem.BasisSet != null
+                            ? new V0_1.BasisSet
+                            {
+                                Name = problem.BasisSet?.Name,
+                                Type = problem.BasisSet?.Type
+                            }
+                            : null,
+                CoulombRepulsion = problem.CoulombRepulsion.ToBroombridgeV0_2(),
+                EnergyOffset = problem.EnergyOffset.ToBroombridgeV0_2(),
+                FciEnergy = problem.FciEnergy?.ToBroombridgeV0_2(),
+                Geometry = problem.Geometry?.ToBroombridgeV0_2(),
+                Hamiltonian = problem.OrbitalIntegralHamiltonian.ToBroombridgeV0_3(),
+                InitialStates = problem.InitialStates?.ToBroombridgeV0_2(),
+                Metadata = problem.Metadata,
+                NElectrons = problem.NElectrons,
+                NOrbitals = problem.NOrbitals,
+                ScfEnergy = problem.ScfEnergy?.ToBroombridgeV0_2(),
+                ScfEnergyOffset = problem.ScfEnergyOffset?.ToBroombridgeV0_2()
+            };
+
+        internal static V0_3.ArrayQuantityWithSymmetry<TOut, TValue> TransformKeys<TIn, TOut, TValue>(
+            this V0_3.ArrayQuantityWithSymmetry<TIn, TValue> arrayQuantity,
+            Func<TIn, TOut> transform
+        ) =>
+            new V0_3.ArrayQuantityWithSymmetry<TOut, TValue>
+            {
+                Format = arrayQuantity.Format,
+                IndexConvention = arrayQuantity.IndexConvention,
+                Symmetry = arrayQuantity.Symmetry,
+                Units = arrayQuantity.Units,
+                Values = arrayQuantity
+                    .Values
+                    .Select(item => new V0_3.ArrayQuantityWithSymmetry<TOut, TValue>.Item
+                    {
+                        Key = transform(item.Key),
+                        Value = item.Value
+                    })
+                    .ToList()
+            };
+
+        internal static V0_3.ArrayQuantityWithSymmetry<TKey, TValue> WithSymmetry<TKey, TValue>(
+            this V0_3.ArrayQuantity<TKey, TValue> arrayQuantity,
+            V0_3.Symmetry symmetry
+        ) =>
+            new V0_3.ArrayQuantityWithSymmetry<TKey, TValue>
+            {
+                Format = arrayQuantity.Format,
+                IndexConvention = arrayQuantity.IndexConvention,
+                Symmetry = symmetry,
+                Units = arrayQuantity.Units,
+                Values = arrayQuantity.Values
+            };
+
+        internal static V0_3.HamiltonianData ToBroombridgeV0_3(this OrbitalIntegralHamiltonian hamiltonian)
+        {
+            var twoElectronIntegrals = hamiltonian
+                    .Terms[TermType.OrbitalIntegral.TwoBody]
+                .ToBroombridgeV0_3(new V0_3.Symmetry
+                {
+                    // List terms explicitly with no compression.
+                    Permutation = V0_3.PermutationSymmetry.Trivial
+                });
+            twoElectronIntegrals.IndexConvention = OrbitalIntegral.Convention.Mulliken;
+            return new V0_3.HamiltonianData
+            {
+                OneElectronIntegrals = hamiltonian
+                    .Terms[TermType.OrbitalIntegral.OneBody]
+                    .ToBroombridgeV0_3(new V0_3.Symmetry
+                    {
+                        // List terms explicitly with no compression.
+                        Permutation = V0_3.PermutationSymmetry.Trivial
+                    })
+                    .TransformKeys(idxs => (idxs[0], idxs[1])),
+                TwoElectronIntegrals = twoElectronIntegrals
+                    .TransformKeys(idxs => (idxs[0], idxs[1], idxs[2], idxs[3]))
+            };
+        }
+
+        internal static V0_3.ArrayQuantityWithSymmetry<long[], double> ToBroombridgeV0_3(
+            this Dictionary<OrbitalIntegrals.OrbitalIntegral, DoubleCoeff> terms,
+            V0_3.Symmetry symmetry
+        ) =>
+            new V0_3.ArrayQuantityWithSymmetry<long[], double>()
+            {
+                Format = V0_3.ArrayFormat.Sparse,
+                Units = "hartree",
+                Values = terms.Select(term =>
+                {
+                    var idxs = ConvertIndices(
+                                    term
+                                    .Key
+                                    .ToCanonicalForm(symmetry.Permutation.FromBroombridgeV0_3())
+                                    .OrbitalIndices,
+                                    OrbitalIntegral.Convention.Dirac,
+                                    OrbitalIntegral.Convention.Mulliken
+                                )
+                                .ToOneBasedIndices()
+                                .Select(idx => (long)idx)
+                                .ToArray();
+                    return new V0_3.ArrayQuantity<long[], double>.Item
+                    {
+                        Key = idxs,
+                        Value = term.Value.Value
+                    };
+                }).ToList(),
+                Symmetry = symmetry
+            };
+
+        internal static V0_3.HamiltonianData ToBroombridgeV0_3(this V0_1.HamiltonianData hamiltonianData) =>
+            new V0_3.HamiltonianData
+            {
+                ParticleHoleRepresentation = hamiltonianData.ParticleHoleRepresentation?.ToBroombridgeV0_3(),
+                OneElectronIntegrals = hamiltonianData
+                    .OneElectronIntegrals
+                    .ToBroombridgeV0_3()
+                    .WithSymmetry(new V0_3.Symmetry
+                    {
+                        Permutation = V0_3.PermutationSymmetry.Eightfold
+                    })
+                    .TransformKeys(key => (key[0], key[1])),
+                TwoElectronIntegrals = hamiltonianData
+                    .TwoElectronIntegrals
+                    .ToBroombridgeV0_3()
+                    .WithSymmetry(new V0_3.Symmetry
+                    {
+                        Permutation = V0_3.PermutationSymmetry.Eightfold
+                    })
+                    .TransformKeys(key => (key[0], key[1], key[2], key[3])),
+            };
+
+        internal static V0_3.ArrayQuantity<TKey[], TValue> ToBroombridgeV0_3<TKey, TValue>(this V0_1.ArrayQuantity<TKey, TValue> array) =>
+            new V0_3.ArrayQuantity<TKey[], TValue>
+            {
+                Format = Enum.TryParse<V0_3.ArrayFormat>(array.Format, out var format)
+                         ? format
+                         : throw new Exception($"Invalid array format {array.Format} when converting 0.1 array quantity to 0.3 array quantity."),
+                IndexConvention = array.IndexConvention,
+                Units = array.Units,
+                Values = array
+                    .Values
+                    .Select(item => new V0_3.ArrayQuantity<TKey[], TValue>.Item
+                    {
+                        Key = item.Item1,
+                        Value = item.Item2
+                    })
+                    .ToList()
+            };
+
+        internal static (O, O) Select<I, O>(this (I, I) value, Func<I, O> func) =>
+            (func(value.Item1), func(value.Item2));
+        internal static (O, O, O) Select<I, O>(this (I, I, I) value, Func<I, O> func) =>
+            (func(value.Item1), func(value.Item2), func(value.Item3));
+        internal static (O, O, O, O) Select<I, O>(this (I, I, I, I) value, Func<I, O> func) =>
+            (func(value.Item1), func(value.Item2), func(value.Item3), func(value.Item4));
+
+        internal static T[] ToArray<T>(this (T, T) value) =>
+            new T[] { value.Item1, value.Item2 };
+        internal static T[] ToArray<T>(this (T, T, T) value) =>
+            new T[] { value.Item1, value.Item2, value.Item3 };
+        internal static T[] ToArray<T>(this (T, T, T, T) value) =>
+            new T[] { value.Item1, value.Item2, value.Item3, value.Item4 };
+    }
+
+    /// <summary>
+    ///     Broombridge v0.3 format.
+    ///
+    ///     Changes from v0.2:
+    ///     <list type="bullet">
+    ///         <item>Addition of new symmetry key in HamiltonianData.</item>
+    ///         <item>Sparse-format arrays are now represented with separate keys and values to simplify parsing logic.</item>
+    ///     </list>
+    /// </summary>
+    #region Broombridge v0.3 format
+    public static class V0_3
+    {
+        // TODO: This URL is not yet valid!
+        public static string SchemaUrl = "https://raw.githubusercontent.com/microsoft/Quantum/main/Chemistry/Schema/broombridge-0.3.schema.json";
+
+        // Root of Broombridge data structure
+        public struct Data
+        {
+            public static readonly Format DefaultFormat = new Broombridge.V0_1.Format
+            {
+                Version = "0.3"
+            };
+
+            [YamlMember(Alias = "$schema", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "$schema")]
+            public string Schema { get; set; }
+
+            [YamlMember(Alias = "format", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "format")]
+            public Format Format { get; set; }
+
+            [YamlMember(Alias = "generator", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "generator")]
+            public Generator Generator { get; set; }
+
+            [YamlMember(Alias = "bibliography", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "bibliography")]
+            public List<BibliographyItem> Bibliography { get; set; }
+
+            [YamlMember(Alias = "problem_description", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "problem_description")]
+            public List<ProblemDescription> ProblemDescriptions { get; set; }
+
+        }
+
+        public struct ProblemDescription
+        {
+            [YamlMember(Alias = "metadata", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "metadata")]
+            public Dictionary<string, object> Metadata { get; set; }
+
+            [YamlMember(Alias = "basis_set", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "basis_set")]
+            public BasisSet? BasisSet { get; set; }
+
+            [YamlMember(Alias = "geometry", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "geometry")]
+            public Geometry? Geometry { get; set; }
+
+            [YamlMember(Alias = "coulomb_repulsion", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "coulomb_repulsion")]
+            public SimpleQuantity CoulombRepulsion { get; set; }
+
+            [YamlMember(Alias = "scf_energy", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "scf_energy")]
+            public SimpleQuantity? ScfEnergy { get; set; }
+
+            [YamlMember(Alias = "scf_energy_offset", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "scf_energy_offset")]
+            public SimpleQuantity? ScfEnergyOffset { get; set; }
+
+            [YamlMember(Alias = "fci_energy", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "fci_energy")]
+            public BoundedQuantity? FciEnergy { get; set; }
+
+            [YamlMember(Alias = "n_orbitals", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "n_orbitals")]
+            public int NOrbitals { get; set; }
+
+            [YamlMember(Alias = "n_electrons", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "n_electrons")]
+            public int NElectrons { get; set; }
+
+            [YamlMember(Alias = "energy_offset", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "energy_offset")]
+            public SimpleQuantity EnergyOffset { get; set; }
+
+            [YamlMember(Alias = "hamiltonian", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "hamiltonian")]
+            public HamiltonianData Hamiltonian { get; set; }
+
+            [YamlMember(Alias = "initial_state_suggestions", ApplyNamingConventions = false)]
+            [JsonProperty(PropertyName = "initial_state_suggestions")]
+            public List<State>? InitialStates { get; set; }
+        }
+
+        public struct HamiltonianData
+        {
+            [YamlMember(Alias = "particle_hole_representation", ApplyNamingConventions = false)]
+            // TODO: Placeholder object for ParticleHoleRepresentation, which we do not
+            // yet support.
+            // NB: Array quantity no longer implicitly adds [], so the type declaration is different
+            //     from in 0.1.
+            public ArrayQuantity<object[], object>? ParticleHoleRepresentation { get; set; }
+
+            [YamlMember(Alias = "one_electron_integrals", ApplyNamingConventions = false)]
+            public ArrayQuantity<(long, long), double> OneElectronIntegrals { get; set; }
+
+            [YamlMember(Alias = "two_electron_integrals", ApplyNamingConventions = false)]
+            public ArrayQuantityWithSymmetry<(long, long, long, long), double> TwoElectronIntegrals { get; set; }
+
+        }
+
+        public enum ArrayFormat
+        {
+            [EnumMember(Value = "sparse")]
+            Sparse
+        }
+
+        public class ArrayQuantity<TIndex, TValue> : HasUnits
+        {
+            public struct Item
+            {
+                [YamlMember(Alias = "key", ApplyNamingConventions = false)]
+                public TIndex Key { get; set; }
+
+                [YamlMember(Alias = "value", ApplyNamingConventions = false)]
+                public TValue Value { get; set; }
+            }
+
+            // TODO: make this an enum.
+            public ArrayFormat Format { get; set; }
+            public List<Item> Values { get; set; }
+            public OrbitalIntegral.Convention? IndexConvention { get; set; } = null;
+        }
+
+        public enum PermutationSymmetry
+        {
+            [EnumMember(Value = "eightfold")]
+            Eightfold,
+            [EnumMember(Value = "fourfold")]
+            Fourfold,
+            [EnumMember(Value = "trivial")]
+            Trivial
+        }
+
+        public struct Symmetry
+        {
+            [YamlMember(Alias = "permutation")]
+            public PermutationSymmetry Permutation { get; set; }
+        }
+
+        public class ArrayQuantityWithSymmetry<TIndex, TValue> : ArrayQuantity<TIndex, TValue>
+        {
+            [YamlMember(Alias = "symmetry")]
+            public Symmetry Symmetry { get; set; }
+        }
+
+        /// <summary>
+        /// Builds Hamiltonian from Broombridge if data is available.
+        /// </summary>
+        internal static OrbitalIntegralHamiltonian ToOrbitalIntegralHamiltonian(ProblemDescription broombridge)
+        {
+            // Add the identity terms
+            var identityterm = broombridge.CoulombRepulsion.Value + broombridge.EnergyOffset.Value;
+            var hamiltonian =  new OrbitalIntegralHamiltonian();
+            var hamiltonianData = broombridge.Hamiltonian;
+
+            // This will convert from Broombridge 1-indexing to 0-indexing.
+            hamiltonian.Add
+                (hamiltonianData.OneElectronIntegrals.Values
+                .Select(o =>
+                    new OrbitalIntegral(
+                        o.Key.Select(k => (int)(k - 1)).ToArray(),
+                        o.Value,
+                        OrbitalIntegral.Convention.Mulliken
+                    )
+                .ToCanonicalForm(PermutationSymmetry.Eightfold.FromBroombridgeV0_3()))
+                .Distinct());
+
+            // This will convert from Broombridge 1-indexing to 0-indexing.
+            // This will convert to Dirac-indexing.
+            hamiltonian.Add
+                (hamiltonianData.TwoElectronIntegrals.Values
+                .Select(o =>
+                    new OrbitalIntegral(
+                        o.Key.Select(k => (int)(k - 1)).ToArray(),
+                        o.Value,
+                        OrbitalIntegral.Convention.Mulliken
+                    )
+                .ToCanonicalForm(hamiltonianData.TwoElectronIntegrals.Symmetry.Permutation.FromBroombridgeV0_3()))
+                .Distinct());
+
+            hamiltonian.Add(new OrbitalIntegral(), identityterm);
+            return hamiltonian;
+        }
+
+    }
+    #endregion
+    
+}

--- a/Chemistry/src/DataModel/Serialization/Broombridge/BroombridgeSerializer.cs
+++ b/Chemistry/src/DataModel/Serialization/Broombridge/BroombridgeSerializer.cs
@@ -26,7 +26,10 @@ namespace Microsoft.Quantum.Chemistry.Broombridge
 
     internal class YamlStringEnumConverter : IYamlTypeConverter
     {
-        public bool Accepts(Type type) => type.IsEnum;
+        public bool Accepts(Type type)
+        {
+            return type.IsEnum;
+        }
 
         public object ReadYaml(IParser parser, Type type)
         {
@@ -89,14 +92,14 @@ namespace Microsoft.Quantum.Chemistry.Broombridge
                     Bibliography = null,
                     Format = new V0_1.Format
                     {
-                        Version = "0.2"
+                        Version = "0.3"
                     },
                     Generator = new V0_1.Generator
                     {
                         Source = "qdk-chem",
                         Version = typeof(BroombridgeSerializer).Assembly.GetName().Version.ToString()
                     },
-                    Schema = V0_2.SchemaUrl,
+                    Schema = V0_3.SchemaUrl,
                     ProblemDescriptions = problems
                         .Select(
                             problem => problem.ToBroombridgeV0_3()

--- a/Chemistry/src/DataModel/Serialization/Broombridge/BroombridgeVersionUpdater.cs
+++ b/Chemistry/src/DataModel/Serialization/Broombridge/BroombridgeVersionUpdater.cs
@@ -16,26 +16,52 @@ namespace Microsoft.Quantum.Chemistry.Broombridge
 
     internal static partial class DataStructures
     {
-        
+        public static V0_3.Data Update(V0_2.Data input) =>
+            new V0_3.Data
+            {
+                Bibliography = input.Bibliography,
+                Format = input.Format,
+                Generator = input.Generator,
+                Schema = V0_3.SchemaUrl,
+                ProblemDescriptions = input
+                    .ProblemDescriptions
+                    .Select(problem => new V0_3.ProblemDescription
+                    {
+                        BasisSet = problem.BasisSet,
+                        CoulombRepulsion = problem.CoulombRepulsion,
+                        EnergyOffset = problem.EnergyOffset,
+                        FciEnergy = problem.FciEnergy,
+                        Geometry = problem.Geometry,
+                        InitialStates = problem.InitialStates,
+                        Metadata = problem.Metadata,
+                        NElectrons = problem.NElectrons,
+                        NOrbitals = problem.NOrbitals,
+                        ScfEnergy = problem.ScfEnergy,
+                        ScfEnergyOffset = problem.ScfEnergyOffset,
+                        Hamiltonian = problem.Hamiltonian.ToBroombridgeV0_3()
+                    })
+                    .ToList()
+            };
+
         /// <summary>
         /// Converts v0.1 Broombridge to v0.2.
         /// </summary>
         /// <param name="input">Source Broombridge in v0.1 format.</param>
         /// <returns>Converted Broombridge in v0.2 format.</returns>
-        public static V0_2.Data Update(V0_1.Data input)
+        public static V0_3.Data Update(V0_1.Data input)
         {
-            var output = new V0_2.Data()
+            var output = new V0_3.Data()
             {
                 Schema = input.Schema,
                 Format = input.Format,
                 Generator = input.Generator,
                 Bibliography = input.Bibliography,
-                ProblemDescriptions = new List<V0_2.ProblemDescription>()
+                ProblemDescriptions = new List<V0_3.ProblemDescription>()
             };
 
             foreach (var integralSet in input.IntegralSets)
             {
-                var problemDescription = new V0_2.ProblemDescription()
+                var problemDescription = new V0_3.ProblemDescription()
                 {
                     Metadata = integralSet.Metadata,
                     BasisSet = integralSet.BasisSet,
@@ -47,7 +73,7 @@ namespace Microsoft.Quantum.Chemistry.Broombridge
                     NOrbitals = integralSet.NOrbitals,
                     NElectrons = integralSet.NElectrons,
                     EnergyOffset = integralSet.EnergyOffset,
-                    Hamiltonian = integralSet.Hamiltonian,
+                    Hamiltonian = integralSet.Hamiltonian.ToBroombridgeV0_3(),
                     InitialStates = new List<V0_2.State>()
                 };
             

--- a/Chemistry/src/Jupyter/ChemistryEncodeMagic.cs
+++ b/Chemistry/src/Jupyter/ChemistryEncodeMagic.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Quantum.Chemistry.Magic
 
             // We target a qubit quantum computer, which requires a Pauli representation of the fermion Hamiltonian.
             // A number of mappings from fermions to qubits are possible. Let us choose the Jordan-Wigner encoding.
-            PauliHamiltonian pauliHamiltonian = args.Hamiltonian.ToPauliHamiltonian(QubitEncoding.JordanWigner);
+            var pauliHamiltonian = args.Hamiltonian.ToPauliHamiltonian(QubitEncoding.JordanWigner);
 
             // We now convert this Hamiltonian and a selected state to a format that than be passed onto the QSharp component
             // of the library that implements quantum simulation algorithms.

--- a/Chemistry/src/Tools/ExportJW.cs
+++ b/Chemistry/src/Tools/ExportJW.cs
@@ -1,0 +1,155 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+#nullable enable
+
+using System.Collections.Generic;
+using System.Linq;
+using System.CommandLine;
+using System.IO;
+using System;
+
+using Microsoft.Quantum.Chemistry.Broombridge;
+using Microsoft.Quantum.Chemistry.OrbitalIntegrals;
+using Microsoft.Quantum.Chemistry.Fermion;
+using Microsoft.Quantum.Chemistry.QSharpFormat;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Quantum.Simulation.Core;
+
+namespace Microsoft.Quantum.Chemistry.Tools
+{
+
+    public static class ExportJW
+    {
+        public static Command CreateCommand() =>
+            new Command("export-jw")
+            {
+                new Argument<FileInfo>(
+                    "path",
+                    "Input data to be loaded, or - to load from stdin."
+                ),
+                new Option<SerializationFormat>(
+                    "--from",
+                    "Format to use in loading problem description data."
+                ),
+                new Option<FileInfo?>(
+                    "--out",
+                    "Path to write output to. Data will be written to stdout by default."
+                )
+            }
+            .WithDescription(
+                "Exports a JSON representation of the Jordan–Wigner transformation of " +
+                "the fermionic Hamiltonian for a particular electronic structure problem."
+            )
+            .WithHandler<FileInfo, SerializationFormat, FileInfo?>(
+                (path, from, @out) =>
+                {
+                    using var reader =
+                        path.Name == "-"
+                        ? System.Console.In
+                        : File.OpenText(path.FullName);
+                    using var writer =
+                        @out == null
+                        ? System.Console.Out
+                        : new StreamWriter(File.OpenWrite(@out.FullName));
+                    ExportJwData(reader, from, writer);
+                }
+            );
+
+        public static void ExportJwData(
+            TextReader reader, SerializationFormat from,
+            TextWriter writer,
+            IndexConvention indexConvention = IndexConvention.UpDown
+        )
+        {
+            var data = Load(reader, from).ToList();
+            if (data.Count != 1)
+            {
+                System.Console.Error.WriteLine($"Expected a single problem description, but got a list of {data.Count}.");
+            }
+            var problem = data.Single();
+
+            var fermionHamiltonian = problem
+                .OrbitalIntegralHamiltonian
+                .ToFermionHamiltonian(indexConvention);
+            var jwHamiltonian = fermionHamiltonian
+                .ToPauliHamiltonian(Paulis.QubitEncoding.JordanWigner)
+                .ToQSharpFormat();
+            var wavefunction = (
+                    (problem.InitialStates?.Count ?? 0) == 0
+                    ? fermionHamiltonian.CreateHartreeFockState(problem.NElectrons)
+                    : problem
+                        .InitialStates
+                        .First()
+                        .Value
+                        .ToIndexing(indexConvention)
+                )
+                .ToQSharpFormat();
+
+            // var encoded = JsonSerializer.Serialize(
+            //     QSharpFormat.Convert.ToQSharpFormat(jwHamiltonian, wavefunction),
+            //     options
+            // );
+            var qsData = QSharpFormat.Convert.ToQSharpFormat(jwHamiltonian, wavefunction);
+            var encoded = JsonSerializer.Serialize(Flatten(qsData));
+
+            writer.Write(encoded);
+            writer.Close();
+        }
+
+        // TODO: Move into common class.
+        internal static IEnumerable<ElectronicStructureProblem> Load(TextReader reader, SerializationFormat from) =>
+            (from switch
+            {
+                SerializationFormat.Broombridge =>
+                    BroombridgeSerializer.Deserialize(reader),
+                SerializationFormat.LiQuiD => 
+                    LiQuiDSerializer.Deserialize(reader),
+                SerializationFormat.FciDump =>
+                    FciDumpSerializer.Deserialize(reader),
+                _ => throw new ArgumentException($"Invalid format {from}.")
+            })
+            .ToList();
+
+        internal static object[] Flatten(JordanWigner.JordanWignerEncodingData data) =>
+            new object[]
+            {
+                data.Item1,
+                Flatten(data.Item2),
+                new object[]
+                {
+                    data.Item3.Item1,
+                    data.Item3.Item2.Select(s => Flatten(s)).ToArray()
+                },
+                data.Item4
+            };
+
+        internal static object[] Flatten(JordanWigner.JWOptimizedHTerms data) =>
+            new object[]
+            {
+                data.Item1.Select(s => Flatten(s)).ToArray(),
+                data.Item2.Select(s => Flatten(s)).ToArray(),
+                data.Item3.Select(s => Flatten(s)).ToArray(),
+                data.Item4.Select(s => Flatten(s)).ToArray(),
+            };
+
+        internal static object[] Flatten(HTerm term) =>
+            new object[]
+            {
+                term.Item1.ToArray(),
+                term.Item2.ToArray()
+            };
+
+        internal static object[] Flatten(JordanWigner.JordanWignerInputState data) =>
+            new object[]
+            {
+                new object[]
+                {
+                    data.Item1.Item1,
+                    data.Item1.Item2
+                },
+                data.Item2.ToArray()
+            };
+    }
+
+}

--- a/Chemistry/src/Tools/Program.cs
+++ b/Chemistry/src/Tools/Program.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Quantum.Chemistry.Tools
             new RootCommand
             {
                 Convert.CreateCommand(),
-                Normalize.CreateCommand()
+                Normalize.CreateCommand(),
+                ExportJW.CreateCommand()
             }
             .WithDescription("Tools for working with quantum chemistry data.");
 

--- a/Chemistry/tests/SamplesTests/DocsSecondQuantization.cs
+++ b/Chemistry/tests/SamplesTests/DocsSecondQuantization.cs
@@ -1,6 +1,6 @@
 ﻿
 
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 // This test ensures that any chemistry library syntax changes


### PR DESCRIPTION
This draft PR starts work on parsing and serialization logic for a new version of the Broombridge spec, primarily including the ability to specify what symmetries are used to expand lists of two-electron fermionic terms, allowing for the specification of fermionic Hamiltonians that violate eightfold symmetry.

This draft PR includes:

- A new `V0_3` class for serializing and deserializing draft Broombridge 0.3 documents.
- A new subcommand `export-jw` for the `qdk-chem` tool that allows for exporting a Jordan–Wigner representation of a given input electronic structure problem, without the need to write a C# or Python host.

This draft PR does not yet include:
- Unit or integration tests
- Perf improvements for new serialization / deserialization features
- Deduplication of new code where appropriate
