### PR TITLE
Add gh-sync workflow

### DIFF
--- a/.github/workflows/gh-sync.yml
+++ b/.github/workflows/gh-sync.yml
@@ -1,0 +1,34 @@
+name: Sync GitHub with ADO
+
+on: 
+  issues:
+    types: [closed, edited, deleted, reopened, assigned, unassigned, labeled, unlabeled]
+  issue_comment:
+
+jobs:
+  sync-issues:
+    name: Run gh-sync from GitHub action
+    if: ${{ github.event.label.name == 'tracking' || contains(github.event.issue.labels.*.name, 'tracking') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Azure
+        uses: Azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - id: AzureKeyVault
+        uses: Azure/get-keyvault-secrets@v1
+        with:
+          keyvault: 'kv-qdk-build'
+          secrets: 'ghSyncBuildPAT'
+
+      - name: 'Trigger gh-sync'
+        uses: microsoft/gh-sync@main
+        with:
+          ado-organization-url: ${{ secrets.ADO_URL }}
+          ado-project: ${{ secrets.ADO_PROJECT }}
+          ado-area-path: ${{ secrets.ADO_AREA_PATH }}
+          github-repo: 'microsoft/QuantumLibraries'
+          issue-number: ${{ github.event.issue.number }}
+          ado-token: ${{ steps.AzureKeyVault.outputs.ghSyncBuildPAT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The gh-sync GitHub Action allows you to synchronize public GitHub issues with internal ADO tracking. It can be customized to be triggered according to a repository's specific needs, see more below.
https://github.com/microsoft/gh-sync