### PR TITLE
Fixing the undesirable dependencies issue for qdk.

### DIFF
--- a/Build/manifest.ps1
+++ b/Build/manifest.ps1
@@ -31,13 +31,13 @@ $artifacts = @{
     ) | ForEach-Object { Join-Path $Env:NUGET_OUTDIR "$_.$Env:NUGET_VERSION.nupkg" };
 
     Assemblies = @(
-        ".\Standard\src\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Standard.dll",
-        ".\Visualization\src\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Standard.Visualization.dll",
-        ".\Numerics\src\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Numerics.dll",
-        ".\MachineLearning\src\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.MachineLearning.dll",
-        ".\Chemistry\src\DataModel\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Chemistry.DataModel.dll",
-        ".\Chemistry\src\Jupyter\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Chemistry.Jupyter.dll",
-        ".\Chemistry\src\Runtime\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.Chemistry.Runtime.dll",
+        ".\Standard\src\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Standard.dll",
+        ".\Visualization\src\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Standard.Visualization.dll",
+        ".\Numerics\src\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Numerics.dll",
+        ".\MachineLearning\src\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.MachineLearning.dll",
+        ".\Chemistry\src\DataModel\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Chemistry.DataModel.dll",
+        ".\Chemistry\src\Jupyter\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Chemistry.Jupyter.dll",
+        ".\Chemistry\src\Runtime\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Chemistry.Runtime.dll",
         ".\Chemistry\src\Tools\bin\$Env:BUILD_CONFIGURATION\net6.0\qdk-chem.dll"
     ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };
 } 

--- a/Chemistry/src/DataModel/DataModel.csproj
+++ b/Chemistry/src/DataModel/DataModel.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <AssemblyName>Microsoft.Quantum.Chemistry.DataModel</AssemblyName>
     <DocumentationFile>bin\$(BuildConfiguration)\$(PlatformTarget)\$(AssemblyName).xml</DocumentationFile>

--- a/Chemistry/src/Jupyter/Jupyter.csproj
+++ b/Chemistry/src/Jupyter/Jupyter.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <AssemblyName>Microsoft.Quantum.Chemistry.Jupyter</AssemblyName>
   </PropertyGroup>

--- a/Chemistry/src/Metapackage/Metapackage.csproj
+++ b/Chemistry/src/Metapackage/Metapackage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <AssemblyName>Microsoft.Quantum.Chemistry.Metapackage</AssemblyName>
   </PropertyGroup>

--- a/Chemistry/src/Runtime/Runtime.csproj
+++ b/Chemistry/src/Runtime/Runtime.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.27.253010">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Chemistry.Runtime</AssemblyName>
     <QsharpDocsGeneration>true</QsharpDocsGeneration>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>

--- a/MachineLearning/src/MachineLearning.csproj
+++ b/MachineLearning/src/MachineLearning.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.27.253010">
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.MachineLearning</AssemblyName>
     <QsharpDocsGeneration>true</QsharpDocsGeneration>
     <QsharpDocsPackageId>Microsoft.Quantum.MachineLearning</QsharpDocsPackageId>

--- a/Numerics/src/Numerics.csproj
+++ b/Numerics/src/Numerics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.27.253010">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Numerics</AssemblyName>
     <QsharpDocsGeneration>true</QsharpDocsGeneration>
     <QsharpDocsPackageId>Microsoft.Quantum.Numerics</QsharpDocsPackageId>

--- a/Standard/src/Standard.csproj
+++ b/Standard/src/Standard.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.27.253010">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Standard</AssemblyName>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages> <!-- otherwise the standard library is included by the Sdk -->
     <NoWarn>1591</NoWarn> <!-- warning regarding missing C# doc comments -->

--- a/Visualization/src/Visualization.csproj
+++ b/Visualization/src/Visualization.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Standard.Visualization</AssemblyName>
     <NoWarn>1591</NoWarn> <!-- warning regarding missing C# doc comments -->
   </PropertyGroup>


### PR DESCRIPTION
DevOps 48463, 48471.
The `netstandard2.1` target framework has undesirable dependencies, migrating the affected packages to `net6.0`.

Multi-repo PR:
[Q#Compiler](https://github.com/microsoft/qsharp-compiler/pull/1601), [Q#RT](https://github.com/microsoft/qsharp-runtime/pull/1121), [iQ#](https://github.com/microsoft/iqsharp/pull/760), [QuantumLibraries](https://github.com/microsoft/QuantumLibraries/pull/656), [Quantum-NC](https://github.com/microsoft/Quantum-NC/pull/84), [Quantum](https://github.com/microsoft/Quantum/pull/771) (samples), [Katas](https://github.com/microsoft/QuantumKatas/pull/868), QDK, and a private repo.

PR CI build can fail, but overall qdk.release (0.27.254480) has succeeded.