### PR TITLE
improved diagnostics message when swapping array elements

### DIFF
--- a/Standard/src/Arrays/Arrays.qs
+++ b/Standard/src/Arrays/Arrays.qs
@@ -462,6 +462,8 @@ namespace Microsoft.Quantum.Arrays {
     /// Swapped(1, 3, [0, 1, 2, 3, 4]);
     /// ```
     function Swapped<'T>(firstIndex : Int, secondIndex : Int, arr : 'T[]) : 'T[] {
+        Fact(firstIndex >= 0 and firstIndex < Length(arr), "First index is out of bounds");
+        Fact(secondIndex >= 0 and secondIndex < Length(arr), "Second index is out of bounds");
         return arr
             w/ firstIndex <- arr[secondIndex]
             w/ secondIndex <- arr[firstIndex];


### PR DESCRIPTION
At the moment it is easy to supply out of bounds indices when using array `Swapped(...)`.

For example:

```
let arr = [1, 2, 3];
let swapped = LocalSwapped(0, 4, arr);
```

produces, on a default simulator:

```
Unhandled exception: System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
```

This PR adds an extra bounds check, similar to what is [already done elsewhere](https://github.com/microsoft/QuantumLibraries/blob/main/Standard/src/Arrays/Multidimensional.qs#L83) to convert the error message to a more helpful

```
Unhandled exception: Microsoft.Quantum.Simulation.Core.ExecutionFailException: Second index is out of bounds
```