### PR TITLE
Gulow/broombridge 0.3

### DIFF
--- a/Chemistry.sln
+++ b/Chemistry.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.28803.156
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32929.385
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentation", "{561759D2-4D2D-4EE3-9565-9AAEC4A7D64B}"
 	ProjectSection(SolutionItems) = preProject
@@ -24,23 +24,25 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Standard", "Standard\src\St
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BroombridgeExamples", "BroombridgeExamples", "{F25F3396-EDE5-4A9F-A428-643EB138F00F}"
 	ProjectSection(SolutionItems) = preProject
-		Chemistry\tests\BroombridgeExamples\broombridge_v0.1.yaml = Chemistry\tests\BroombridgeExamples\broombridge_v0.1.yaml
-		Chemistry\tests\BroombridgeExamples\broombridge_v0.2.yaml = Chemistry\tests\BroombridgeExamples\broombridge_v0.2.yaml
-		Chemistry\tests\BroombridgeExamples\hydrogen_0.1.yaml = Chemistry\tests\BroombridgeExamples\hydrogen_0.1.yaml
-		Chemistry\tests\BroombridgeExamples\hydrogen_0.2.yaml = Chemistry\tests\BroombridgeExamples\hydrogen_0.2.yaml
-		Chemistry\tests\BroombridgeExamples\LiH_0.1.yaml = Chemistry\tests\BroombridgeExamples\LiH_0.1.yaml
-		Chemistry\tests\BroombridgeExamples\LiH_0.2.yaml = Chemistry\tests\BroombridgeExamples\LiH_0.2.yaml
+		Chemistry\tests\TestData\Broombridge\broombridge_v0.1.yaml = Chemistry\tests\TestData\Broombridge\broombridge_v0.1.yaml
+		Chemistry\tests\TestData\Broombridge\broombridge_v0.2.yaml = Chemistry\tests\TestData\Broombridge\broombridge_v0.2.yaml
+		Chemistry\tests\TestData\Broombridge\hydrogen_0.1.yaml = Chemistry\tests\TestData\Broombridge\hydrogen_0.1.yaml
+		Chemistry\tests\TestData\Broombridge\hydrogen_0.2.yaml = Chemistry\tests\TestData\Broombridge\hydrogen_0.2.yaml
+		Chemistry\tests\TestData\Broombridge\LiH_0.1.yaml = Chemistry\tests\TestData\Broombridge\LiH_0.1.yaml
+		Chemistry\tests\TestData\Broombridge\LiH_0.2.yaml = Chemistry\tests\TestData\Broombridge\LiH_0.2.yaml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SamplesTests", "Chemistry\tests\SamplesTests\SamplesTests.csproj", "{2A0E61DB-7187-4359-B5C7-C30FCB1D6800}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Metapackage", "Chemistry\src\Metapackage\Metapackage.csproj", "{E8268248-FC5B-4F4E-82FF-5C8CC40950BB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Metapackage", "Chemistry\src\Metapackage\Metapackage.csproj", "{E8268248-FC5B-4F4E-82FF-5C8CC40950BB}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Chemistry", "Chemistry", "{43A9F607-5884-4CB9-A455-01E98F5532E2}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{812F2D11-792D-4305-8427-01B632A92299}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tools", "Chemistry\src\Tools\Tools.csproj", "{3EF5845F-B348-4DC9-A905-23A6FB9AB421}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tools", "Chemistry\src\Tools\Tools.csproj", "{3EF5845F-B348-4DC9-A905-23A6FB9AB421}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DataModelTests", "Chemistry\tests\DataModelTests\DataModelTests.csproj", "{B86DDA60-44F0-4C05-837E-CEA84DBCADF7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -80,6 +82,10 @@ Global
 		{3EF5845F-B348-4DC9-A905-23A6FB9AB421}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3EF5845F-B348-4DC9-A905-23A6FB9AB421}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3EF5845F-B348-4DC9-A905-23A6FB9AB421}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B86DDA60-44F0-4C05-837E-CEA84DBCADF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B86DDA60-44F0-4C05-837E-CEA84DBCADF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B86DDA60-44F0-4C05-837E-CEA84DBCADF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B86DDA60-44F0-4C05-837E-CEA84DBCADF7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -93,6 +99,7 @@ Global
 		{E8268248-FC5B-4F4E-82FF-5C8CC40950BB} = {F561BE56-63D8-4C33-A3B3-CF2685BC7A5C}
 		{812F2D11-792D-4305-8427-01B632A92299} = {43A9F607-5884-4CB9-A455-01E98F5532E2}
 		{3EF5845F-B348-4DC9-A905-23A6FB9AB421} = {812F2D11-792D-4305-8427-01B632A92299}
+		{B86DDA60-44F0-4C05-837E-CEA84DBCADF7} = {595D5855-8820-48D7-B5E1-9C88215A866A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6869E5BF-551A-40F1-9B6B-D1B27A5676CB}

--- a/Chemistry/src/DataModel/Serialization/Broombridge/BroombridgeDataStructurev0.1.cs
+++ b/Chemistry/src/DataModel/Serialization/Broombridge/BroombridgeDataStructurev0.1.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Quantum.Chemistry.Broombridge
                              ConvertIndices(
                                  term
                                 .Key
-                                .ToCanonicalForm(OrbitalIntegral.PermutationSymmetry.Eightfold)
+                                .ToCanonicalForm()
                                 .OrbitalIndices,
                                 OrbitalIntegral.Convention.Dirac,
                                 OrbitalIntegral.Convention.Mulliken
@@ -386,7 +386,7 @@ namespace Microsoft.Quantum.Chemistry.Broombridge
             hamiltonian.Add
                 (hamiltonianData.OneElectronIntegrals.Values
                 .Select(o => new OrbitalIntegral(o.Item1
-                .Select(k => (int)(k - 1)), o.Item2, OrbitalIntegral.Convention.Mulliken)
+                .Select(k => (int)(k - 1)), o.Item2, OrbitalIntegral.PermutationSymmetry.Eightfold, OrbitalIntegral.Convention.Mulliken)
                 .ToCanonicalForm())
                 .Distinct());
 
@@ -395,7 +395,7 @@ namespace Microsoft.Quantum.Chemistry.Broombridge
             hamiltonian.Add
                 (hamiltonianData.TwoElectronIntegrals.Values
                 .Select(o => new OrbitalIntegral(o.Item1
-                .Select(k => (int)(k - 1)), o.Item2, OrbitalIntegral.Convention.Mulliken)
+                .Select(k => (int)(k - 1)), o.Item2, OrbitalIntegral.PermutationSymmetry.Eightfold, OrbitalIntegral.Convention.Mulliken)
                 .ToCanonicalForm())
                 .Distinct());
 

--- a/Chemistry/src/DataModel/Serialization/LegacyFormats/FciDump.cs
+++ b/Chemistry/src/DataModel/Serialization/LegacyFormats/FciDump.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Quantum.Chemistry
                 .SelectMaybe(
                     row => row.Item2.Length % 2 == 0
                            ? new OrbitalIntegral(
-                                 row.Item2, row.Item1, OrbitalIntegral.Convention.Mulliken
+                                 row.Item2, row.Item1, OrbitalIntegral.PermutationSymmetry.Eightfold, OrbitalIntegral.Convention.Mulliken
                              ).ToCanonicalForm()
                            : null
                 )

--- a/Chemistry/tests/DataModelTests/FermionTermTests/FermionHamiltonianTests.cs
+++ b/Chemistry/tests/DataModelTests/FermionTermTests/FermionHamiltonianTests.cs
@@ -148,55 +148,55 @@ namespace Microsoft.Quantum.Chemistry.Tests
         public static IEnumerable<object[]> OrbitalsData =>
             new List<object[]>
             {
-                new object[] { new OrbitalIntegral(new[] {0,0 },1.0, OrbitalIntegral.Convention.Dirac), TermType.Fermion.PP,
+                new object[] { new OrbitalIntegral(new[] {0,0 },1.0, OrbitalIntegral.PermutationSymmetry.Eightfold, OrbitalIntegral.Convention.Dirac), TermType.Fermion.PP,
                     new (int, int[], double)[] {
                         (1, new[] { 0, 0 }, 1.0 ),
                         (1, new[] { 1, 1 }, 1.0 )}},
-                new object[] { new OrbitalIntegral(new[] {0,1 },1.0, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQ,
+                new object[] { new OrbitalIntegral(new[] {0,1 },1.0, OrbitalIntegral.PermutationSymmetry.Eightfold, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQ,
                     new (int, int[], double)[] {
                         (2, new[] { 0, 1 }, 2.0 ),
                         (2, new[] { 2, 3 }, 2.0 )}},
-                new object[] { new OrbitalIntegral(new[] {0,1,1,0 },1.0, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQQP,
+                new object[] { new OrbitalIntegral(new[] {0,1,1,0 },1.0, OrbitalIntegral.PermutationSymmetry.Eightfold, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQQP,
                     new (int, int[], double)[] {
                         (2, new[] { 0, 1, 1, 0 }, 1.0 ),
                         (2, new[] { 2, 3, 3, 2 }, 1.0 ),
                         (2, new[] { 0, 3, 3, 0 }, 1.0 ),
                         (2, new[] { 1, 2, 2, 1 }, 1.0 )}},
-                new object[] { new OrbitalIntegral(new[] {0,1,0,1 },1.0, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQQP,
+                new object[] { new OrbitalIntegral(new[] {0,1,0,1 },1.0, OrbitalIntegral.PermutationSymmetry.Eightfold, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQQP,
                     new (int, int[], double)[] {
                         (2, new[] { 0, 1, 1, 0 }, -1.0 ),
                         (2, new[] { 2, 3, 3, 2 }, -1.0 ),
                     } },
-                new object[] { new OrbitalIntegral(new[] {0,1,0,1 },1.0, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQRS,
+                new object[] { new OrbitalIntegral(new[] {0,1,0,1 },1.0, OrbitalIntegral.PermutationSymmetry.Eightfold, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQRS,
                     new (int, int[], double)[] {
                         (2, new[] { 0, 3, 2, 1 }, 2.0 ),
                         (2,  new[] { 0, 2, 3, 1 }, 2.0 )
                     } },
-                new object[] { new OrbitalIntegral(new[] {0,1,0,0 },1.0, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQQR,
+                new object[] { new OrbitalIntegral(new[] {0,1,0,0 },1.0, OrbitalIntegral.PermutationSymmetry.Eightfold, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQQR,
                     new (int, int[], double)[] {
                         (2, new[] { 0, 2, 2, 1 }, 2.0 ),
                         (2, new[] { 0, 2, 3, 0 }, 2.0 ),
                     } },
-                new object[] {new OrbitalIntegral(new[] {0,0,1,2 },1.0, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQQR,
+                new object[] {new OrbitalIntegral(new[] {0,0,1,2 },1.0, OrbitalIntegral.PermutationSymmetry.Eightfold, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQQR,
                     new (int, int[], double)[] {
                         (3, new[] { 0, 1, 2, 0 }, -2.0 ),
                         (3, new[] { 3, 4, 5, 3 }, -2.0 ),
                     } },
-                new object[] { new OrbitalIntegral(new[] {0,0,1,2 },1.0, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQRS,
+                new object[] { new OrbitalIntegral(new[] {0,0,1,2 },1.0, OrbitalIntegral.PermutationSymmetry.Eightfold, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQRS,
                     new (int, int[], double)[] {
                         (3, new[] { 0, 3, 4, 2 }, 2.0 ),
                         (3, new[] { 0, 3, 5, 1 }, 2.0 ),
                         (3, new[] { 0, 4, 3, 2 }, 2.0 ),
                         (3, new[] { 0, 5, 3, 1 }, 2.0 ),
                     } },
-                new object[] { new OrbitalIntegral(new[] {0,1,2,0 },1.0, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQQR,
+                new object[] { new OrbitalIntegral(new[] {0,1,2,0 },1.0, OrbitalIntegral.PermutationSymmetry.Eightfold, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQQR,
                     new (int, int[], double)[] {
                         (3, new[] { 0, 1, 2, 0 }, 2.0 ),
                         (3, new[] { 1, 3, 3, 2 }, 2.0 ),
                         (3, new[] { 0, 4, 5, 0 }, 2.0 ),
                         (3, new[] { 3, 4, 5, 3 }, 2.0 ),
                     } },
-                new object[] { new OrbitalIntegral(new[] {0,1,2,3 },1.0, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQRS,
+                new object[] { new OrbitalIntegral(new[] {0,1,2,3 },1.0, OrbitalIntegral.PermutationSymmetry.Eightfold, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQRS,
                     new (int, int[], double)[] {
                         (4, new[] { 0, 5, 6, 3 }, 2.0 ),
                         (4, new[] { 0, 6, 5, 3 }, 2.0 ),
@@ -207,7 +207,7 @@ namespace Microsoft.Quantum.Chemistry.Tests
                         (4, new[] { 0, 2, 3, 1 }, -2.0 ),
                         (4, new[] { 1, 7, 4, 2 }, 2.0 ),
                     } },
-                new object[] { new OrbitalIntegral(new[] {3,1,0,2 },1.0, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQRS,
+                new object[] { new OrbitalIntegral(new[] {3,1,0,2 },1.0, OrbitalIntegral.PermutationSymmetry.Eightfold, OrbitalIntegral.Convention.Dirac),  TermType.Fermion.PQRS,
                     new (int, int[], double)[] {
                         (4, new[] { 2, 4, 5, 3 }, 2.0 ),
                         (4, new[] { 0, 6, 7, 1 }, 2.0 ),

--- a/Chemistry/tests/DataModelTests/SerializationTests/LiQuiDTests.cs
+++ b/Chemistry/tests/DataModelTests/SerializationTests/LiQuiDTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Quantum.Chemistry.Tests
 {
     using static TermType.OrbitalIntegral;
     using static OrbitalIntegral.Convention;
+    using static OrbitalIntegral.PermutationSymmetry;
 
 
     public class LoadFromLiquidTests
@@ -44,17 +45,17 @@ namespace Microsoft.Quantum.Chemistry.Tests
         public static IEnumerable<object[]> LiquidOrbitalsData =>
             new List<object[]>
             {
-                new object[] { "0,0=1.0", OneBody, new OrbitalIntegral(new[] {0,0},1.0, Dirac) },
-                new object[] { "0,1=1.0", OneBody, new OrbitalIntegral(new[] {0,1},1.0, Dirac) },
-                new object[] { "0,1,1,0=1.0", TwoBody, new OrbitalIntegral(new[] {0,1,1,0},1.0, Dirac) },
-                new object[] { "0,1,0,1=1.0", TwoBody, new OrbitalIntegral(new[] {0,1,0,1},1.0, Dirac) },
-                new object[] { "0,1,0,1=1.0", TwoBody, new OrbitalIntegral(new[] {0,1,0,1},1.0, Dirac) },
-                new object[] { "0,1,0,0=1.0", TwoBody, new OrbitalIntegral(new[] {0,1,0,0},1.0, Dirac) },
-                new object[] { "0,0,1,2=1.0", TwoBody, new OrbitalIntegral(new[] {0,0,1,2},1.0, Dirac) },
-                new object[] { "0,0,1,2=1.0", TwoBody, new OrbitalIntegral(new[] {0,0,1,2},1.0, Dirac) },
-                new object[] { "0,1,2,0=1.0", TwoBody, new OrbitalIntegral(new[] {0,1,2,0},1.0, Dirac) },
-                new object[] { "0,1,2,3=1.0", TwoBody, new OrbitalIntegral(new[] {0,1,2,3},1.0, Dirac) },
-                new object[] { "3,1,0,2=1.0", TwoBody, new OrbitalIntegral(new[] {3,1,0,2},1.0, Dirac) }
+                new object[] { "0,0=1.0", OneBody, new OrbitalIntegral(new[] {0,0},1.0, Eightfold, Dirac) },
+                new object[] { "0,1=1.0", OneBody, new OrbitalIntegral(new[] {0,1},1.0, Eightfold, Dirac) },
+                new object[] { "0,1,1,0=1.0", TwoBody, new OrbitalIntegral(new[] {0,1,1,0},1.0, Eightfold, Dirac) },
+                new object[] { "0,1,0,1=1.0", TwoBody, new OrbitalIntegral(new[] {0,1,0,1},1.0, Eightfold, Dirac) },
+                new object[] { "0,1,0,1=1.0", TwoBody, new OrbitalIntegral(new[] {0,1,0,1},1.0, Eightfold, Dirac) },
+                new object[] { "0,1,0,0=1.0", TwoBody, new OrbitalIntegral(new[] {0,1,0,0},1.0, Eightfold, Dirac) },
+                new object[] { "0,0,1,2=1.0", TwoBody, new OrbitalIntegral(new[] {0,0,1,2},1.0, Eightfold, Dirac) },
+                new object[] { "0,0,1,2=1.0", TwoBody, new OrbitalIntegral(new[] {0,0,1,2},1.0, Eightfold, Dirac) },
+                new object[] { "0,1,2,0=1.0", TwoBody, new OrbitalIntegral(new[] {0,1,2,0},1.0, Eightfold, Dirac) },
+                new object[] { "0,1,2,3=1.0", TwoBody, new OrbitalIntegral(new[] {0,1,2,3},1.0, Eightfold, Dirac) },
+                new object[] { "3,1,0,2=1.0", TwoBody, new OrbitalIntegral(new[] {3,1,0,2},1.0, Eightfold, Dirac) }
             };
 
 

--- a/Chemistry/tests/SamplesTests/DocsSecondQuantization.cs
+++ b/Chemistry/tests/SamplesTests/DocsSecondQuantization.cs
@@ -307,10 +307,15 @@ namespace Microsoft.Quantum.Chemistry.Tests.Docs
             // This enumerates all two-electron integrals with the same coefficient -- 
             // an array of equivalent `OrbitalIntegral` instances is generated. In 
             // this case, there are 4 elements.
-            var twoElectronIntegrals = twoElectronIntegral.EnumerateSpinOrbitals();
+            var twoElectronIntegrals = twoElectronIntegral.EnumerateOrbitalSymmetries();
 
-            Assert.Equal(8, twoElectronIntegrals.Count());
+            Assert.Equal(4, twoElectronIntegrals.Count());
 
+            // These orbital indices should all be equivalent
+            foreach (OrbitalIntegral integral in twoElectronIntegrals)
+            {
+                Assert.Equal(integral.ToCanonicalForm().OrbitalIndices, twoElectronIntegral.ToCanonicalForm().OrbitalIndices);
+            }
         }
 
         [Fact]
@@ -341,7 +346,7 @@ namespace Microsoft.Quantum.Chemistry.Tests.Docs
             // orders the `HermitianFermionTerm` instances in canonical order. We will need to
             // choose an indexing convention as well.
             fermionHamiltonian.AddRange(orbitalIntegral
-                .ToHermitianFermionTerms(0, indexConvention: IndexConvention.UpDown)
+                .ToHermitianFermionTerms(0, IndexConvention.UpDown)
                 .Select(o => (o.Item1, o.Item2.ToDoubleCoeff())));
 
             Assert.Equal(8, fermionHamiltonian.CountTerms());

--- a/Chemistry/tests/SamplesTests/DocsSecondQuantization.cs
+++ b/Chemistry/tests/SamplesTests/DocsSecondQuantization.cs
@@ -298,6 +298,22 @@ namespace Microsoft.Quantum.Chemistry.Tests.Docs
         }
 
         [Fact]
+        static void MakeOrbitalIntegralFourFoldSymmetry()
+        {
+            // We create a `OrbitalIntegral` object to store a two-electron molecular
+            //  orbital integral data with four-fold symmetry.
+            var twoElectronIntegral = new OrbitalIntegral(new[] { 0, 1, 2, 3 }, 0.123,OrbitalIntegral.PermutationSymmetry.Fourfold);
+
+            // This enumerates all two-electron integrals with the same coefficient -- 
+            // an array of equivalent `OrbitalIntegral` instances is generated. In 
+            // this case, there are 4 elements.
+            var twoElectronIntegrals = twoElectronIntegral.EnumerateSpinOrbitals();
+
+            Assert.Equal(8, twoElectronIntegrals.Count());
+
+        }
+
+        [Fact]
         static void MakeHamiltonian()
         {
             // We load the namespace containing fermion objects. This
@@ -325,7 +341,7 @@ namespace Microsoft.Quantum.Chemistry.Tests.Docs
             // orders the `HermitianFermionTerm` instances in canonical order. We will need to
             // choose an indexing convention as well.
             fermionHamiltonian.AddRange(orbitalIntegral
-                .ToHermitianFermionTerms(0, IndexConvention.UpDown)
+                .ToHermitianFermionTerms(0, indexConvention: IndexConvention.UpDown)
                 .Select(o => (o.Item1, o.Item2.ToDoubleCoeff())));
 
             Assert.Equal(8, fermionHamiltonian.CountTerms());


### PR DESCRIPTION
- Fixes for fourfold symmetry in v0.3.
- Added Symmetry as a property of OrbitalIntegral to simplify code.
- Updated DataModels tests for OrbitalIntegral Symmetry property.

Self-approving to facilitate beta testing.