### PR TITLE
Improves MultiplexOperations implementation

### DIFF
--- a/Standard/tests/Canon/Utils/MultiplexerTests.cs
+++ b/Standard/tests/Canon/Utils/MultiplexerTests.cs
@@ -14,11 +14,11 @@ namespace Microsoft.Quantum.Tests
         {
             foreach (var (numControls, expectedTCount, expectedWidth) in new [] {
                     (1, 0, 6),
-                    (2, 28, 8),
-                    (3, 84, 10),
-                    (4, 196, 12),
-                    (5, 420, 14),
-                    (6, 868, 16)
+                    (2, 8, 8),
+                    (3, 24, 10),
+                    (4, 56, 12),
+                    (5, 120, 14),
+                    (6, 248, 16)
                 }) {
                 var estimator = new ResourcesEstimator();
                 EstimateMultiplexOperationsCosts.Run(estimator, numControls, 1 << numControls).Wait();

--- a/Standard/tests/Canon/Utils/MultiplexerTests.cs
+++ b/Standard/tests/Canon/Utils/MultiplexerTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+
+using Microsoft.Quantum.Simulation.Simulators;
+using Xunit;
+
+namespace Microsoft.Quantum.Tests
+{
+    public class MultiplexerTests
+    {
+        [Fact]
+        public void TestMultiplexerResources()
+        {
+            foreach (var (numControls, expectedTCount, expectedWidth) in new [] {
+                    (1, 0, 6),
+                    (2, 28, 8),
+                    (3, 84, 10),
+                    (4, 196, 12),
+                    (5, 420, 14),
+                    (6, 868, 16)
+                }) {
+                var estimator = new ResourcesEstimator();
+                EstimateMultiplexOperationsCosts.Run(estimator, numControls, 1 << numControls).Wait();
+                var tcount = (double)estimator.Data.Rows.Find("T")[1];
+                var width = (double)estimator.Data.Rows.Find("Width")[1];
+                Assert.Equal(expectedTCount, tcount);
+                Assert.Equal(expectedWidth, width);
+            }
+        }
+    }
+}

--- a/Standard/tests/MultiplexerTests.qs
+++ b/Standard/tests/MultiplexerTests.qs
@@ -497,6 +497,17 @@ namespace Microsoft.Quantum.Tests {
         }
     }
 
+    internal operation EstimateMultiplexOperationsCosts(numControls : Int, numData : Int) : Unit {
+        Diag.Fact(numData <= 2^numControls, "Too few address bits");
+
+        use address = Qubit[numControls];
+        use target = Qubit[5];
+
+        let unitaries = [ApplyPauliFromBitString(PauliX, true, [true, size = 5], _), size = numData];
+
+        MultiplexOperations(unitaries, LittleEndian(address), target);
+    }
+
 }
 
 


### PR DESCRIPTION
Previous counts (`numControls`, `tcount`, `width`) for `2^numControls` unitaries:

```
(1, 0, 6),
(2, 28, 8),
(3, 84, 10),
(4, 196, 12),
(5, 420, 14),
(6, 868, 16)
```

New counts:

```
(1, 0, 6),
(2, 8, 8),
(3, 24, 10),
(4, 56, 12),
(5, 120, 14),
(6, 248, 16)
```
