### PR TITLE
Fix the ReleasedQubitsAreNotInZeroState in Modular.qs

### DIFF
--- a/Standard/src/Arithmetic/Modular.qs
+++ b/Standard/src/Arithmetic/Modular.qs
@@ -91,7 +91,7 @@ namespace Microsoft.Quantum.Arithmetic {
 
             // note that controlled version is correct only under the assumption
             // that the value of target is less than modulus
-            use lessThanModulusFlag = Qubit();
+            borrow lessThanModulusFlag = Qubit(){
             let copyMostSignificantBitPhaseLE = ApplyLEOperationOnPhaseLEA(CopyMostSignificantBit(_, lessThanModulusFlag), _);
 
             // lets track the state of target register through the computation
@@ -112,6 +112,7 @@ namespace Microsoft.Quantum.Arithmetic {
             X(lessThanModulusFlag);
             copyMostSignificantBitPhaseLE(target);
             Controlled IncrementPhaseByInteger(controls, (increment, target));
+            }
         }
     }
 


### PR DESCRIPTION
A ReleasedQubitsAreNotInZeroState will occur when calling IncrementByModularInteger, IncrementPhaseByModularInteger and MultiplyAndAddPhaseByModularInteger, even if the qubit arrays in their arguments are reset. It seems that some qubit resources are not released on time, so I tried this update to avoid exceptional quibit state.