### PR TITLE
Try to solve ReleasedQubitsAreNotInZeroState in IncrementPhaseByModularInteger

### DIFF
--- a/Standard/src/Arithmetic/Modular.qs
+++ b/Standard/src/Arithmetic/Modular.qs
@@ -112,6 +112,8 @@ namespace Microsoft.Quantum.Arithmetic {
             X(lessThanModulusFlag);
             copyMostSignificantBitPhaseLE(target);
             Controlled IncrementPhaseByInteger(controls, (increment, target));
+
+            ResetAll(lessThanModulusFlag);
         }
     }
 


### PR DESCRIPTION
IncrementPhaseByModularInteger will lead to a ReleasedQubitsAreNotInZeroState exception even when programs reset all qubits. Therefore, I try to add a reset operation in its source code to avoid this exception.