### PR TITLE
Details or example lacking for ResultArrayAsInt function #635

### DIFF
--- a/Standard/src/Convert/Convert.qs
+++ b/Standard/src/Convert/Convert.qs
@@ -118,6 +118,15 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Input
     /// ## results
+    ///
+    /// # Output
+    /// A non-negative integer
+    ///
+    /// # Example
+    /// ```qsharp
+    /// // The following returns 1
+    /// let int1 = ResultArrayAsInt([One,Zero])
+    /// ```
     /// Results in binary representation of number.
     function ResultArrayAsInt(results : Result[]) : Int {
         return BoolArrayAsInt(ResultArrayAsBoolArray(results));

--- a/Standard/src/Convert/Convert.qs
+++ b/Standard/src/Convert/Convert.qs
@@ -118,6 +118,7 @@ namespace Microsoft.Quantum.Convert {
     ///
     /// # Input
     /// ## results
+    /// Results in binary representation of number.
     ///
     /// # Output
     /// A non-negative integer
@@ -127,7 +128,6 @@ namespace Microsoft.Quantum.Convert {
     /// // The following returns 1
     /// let int1 = ResultArrayAsInt([One,Zero])
     /// ```
-    /// Results in binary representation of number.
     function ResultArrayAsInt(results : Result[]) : Int {
         return BoolArrayAsInt(ResultArrayAsBoolArray(results));
     }


### PR DESCRIPTION
Followed advice from @msoeken to add an example to ResultArrayAsInt function Microsoft Learn page.
Issue: Details or example lacking for ResultArrayAsInt function #635

https://learn.microsoft.com/en-us/qsharp/api/qsharp/microsoft.quantum.convert.resultarrayasint