### PR TITLE
Creating global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,9 @@
+{
+    "sdk": {
+        "version": "6.0.100",
+        "rollForward": "latestMinor"
+    },
+    "msbuild-sdks": {
+        "Microsoft.Quantum.Sdk": "0.24.210051-beta"
+    }
+}

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
         "rollForward": "latestMinor"
     },
     "msbuild-sdks": {
-        "Microsoft.Quantum.Sdk": "0.24.210051-beta"
+        "Microsoft.Quantum.Sdk": "0.24.201332"
     }
 }


### PR DESCRIPTION
Changes on .Net 6.0.300 requires that a local global.json includes the version of the Quantum.Sdk otherwise projects that don't have it specified fail compilation, even if there is another global.json in their parent path.